### PR TITLE
Updated parts of the processHAnimHumanoid method to prepare for use o…

### DIFF
--- a/rawkee/RKSceneEditor.py
+++ b/rawkee/RKSceneEditor.py
@@ -241,9 +241,9 @@ class RKSceneEditor(MayaQWidgetDockableMixin, QWidget):
     def create_layout(self):
         #####################################################
         # X3D Player and Node Editor Layout                 #
-        plr_layout     = QtWidgets.QVBoxLayout()            #
+        plr_layout = QtWidgets.QVBoxLayout()           #
                                                             #
-        plrCtrl_layout = QtWidgets.QHBoxLayout()
+        plrCtrl_layout  = QtWidgets.QHBoxLayout()
         plrCtrl_layout.addWidget(self.plcLabel)
         plrCtrl_layout.addWidget(self.combo_box)
         plrCtrl_layout.setContentsMargins(0,0,0,0)
@@ -327,7 +327,8 @@ class RKCustomNodeEditor(QWidget):
 
         #Create Graphics View
         self.view = RKGraphicsView(self.scene.grScene, self)
-        self.view.setAlignment(Qt.AlignCenter)
+        #self.view.setAlignment(Qt.AlignCenter)
+        #self.view.setAlignment(Qt.AlignTop)
         self.layout.addWidget(self.view)
         
         # Adding an RKXNode for Development / Testing purposes.
@@ -339,16 +340,19 @@ class RKCustomNodeEditor(QWidget):
         node3.setPos(600,0)
         
     def centerView(self):
-        #maya_main_window_ptr = omui.MQtUtil.mainWindow()
-        #maya_main_window = wrapInstance(int(maya_main_window_ptr), QWidget)
+        m = get_monitors()
+        #s = self.geometry() #self.view.geometry()
+        n = len(m)
+        x = m[n-1].width  / 2
+        y = m[n-1].height / 2
         
-        #self.view.centerOn(2700,800)
-        #self.view.centerOn(0,0)
+        self.view.centerOn(x+(y/2), y/2)
         
         for m in get_monitors():
             print(str(m))
 
-        
+        '''
+        print("Viewport - Width: " + str(x2) + ", Height: " + str(y2))
         mPoint = self.view.mapFromScene(QPointF(0.0,0.0))
         
         pstr = "X: " + str(mPoint.x()) + ", Y: " + str(mPoint.y())
@@ -356,7 +360,7 @@ class RKCustomNodeEditor(QWidget):
         mRect = self.view.sceneRect()
         print(pstr)
         print(mRect)
-        
+        '''
         
         
     def addDebugContent(self):


### PR DESCRIPTION
This pull request includes several changes to the `rawkee` project, primarily focused on improving the handling of HAnimHumanoid nodes and refining the processing of various Maya nodes. The changes include the addition of new methods, modifications to existing methods, and some code clean-up.

### Improvements to HAnimHumanoid processing:

* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR716-R734): Added a new method `getBindPoseNode` to check if a dag node is connected to a 'bindPose' node and return it if found.
* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR744-R819): Modified `processHAnimHumanoid` to include an additional parameter `bpNode` and updated the method to handle different child node types more effectively.

### Enhancements to transform node processing:

* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL905-R991): Updated `processMayaTransformNode` to check for 'bindPose' connections and process the node as an HAnimHumanoid if found.

### Code clean-up and refactoring:

* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL970-L974): Removed unnecessary comments and unused methods to improve code readability and maintainability. [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL970-L974) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL1001-L1030)

### UI adjustments:

* [`rawkee/RKSceneEditor.py`](diffhunk://#diff-7740f1ed3199485bedb5f918dd19dfed6d80e4bebc5d237729fc0ec0fbe2cd3eL330-R331): Modified the `initUI` method to adjust the alignment settings for the graphics view and updated the `centerView` method to center the view based on monitor dimensions. [[1]](diffhunk://#diff-7740f1ed3199485bedb5f918dd19dfed6d80e4bebc5d237729fc0ec0fbe2cd3eL330-R331) [[2]](diffhunk://#diff-7740f1ed3199485bedb5f918dd19dfed6d80e4bebc5d237729fc0ec0fbe2cd3eL342-R363)…f HAnimMotion nodes.