### PR TITLE
Implemented Maya OptionVar variables and a GUI to set these variables

### DIFF
--- a/RawKee_Python_X3D.py
+++ b/RawKee_Python_X3D.py
@@ -221,6 +221,64 @@ class RKX3DSelExportOp(aom.MPxCommand):
             print("rkWeb3D was None")
 
 
+# Creating the MEL Command for the RawKee's function to activate export function
+class RKX3DCastleProject(aom.MPxCommand):
+    kPluginCmdName = "rkCASSetProject"
+
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+
+    @staticmethod
+    def cmdCreator():
+        return RKX3DCastleProject()
+        
+    def doIt(self, args):
+        global rkWeb3D
+        
+        if rkWeb3D is not None:
+            rkWeb3D.setCastleProjectDirectory()
+        else:
+            print("rkWeb3D was None")
+
+
+class RKX3DCastleExportOp(aom.MPxCommand):
+    kPluginCmdName = "rkCASExportOp"
+
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+
+    @staticmethod
+    def cmdCreator():
+        return RKX3DCastleExportOp()
+        
+    def doIt(self, args):
+        global rkWeb3D
+        
+        if rkWeb3D is not None:
+            rkWeb3D.activateCastleExportOptions()
+        else:
+            print("rkWeb3D was None")
+
+
+class RKX3DCastleSelExportOp(aom.MPxCommand):
+    kPluginCmdName = "rkCASSelExportOp"
+
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+
+    @staticmethod
+    def cmdCreator():
+        return RKX3DCastleSelExportOp()
+        
+    def doIt(self, args):
+        global rkWeb3D
+        
+        if rkWeb3D is not None:
+            rkWeb3D.activateCastleSelExportOptions()
+        else:
+            print("rkWeb3D was None")
+
+
 class RKShowSceneEditor(aom.MPxCommand):
     kPluginCmdName = "rkShowSceneEditor"
     
@@ -254,7 +312,7 @@ class RKShowSceneEditor(aom.MPxCommand):
 
 # Initialize the plug-in
 def initializePlugin(plugin):
-    print("Made possible by the Alias Research Donation Program\n - Yes, the 'ALIAS' Research Donation Program - from 2003/4-ish\n   I can't remember exactly when, it's been a long long time.")
+    print("Made possible by the: Alias Research Donation Program\n\n")
     pluginFn = aom.MFnPlugin(plugin, RAWKEE_VENDOR, RAWKEE_VERSION)
  
     # RawKee Utility Functions required to be in MEL format such as functions related to AE Templates.
@@ -327,18 +385,23 @@ def initializePlugin(plugin):
         #pluginFn.registerCommand(RKWeb3DExporter.kPluginCmdName, RKWeb3DExporter.cmdCreator)
         #pluginFn.registerCommand(        RKServer.kPluginCmdName,         RKServer.cmdCreator)
         #pluginFn.registerCommand(          RKAddX3DSound.kPluginCmdName,     RKAddX3DSound.cmdCreator)
-        pluginFn.registerCommand(       RKSetAsBillboard.kPluginCmdName,  RKSetAsBillboard.cmdCreator)
-        pluginFn.registerCommand(         RKAddCollision.kPluginCmdName,    RKAddCollision.cmdCreator)
-        pluginFn.registerCommand(             RKAddGroup.kPluginCmdName,        RKAddGroup.cmdCreator)
-        pluginFn.registerCommand(            RKAddSwitch.kPluginCmdName,       RKAddSwitch.cmdCreator)
-        pluginFn.registerCommand(                 RKInfo.kPluginCmdName,            RKInfo.cmdCreator)
-        pluginFn.registerCommand(          RKX3DExportOp.kPluginCmdName,     RKX3DExportOp.cmdCreator)
-        pluginFn.registerCommand(            RKX3DExport.kPluginCmdName,       RKX3DExport.cmdCreator)
-        pluginFn.registerCommand(          RKX3DImportOp.kPluginCmdName,     RKX3DImportOp.cmdCreator)
-        pluginFn.registerCommand(            RKX3DImport.kPluginCmdName,       RKX3DImport.cmdCreator)
-        #pluginFn.registerCommand(        RKPrimeX3DScene.kPluginCmdName,   RKPrimeX3DScene.cmdCreator)
-        pluginFn.registerCommand(               RKTestIt.kPluginCmdName,          RKTestIt.cmdCreator)
-        pluginFn.registerCommand(      RKShowSceneEditor.kPluginCmdName, RKShowSceneEditor.cmdCreator)
+        pluginFn.registerCommand(       RKSetAsBillboard.kPluginCmdName,        RKSetAsBillboard.cmdCreator)
+        pluginFn.registerCommand(         RKAddCollision.kPluginCmdName,          RKAddCollision.cmdCreator)
+        pluginFn.registerCommand(             RKAddGroup.kPluginCmdName,              RKAddGroup.cmdCreator)
+        pluginFn.registerCommand(            RKAddSwitch.kPluginCmdName,             RKAddSwitch.cmdCreator)
+        pluginFn.registerCommand(                 RKInfo.kPluginCmdName,                  RKInfo.cmdCreator)
+        pluginFn.registerCommand(          RKX3DExportOp.kPluginCmdName,           RKX3DExportOp.cmdCreator)
+        pluginFn.registerCommand(            RKX3DExport.kPluginCmdName,             RKX3DExport.cmdCreator)
+        pluginFn.registerCommand(       RKX3DSelExportOp.kPluginCmdName,        RKX3DSelExportOp.cmdCreator)
+        pluginFn.registerCommand(         RKX3DSelExport.kPluginCmdName,          RKX3DSelExport.cmdCreator)
+        pluginFn.registerCommand(          RKX3DImportOp.kPluginCmdName,           RKX3DImportOp.cmdCreator)
+        pluginFn.registerCommand(            RKX3DImport.kPluginCmdName,             RKX3DImport.cmdCreator)
+        #pluginFn.registerCommand(        RKPrimeX3DScene.kPluginCmdName,        RKPrimeX3DScene.cmdCreator)
+        pluginFn.registerCommand(               RKTestIt.kPluginCmdName,                RKTestIt.cmdCreator)
+        pluginFn.registerCommand(      RKShowSceneEditor.kPluginCmdName,       RKShowSceneEditor.cmdCreator)
+        pluginFn.registerCommand(     RKX3DCastleProject.kPluginCmdName,      RKX3DCastleProject.cmdCreator)
+        pluginFn.registerCommand(    RKX3DCastleExportOp.kPluginCmdName,     RKX3DCastleExportOp.cmdCreator)
+        pluginFn.registerCommand( RKX3DCastleSelExportOp.kPluginCmdName,  RKX3DCastleSelExportOp.cmdCreator)
         
     except:
         sys.stderr.write("Failed to register a plugin command.\n")
@@ -365,18 +428,23 @@ def uninitializePlugin(plugin):
     '''
     ##################################
     try:
-        pluginFn.deregisterCommand(RKShowSceneEditor.kPluginCmdName)
-        pluginFn.deregisterCommand(         RKTestIt.kPluginCmdName)
-        #pluginFn.deregisterCommand(  RKPrimeX3DScene.kPluginCmdName)
-        pluginFn.deregisterCommand(      RKX3DImport.kPluginCmdName)
-        pluginFn.deregisterCommand(    RKX3DImportOp.kPluginCmdName)
-        pluginFn.deregisterCommand(      RKX3DExport.kPluginCmdName)
-        pluginFn.deregisterCommand(    RKX3DExportOp.kPluginCmdName)
-        pluginFn.deregisterCommand(           RKInfo.kPluginCmdName)
-        pluginFn.deregisterCommand(      RKAddSwitch.kPluginCmdName)
-        pluginFn.deregisterCommand(       RKAddGroup.kPluginCmdName)
-        pluginFn.deregisterCommand(   RKAddCollision.kPluginCmdName)
-        pluginFn.deregisterCommand( RKSetAsBillboard.kPluginCmdName)
+        pluginFn.deregisterCommand(RKX3DCastleSelExportOp.kPluginCmdName)
+        pluginFn.deregisterCommand(   RKX3DCastleExportOp.kPluginCmdName)
+        pluginFn.deregisterCommand(    RKX3DCastleProject.kPluginCmdName)
+        pluginFn.deregisterCommand(     RKShowSceneEditor.kPluginCmdName)
+        pluginFn.deregisterCommand(              RKTestIt.kPluginCmdName)
+        #pluginFn.deregisterCommand(      RKPrimeX3DScene.kPluginCmdName)
+        pluginFn.deregisterCommand(           RKX3DImport.kPluginCmdName)
+        pluginFn.deregisterCommand(         RKX3DImportOp.kPluginCmdName)
+        pluginFn.deregisterCommand(        RKX3DSelExport.kPluginCmdName)
+        pluginFn.deregisterCommand(      RKX3DSelExportOp.kPluginCmdName)
+        pluginFn.deregisterCommand(           RKX3DExport.kPluginCmdName)
+        pluginFn.deregisterCommand(         RKX3DExportOp.kPluginCmdName)
+        pluginFn.deregisterCommand(                RKInfo.kPluginCmdName)
+        pluginFn.deregisterCommand(           RKAddSwitch.kPluginCmdName)
+        pluginFn.deregisterCommand(            RKAddGroup.kPluginCmdName)
+        pluginFn.deregisterCommand(        RKAddCollision.kPluginCmdName)
+        pluginFn.deregisterCommand(      RKSetAsBillboard.kPluginCmdName)
         #pluginFn.deregisterCommand(    RKAddX3DSound.kPluginCmdName)
         #pluginFn.deregisterCommand(         RKServer.kPluginCmdName)
         

--- a/mel/x3d.mel
+++ b/mel/x3d.mel
@@ -33,6 +33,67 @@ global proc x3dOptionSuppression()
 	editorTemplate -suppress "x3dMetadataIn"; editorTemplate -suppress "audioOut"; editorTemplate -suppress "audioIn";
 }
 
+// Stackoverflow post on how to add menuItems to an existing Maya Menu
+// https://stackoverflow.com/questions/19236669/how-do-i-safely-add-menuitems-to-an-existing-menu-in-maya-mel
+
+global proc checkForFileMenuItems()
+{
+    global string $gMainFileMenu;
+    buildFileMenu();
+    
+    string $menus[] = `menu -q -ia $gMainFileMenu`;
+    
+    for($menu in $menus)
+    {
+        string $parent = "";
+        if(catchQuiet($parent = `menu -q -l $menu`))
+        {
+            print("MenuItem: " + $menu + "\n");
+        }
+        else
+        {
+            print("Parent: " + $parent + ", Menu: " + $menu + "\n");
+        }
+    }
+}
+
+
+global proc addRawKeeMenuItemsToFileMenu()
+{
+    global string $gMainFileMenu;
+    buildFileMenu();
+
+    menuItem -divider true -dividerLabel "RawKee X3D Export" -insertAfter "exportActiveFileOptions" -parent $gMainFileMenu rawkeeIODivider;
+    menuItem -label "X3D - Export All"                       -insertAfter "rawkeeIODivider"         -parent $gMainFileMenu -command "rkX3DExport"                      rawkeeIOExport;
+    menuItem -image ":menu_options.png"                      -insertAfter "rawkeeIOExport"          -parent $gMainFileMenu -command "rkX3DExportOp"    -optionBox true rawkeeIOExportOp;
+    menuItem -label "X3D - Export Selected"                  -insertAfter "rawkeeIOExportOp"        -parent $gMainFileMenu -command "rkX3DSelExport"                   rawkeeIOSelExport;
+    menuItem -image ":menu_options.png"                      -insertAfter "rawkeeIOSelExport"       -parent $gMainFileMenu -command "rkX3DSelExportOp" -optionBox true rawkeeIOSelExportOp;
+    
+    menuItem -label "Send To Castle"                         -insertAfter "sendToDivider"           -parent $gMainFileMenu                               -sm true        rawkeeCastleMenu;
+    menuItem -label "Send All"                                                                      -parent rawkeeCastleMenu -command "rkCASExport"                      rawkeeCASExport;
+    menuItem -image ":menu_options.png"                      -insertAfter "rawkeeCASExport"         -parent rawkeeCastleMenu -command "rkCASExportOp"    -optionBox true rawkeeCASExportOp;
+    menuItem -label "Send Selected"                          -insertAfter "rawkeeCASExportOp"       -parent rawkeeCastleMenu -command "rkCASSelExport"                   rawkeeCASSelExport;
+    menuItem -image ":menu_options.png"                      -insertAfter "rawkeeCASSelExport"      -parent rawkeeCastleMenu -command "rkCASSelExportOp" -optionBox true rawkeeCASSelExportOp;
+    menuItem -label "Set Castle Project"                     -insertAfter "rawkeeCASSelExportOp"    -parent rawkeeCastleMenu -command "rkCASSetProject"                  rawkeeCASSetProject;
+
+}
+
+global proc removeRawKeeMenuItemsFromFileMenu()
+{
+    deleteUI -mi rawkeeIOSelExportOp;
+    deleteUI -mi rawkeeIOSelExport;
+    deleteUI -mi rawkeeIOExportOp;
+    deleteUI -mi rawkeeIOExport;
+    deleteUI -mi rawkeeIODivider;
+    
+    deleteUI -mi rawkeeCASSetProject;
+    deleteUI -mi rawkeeCASSelExportOp;
+    deleteUI -mi rawkeeCASSelExport;
+    deleteUI -mi rawkeeCASExportOp;
+    deleteUI -mi rawkeeCASExport;
+    deleteUI -mi rawkeeCastleMenu;
+}
+
 
 //------------------------------------------------------------------
 // Looks to see if global Maya variables exist, and if they don't, 
@@ -42,231 +103,159 @@ global proc setDefRKOptVars()
 {
 	putenv "AW_JPEG_Q_FACTOR" "100";
 	
-	if(`optionVar -exists "x3dEncoding"`){
-	}else{
-		optionVar -iv x3dEncoding 0;
-	}
-	if(`optionVar -exists "x3dIsProcTree"`){
-	}else{
-		optionVar -iv x3dIsProcTree 0;
-	}
-	if(`optionVar -exists "x3dIsFrom"`){
-	}else{
-		optionVar -iv x3dIsFrom 1;
-	}
-	if(`optionVar -exists "x3dNodeTreeWidth"`){
-	}else{
-		optionVar -iv x3dNodeTreeWidth 0;
-	}
-	if(`optionVar -exists "x3dFieldAccessChoice"`){
-	}else{
-		optionVar -iv x3dFieldAccessChoice 1;
-	}
+    //-------------------------------------------
+    // New RawKee Python optionVars
+    //-------------------------------------------
+    if(`optionVar -exists "rkCastlePrjDir"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the current Castle Game Engine Project Directory");
+		optionVar -sv "rkCastlePrjDir" "";
+    }
+    
+    if(`optionVar -exists "rkSunrizePrjDir"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the current Castle Game Engine Project Directory");
+		optionVar -sv "rkSunrizePrjDir" "";
+    }
+    
+    if(`optionVar -exists "rkPrjDir"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkPrjDir" "";
+    }
 
-	if(`optionVar -exists "x3dFieldTypeChoice"`){
-	}else{
-		optionVar -iv x3dFieldTypeChoice 1;
-	}
+    if(`optionVar -exists "rkBaseDomain"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkBaseDomain" "";
+    }
 
-	if(`optionVar -exists "x3dExternalPixel"`){
+    if(`optionVar -exists "rkBasePath"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkBasePath" "";
+    }
+    
+    if(`optionVar -exists "rkImagePath"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkImagePath" "images/";
+    }
+    
+    if(`optionVar -exists "rkAudioPath"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkAudioPath" "audio/";
+    }
+    
+    if(`optionVar -exists "rkInlinePath"`)
+    {
+    }else{
+        print("Creating the optionVar to hold the a RawKee Project Directory for general X3D Export");
+		optionVar -sv "rkInlinePath" "inline/";
+    }
+    
+	if(`optionVar -exists "rk2dTexWrite"`){
 	}else{
-		optionVar -iv x3dExternalPixel 0;
+    //bool
+		optionVar -iv rk2dTexWrite 1;
 	}
 	
-	if(`optionVar -exists "x3dInternalPixel"`){
+	if(`optionVar -exists "rkMovTexWrite"`){
 	}else{
-		optionVar -iv x3dInternalPixel 0;
+    //bool
+		optionVar -iv rkMovTexWrite 1;
 	}
 	
-	//X3D Interaction Editor Routing Mode Option
-	if(`optionVar -exists "x3dIEMode"`){
+	if(`optionVar -exists "rkAudioTexWrite"`){
 	}else{
-		print("adding 'optionVar x3dIEMode' setting it to '0'\n");
-		optionVar -iv "x3dIEMode" 0;
+    //bool
+		optionVar -iv rkAudioTexWrite 1;
 	}
 	
-	//Lets us know if we should export location leaf nodes
-	//such as lights and cameras as syblings of their
-	//parent transforms.
-	if(`optionVar -exists "x3dUseEmpties"`){
+	if(`optionVar -exists "rk2dFileFormat"`){
 	}else{
-		optionVar -iv "x3dUseEmpties" 1;
+    //bool
+		optionVar -iv rk2dFileFormat 0;
 	}
 	
-	if(`optionVar -exists "x3dUnderworld"`){
+	if(`optionVar -exists "rkMovFileFormat"`){
 	}else{
-		print("adding 'optionVar x3dUnderworld' and setting it to '0'.\n");
-		optionVar -iv "x3dUnderworld" 0;
-	}
-
-	if(`optionVar -exists "x3dExportMetadata"`){
-	}else{
-		print("adding 'optionVar x3dExportMetadata' and  setting it to '1'.\n");
-		optionVar -iv "x3dExportMetadata" 1;
+    //bool
+		optionVar -iv rkMovFileFormat 0;
 	}
 	
-	if(`optionVar -exists "x3dExportTextures"`){
+	if(`optionVar -exists "rkAudioFileFormat"`){
 	}else{
-		print("adding 'optionVar x3dExportTextures' and  setting it to '1'.\n");
-		optionVar -iv "x3dExportTextures" 1;
+    //bool
+		optionVar -iv rkAudioFileFormat 0;
 	}
 	
-	if(`optionVar -exists "x3dSaveMayaTextures"`){
+	if(`optionVar -exists "rkExportCameras"`){
 	}else{
-		print("adding 'optionVar x3dSaveMayaTextures' and  setting it to '1'.\n");
-		optionVar -iv "x3dSaveMayaTextures" 1;
+    //bool
+		optionVar -iv rkExportCameras 1;
 	}
 	
-	if(`optionVar -exists "x3dTextureWidth"`){
+	if(`optionVar -exists "rkExportLights"`){
 	}else{
-		print("adding 'optionVar x3dTextureWidth' and  setting it to '256'.\n");
-		optionVar -iv "x3dTextureWidth" 256;
+    //bool
+		optionVar -iv rkExportLights 1;
 	}
 	
-	if(`optionVar -exists "x3dTextureHeight"`){
+	if(`optionVar -exists "rkExportSounds"`){
 	}else{
-		print("adding 'optionVar x3dTextureHeight' and  setting it to '256'.\n");
-		optionVar -iv "x3dTextureHeight" 256;
+    //bool
+		optionVar -iv rkExportSounds 1;
 	}
 	
-	if(`optionVar -exists "x3dConsolidateMedia"`){
+	if(`optionVar -exists "rkExportMetadata"`){
 	}else{
-		print("adding 'optionVar x3dConsolidateMedia' and  setting it to '1'.\n");
-		optionVar -iv "x3dConsolidateMedia" 1;
+    //bool
+		optionVar -iv rkExportMetadata 0;
 	}
 	
-	if(`optionVar -exists "x3dFileOverwrite"`){
+	if(`optionVar -exists "rkProcTexNode"`){
 	}else{
-		optionVar -iv x3dFileOverwrite 0;
+    //bool
+		optionVar -iv rkProcTexNode 0;
 	}
 	
-	if(`optionVar -exists "x3dAdjustTextureSize"`){
+	if(`optionVar -exists "rkFileTexNode"`){
 	}else{
-		print("adding 'optionVar x3dAdjustTextureSize' and  setting it to '1'.\n");
-		optionVar -iv "x3dAdjustTextureSize" 1;
+    //bool
+		optionVar -iv rkFileTexNode 0;
 	}
 	
-	if(`optionVar -exists "x3dTextureDirectory"`){
+	if(`optionVar -exists "rkLayerTexNode"`){
 	}else{
-		print("adding 'optionVar x3dTextureDirectory' and  setting it to 'images/'.\n");
-		optionVar -sv "x3dTextureDirectory" "images/";
+    //bool
+		optionVar -iv rkLayerTexNode 0;
 	}
 	
-	if(`optionVar -exists "x3dTextureFormat"`){
+	if(`optionVar -exists "rkAdjTexSize"`){
 	}else{
-		print("adding 'optionVar x3dTextureFormat' and  setting it to '0'.\n");
-		optionVar -iv "x3dTextureFormat" 0;
+    //bool
+		optionVar -iv rkAdjTexSize 0;
 	}
 	
-	if(`optionVar -exists "x3dExportAudio"`){
+	if(`optionVar -exists "rkDefTexWidth"`){
 	}else{
-		print("adding 'optionVar x3dExportAudio' and  setting it to '1'.\n");
-		optionVar -iv "x3dExportAudio" 1;
+    //bool
+		optionVar -iv rkDefTexWidth 256;
 	}
 	
-	if(`optionVar -exists "x3dAudioDirectory"`){
+	if(`optionVar -exists "rkDefTexHeight"`){
 	}else{
-		print("adding 'optionVar x3dAudioDirectory' and  setting it to 'audio/'.\n");
-		optionVar -sv "x3dAudioDirectory" "audio/";
-	}
-	
-	if(`optionVar -exists "x3dInlineDirectory"`){
-	}else{
-		print("adding 'optionVar x3dInlineDirectory' and  setting it to 'inline/'.\n");
-		optionVar -sv "x3dInlineDirectory" "inline/";
-	}
-	
-	if(`optionVar -exists "x3dCPV"`){
-	}else{
-		print("adding 'optionVar x3dCPV' and setting it to '1'.\n");
-		optionVar -iv "x3dCPV" 1;
-	}
-	
-	if(`optionVar -exists "x3dNPV"`){
-	}else{
-		print("adding 'optionVar x3dNPV' and setting it to '1'.\n");
-		optionVar -iv "x3dNPV" 1;
-	}
-	
-	if(`optionVar -exists "x3dCreaseAngle"`){
-	}else{
-		print("adding 'optionVar x3dCreaseAngle' and setting it to '1.57'.\n");
-		optionVar -fv "x3dCreaseAngle" 1.57;
-	}
-	
-//	if(`optionVar -exists "x3dSolid"`){
-//	}else{
-//		print("adding 'optionVar x3dSolid' and setting it to '1'.\n");
-//		optionVar -iv "x3dSolid" 1;
-//	}
-	
-	if(`optionVar -exists "x3dNSHAnim"`){
-	}else{
-		print("adding 'optionVar x3dNSHAnim' and setting it to '1'.\n");
-		optionVar -iv "x3dNSHAnim" 1;
-	}
-	
-	if(`optionVar -exists "x3dBaseURL"`){
-	}else{
-		print("adding 'optionVar x3dBaseURL' and  setting it to ''.\n");
-		optionVar -sv "x3dBaseURL" "";
-	}
-	
-	if(`optionVar -exists "x3dNonMovieTextureFormat"`){
-	}else{
-		print("adding 'optionVar x3dNonMovieTextureFormat' and  setting it to '0' - Current Format.\n");
-		optionVar -iv "x3dNonMovieTextureFormat" 0;
-	}
-	
-	if(`optionVar -exists "x3dRigidBodyExport"`){
-	}else{
-		print("adding 'optionVar x3dRigidBodyExport' and setting it to '0'.\n");
-		optionVar -iv "x3dRigidBodyExport" 0 ;
-	}
-	if(`optionVar -exists "x3dHAnimExport"`){
-	}else{
-		print("adding 'optionVar x3dHAnimExport' and setting it to '0'.\n");
-		optionVar -iv "x3dHAnimExport" 0 ;
-	}
-	
-	if(`optionVar -exists "x3dIODeviceExport"`){
-	}else{
-		print("adding 'optionVar x3dIODeviceExport' and setting it to '0'.\n");
-		optionVar -iv "x3dIODeviceExport" 0 ;
-	}
-	if(`optionVar -exists "x3dUseRelURL"`)
-	{
-	}else{
-		print("adding 'optionVar x3dUseRelURL' and setting it to '1'.\n");
-		optionVar -iv "x3dUseRelURL" 1;
-	}
-	
-	if(`optionVar -exists "x3dUseRelURLW"`)
-	{
-	}else{
-		print("adding 'optionVar x3dUseRelURLW' and setting it to '1'.\n");
-		optionVar -iv "x3dUseRelURLW" 1;
-	}
-	
-	if(`optionVar -exists "x3dUseAbsURL"`)
-	{
-	}else{
-		print("adding 'optionVar x3dUseAbsURL' and setting it to '1'.\n");
-		optionVar -iv "x3dUseAbsURL" 1;
-	}
-	
-	if(`optionVar -exists "x3dJavaMemory"`)
-	{
-	}else{
-		print("adding 'optionVar x3dJavaMemory' and setting it to '64'\n");
-		optionVar -iv "x3dJavaMemory" 64;
-	}
-	
-	if(`optionVar -exists "x3dBCFlag"`)
-	{
-	}else{
-		print("adding 'optionVar x3dBCFlag' and setting it to '1'.\n");
-		optionVar -iv "x3dBCFlag" 1;
+    //bool
+		optionVar -iv rkDefTexHeight 256;
 	}
 }
 

--- a/rawkee/RKFOptsDialog.py
+++ b/rawkee/RKFOptsDialog.py
@@ -1,39 +1,25 @@
-#import os
-#os.environ['QTWEBENGINE_CHROMIUM_FLAGS'] = "--disable-gpu"
-#os.environ['QTWEBENGINE_CHROMIUM_FLAGS'] = "--enable-blink-features=InterestCohortAPI --enable-features='FederatedLearningOfCohorts:update_interval/10s/minimum_history_domain_size_required/1,FlocIdSortingLshBasedComputation,InterestCohortFeaturePolicy'"
-
 try:
     #Qt5
     from PySide2           import QtCore
     from PySide2           import QtWidgets
-    from PySide2.QtWebEngineWidgets import QWebEngineView
     from PySide2           import QtGui
     from PySide2           import QMenu
     from PySide2.QtWidgets import QAction
     from PySide2.QtWidgets import QMenu
     from PySide2.QtCore    import QUrl
-    from PySide2.QtWebEngineWidgets import QWebEngineSettings
-    from PySide2.QtWebEngineWidgets import QWebEnginePage
-    from PySide2.QtQui import QDesktopServices
+    from PySide2.QtQui     import QDesktopServices
 
-    from PySide2.QtCore import QLoggingCategory, qInstallMessageHandler
-    
     from shiboken2         import wrapInstance
 
 except:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets
-    from PySide6.QtWebEngineWidgets import QWebEngineView
     from PySide6           import QtGui
     from PySide6.QtGui     import QAction
     from PySide6.QtWidgets import QMenu
     from PySide6.QtCore    import QUrl
-    from PySide6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings, qWebEngineVersion, qWebEngineChromiumVersion, qWebEngineChromiumSecurityPatchVersion
-    from PySide6.QtWebEngineCore import QWebEnginePage
-    from PySide6.QtGui import QDesktopServices
-    
-    from PySide6.QtCore import qInstallMessageHandler, QtMsgType, QMessageLogContext
+    from PySide6.QtGui     import QDesktopServices
     
     from shiboken6         import wrapInstance
 
@@ -43,6 +29,8 @@ import maya.OpenMaya as om
 import maya.OpenMayaUI as omui
 import maya.cmds as cmds
 
+import os
+
 #######################################
 # Don't remember why this is here
 #######################################
@@ -50,38 +38,17 @@ import maya.cmds as cmds
 # import maya.standalone as mst
 # print(inspect.getfile(mst))
 
-os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--enable-logging --log-level=3 --remote-debugging-port=2345"
-os.environ["QT_LOGGING_RULES"] = "qt.webenginecontext.debug=true"
-
-
-print("Qt: v", PySide6.QtCore.__version__, "\tPyQt: v", PySide6.__version__)
-
 def mayaMainWindow():
     mainWindowPtr = omui.MQtUtil.mainWindow()
     return wrapInstance(int(mainWindowPtr), QtWidgets.QWidget)
     
-def handleJSConsoleMessage(msg_type, context, msg):
-    # Format the message based on its type
-    if msg_type == QtMsgType.QtDebugMsg:
-        msg_type_str = "Debug"
-    elif msg_type == QtMsgType.QtWarningMsg:
-        msg_type_str = "Warning"
-    elif msg_type == QtMsgType.QtCriticalMsg:
-        msg_type_str = "Critical"
-    elif msg_type == QtMsgType.QtFatalMsg:
-        msg_type_str = "Fatal"
-    else:
-        msg_type_str = "Unknown"
-
-    # Print the formatted message
-    print(f"{msg_type_str}: {msg}")    
-                
 class RKFOptsDialog(QtWidgets.QDialog):
-    def __init__(self, parent=mayaMainWindow()):
+    def __init__(self, parent=mayaMainWindow(), dialogTitle="X3D"):
         super(RKFOptsDialog, self).__init__(parent)
-        
-        self.setWindowTitle("RawKee (X3D) wtih X_ITE")
+        self.dialogTitle = dialogTitle
+        self.setWindowTitle(self.dialogTitle)
         self.setMinimumSize(600,400)
+        self.setFixedWidth(800)
 
         #On macOS make the window a Tool to keep it on top of Maya
         if sys.platform == "darwin":
@@ -91,35 +58,405 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.createWidgets()
             
     def createWidgets(self):
-        qInstallMessageHandler(handleJSConsoleMessage)
-
-        layout = QtWidgets.QVBoxLayout()
+        scrollArea = QtWidgets.QScrollArea()
+        scrollArea.setWidgetResizable(True)
         
-        settings = QWebEngineProfile.defaultProfile().settings()
-        settings.setAttribute(QWebEngineSettings.WebAttribute.WebGLEnabled, True)
-        settings.setAttribute(QWebEngineSettings.LocalContentCanAccessRemoteUrls, True)
+        contentWidget = QtWidgets.QWidget()
+        contentLayout = QtWidgets.QVBoxLayout(contentWidget)
         
-        view = QWebEngineView()
+        if self.dialogTitle == "X3D Export Options":
+            contentLayout = self.buildX3DExportPanel(contentLayout)
 
-#        view.javaScriptConsoleMessage.connect(handleJSConsoleMessage)
-       
-        layout.addWidget(view)
-#        view.setHtml('<!DOCTYPE html><html><head><meta charset="utf-8"><script defer src="https://cdn.jsdelivr.net/npm/x_ite@11.0.2/dist/x_ite.min.js"></script><style>x3d-canvas{width: 768px; height: 432px;}</style></head><body><x3d-canvas src="https://www.web3d.org/x3d/content/examples/Basic/NURBS/FredTheBunny.x3d"></x3d-canvas></body></html>')
-#        view.setUrl(QUrl("https://vr.csgrid.org/x_ite/pum___p.html"))
-        view.setUrl(QUrl("http://localhost:8080/"))
-#        view.setUrl(QUrl("https://www.x3dom.org/"))
-#        view.show()
-#        view.setUrl(QUrl("https://create3000.github.io/x_ite/dom-integration/"))
-#        view.setUrl(QUrl("https://get.webgl.org/"))
-#        view.setUrl(QUrl("chrome://gpu"))
-        self.setLayout(layout)
-#        view.show()
-#        QDesktopServices.openUrl("https://create3000.github.io/x_ite/playground/")
+            scrollArea.setWidget(contentWidget)
+            dialogLayout = QtWidgets.QVBoxLayout()
+            dialogLayout.addWidget(scrollArea)
+            
+            buttonRow = QtWidgets.QHBoxLayout()
+            self.buttonSpace = QtWidgets.QLabel(" ")
+            self.buttonSpace.setFixedWidth(400)
+            self.buttonSpace.setAlignment(QtCore.Qt.AlignRight)
+            self.cancelButton = QtWidgets.QPushButton("Save Options and Close")
+            self.exportButton = QtWidgets.QPushButton("Save Options and Export")
+            
+            buttonRow.addWidget(self.buttonSpace)
+            buttonRow.addWidget(self.cancelButton)
+            buttonRow.addWidget(self.exportButton)
+            dialogLayout.addLayout(buttonRow)
+
+            self.setLayout(dialogLayout)
+            
+        elif self.dialogTitle == "X3D Export Selected Options":
+            pass
+        elif self.dialogTitle == "X3D Import Options":
+            pass
+        elif self.dialogTitle == "Castle Export All - Options":
+            pass
+        elif self.dialogTitle == "Castle Export Selected - Options":
+            pass
 
 
-        print(qWebEngineVersion())
-        print(qWebEngineChromiumVersion())
-    
+
+    def buildX3DExportPanel(self, layout):
+        #layout = QtWidgets.QVBoxLayout()
+
+        # Option One
+        layoutOne = QtWidgets.QHBoxLayout()
+        self.mayaTexLabel = QtWidgets.QLabel("     Procedural Textures - Export as:")
+        self.mayaTexLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.mayaTexLabel.setFixedWidth(250)
+        self.comboMayaTexOptions = QtWidgets.QComboBox()
+        self.comboMayaTexOptions.addItems(["ImageTexture", "PixelTexture"])
+        self.comboMayaTexOptions.setFixedWidth(200)
+        
+        layoutOne.addWidget(self.mayaTexLabel)
+        layoutOne.addWidget(self.comboMayaTexOptions)
+        layoutOne.addStretch()
+        
+        # Option Two
+        layoutTwo = QtWidgets.QHBoxLayout()
+        self.mayaTexFileLabel = QtWidgets.QLabel("     File Textures - Export as:")
+        self.mayaTexFileLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.mayaTexFileLabel.setFixedWidth(250)
+        self.comboMayaTexFileOptions = QtWidgets.QComboBox()
+        self.comboMayaTexFileOptions.addItems(["ImageTexture", "PixelTexture"])
+        self.comboMayaTexFileOptions.setFixedWidth(200)
+        
+        layoutTwo.addWidget(self.mayaTexFileLabel)
+        layoutTwo.addWidget(self.comboMayaTexFileOptions)
+        layoutTwo.addStretch()
+        
+        # Option Three
+        layoutThree = QtWidgets.QHBoxLayout()
+        self.mayaLayeredLabel = QtWidgets.QLabel("     Layered Textures - Export as:")
+        self.mayaLayeredLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.mayaLayeredLabel.setFixedWidth(250)
+        self.comboMayaLayeredOptions = QtWidgets.QComboBox()
+        self.comboMayaLayeredOptions.addItems(["MultiTexture", "ImageTexture", "PixelTexture"])
+        self.comboMayaLayeredOptions.setFixedWidth(200)
+        
+        layoutThree.addWidget(self.mayaLayeredLabel)
+        layoutThree.addWidget(self.comboMayaLayeredOptions)
+        layoutThree.addStretch()
+        
+        # Option Three Alpha
+        layoutThreeAlpha = QtWidgets.QHBoxLayout()
+        self.texFileFormatLabel = QtWidgets.QLabel("     2D Texture File Format:")
+        self.texFileFormatLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.texFileFormatLabel.setFixedWidth(250)
+        self.texFileFormatOptions = QtWidgets.QComboBox()
+        self.texFileFormatOptions.addItems(["PNG - Portable Netowrk Graphics", "WebP - Web Picture", "JPG - Joint Photographic Experts Group"])
+        self.texFileFormatOptions.setFixedWidth(250)
+        
+        layoutThreeAlpha.addWidget(self.texFileFormatLabel)
+        layoutThreeAlpha.addWidget(self.texFileFormatOptions)
+        layoutThreeAlpha.addStretch()
+        
+        
+        # Option Three Bravo
+        layoutThreeBravo = QtWidgets.QHBoxLayout()
+        self.movFileFormatLabel = QtWidgets.QLabel("     Movie/Video File Format:")
+        self.movFileFormatLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.movFileFormatLabel.setFixedWidth(250)
+        self.movFileFormatOptions = QtWidgets.QComboBox()
+        self.movFileFormatOptions.addItems(["MP4 with H.264", "WebM with VP9", "Ogg with Theora/Vorbis"])
+        self.movFileFormatOptions.setFixedWidth(250)
+        
+        layoutThreeBravo.addWidget(self.movFileFormatLabel)
+        layoutThreeBravo.addWidget(self.movFileFormatOptions)
+        layoutThreeBravo.addStretch()
+        
+        
+        # Option Three Charlie
+        layoutThreeCharlie = QtWidgets.QHBoxLayout()
+        self.audFileFormatLabel = QtWidgets.QLabel("     Audio File Format:")
+        self.audFileFormatLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.audFileFormatLabel.setFixedWidth(250)
+        self.audFileFormatOptions = QtWidgets.QComboBox()
+        self.audFileFormatOptions.addItems(["MP3 - MPEG Audio Layer 3", "AAC - Advanced Audio Coding", "Ogg Vorbis"])
+        self.audFileFormatOptions.setFixedWidth(250)
+        
+        layoutThreeCharlie.addWidget(self.audFileFormatLabel)
+        layoutThreeCharlie.addWidget(self.audFileFormatOptions)
+        layoutThreeCharlie.addStretch()
+        
+        
+        # Option Four
+        layoutFour = QtWidgets.QHBoxLayout()
+        spacer4 = QtWidgets.QLabel(" ")
+        spacer4.setAlignment(QtCore.Qt.AlignLeft)
+        spacer4.setFixedWidth(80)
+        self.media2FileLabel = QtWidgets.QLabel("Consolidate Media Files (write/overwrite) in RawKee Project Folder:")
+        self.media2FileLabel.setAlignment(QtCore.Qt.AlignLeft)
+        self.media2FileLabel.setFixedWidth(400)
+
+        layoutFour.addWidget(spacer4)
+        layoutFour.addWidget(self.media2FileLabel)
+        layoutFour.addStretch()
+        
+        # Option FourB
+        layoutFourB = QtWidgets.QHBoxLayout()
+        spacer4B = QtWidgets.QLabel(" ")
+        spacer4B.setAlignment(QtCore.Qt.AlignRight)
+        spacer4B.setFixedWidth(150)
+        self.texture2FileCheckBox = QtWidgets.QCheckBox("2D Textures")
+        self.movie2FileCheckBox   = QtWidgets.QCheckBox("Movie Textures")
+        self.audio2FileCheckBox   = QtWidgets.QCheckBox("Audio Clips")
+        
+        layoutFourB.addWidget(spacer4B)
+        layoutFourB.addWidget(self.texture2FileCheckBox)
+        layoutFourB.addWidget(self.movie2FileCheckBox)
+        layoutFourB.addWidget(self.audio2FileCheckBox)
+        layoutFourB.addStretch()
+        
+        # Option Five
+        layoutFive = QtWidgets.QHBoxLayout()
+        adjTexSizeLabel = QtWidgets.QLabel("Adjust Texture Size:")
+        adjTexSizeLabel.setAlignment(QtCore.Qt.AlignRight)
+        adjTexSizeLabel.setFixedWidth(250)
+        layoutFive.addWidget(adjTexSizeLabel)
+#        layoutFive.addStretch()
+        
+        # Option FiveB
+        layoutFiveB = QtWidgets.QHBoxLayout()
+        spacer5B = QtWidgets.QLabel(" ")
+        spacer5B.setAlignment(QtCore.Qt.AlignRight)
+        spacer5B.setFixedWidth(180)
+        self.adjTexCheckBox = QtWidgets.QCheckBox()
+        self.adjTexCheckBox.setFixedWidth(20)
+        
+        layoutFiveB.addWidget(spacer5B)
+        layoutFive.addWidget(self.adjTexCheckBox)
+#        layoutFiveB.addStretch()
+        
+        # Option Six
+        layoutSix = QtWidgets.QHBoxLayout()
+        spacer6 = QtWidgets.QLabel(" ")
+        spacer6.setAlignment(QtCore.Qt.AlignRight)
+        spacer6.setFixedWidth(180)
+        
+        self.adjTexWidthLabel = QtWidgets.QLabel("Width:")
+        self.adjTexWidthLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.adjTexWidthLabel.setFixedWidth(50)
+        self.textureWidth = QtWidgets.QLineEdit()
+        self.textureWidth.setAlignment(QtCore.Qt.AlignLeft)
+        self.textureWidth.setFixedWidth(50)
+        intVal = QtGui.QIntValidator()
+        intVal.setRange(1,8192)
+        self.textureWidth.setValidator(intVal)
+        
+        self.adjTexHeightLabel = QtWidgets.QLabel("Height:")
+        self.adjTexHeightLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.adjTexHeightLabel.setFixedWidth(50)
+        self.textureHeight = QtWidgets.QLineEdit()
+        self.textureHeight.setAlignment(QtCore.Qt.AlignLeft)
+        self.textureHeight.setFixedWidth(50)
+        self.textureHeight.setValidator(intVal)
+        
+        layoutFive.addWidget(self.adjTexWidthLabel)
+        layoutFive.addWidget(self.textureWidth)
+        layoutFive.addWidget(self.adjTexHeightLabel)
+        layoutFive.addWidget(self.textureHeight)
+        layoutFive.addStretch()
+        
+        # Option Seven
+        layoutSeven = QtWidgets.QHBoxLayout()
+        self.regOptsLabel = QtWidgets.QLabel("Include Nodes for Export:")
+        self.regOptsLabel.setAlignment(QtCore.Qt.AlignLeft)
+        self.regOptsLabel.setFixedWidth(300)
+        
+        spacer7 = QtWidgets.QLabel(" ")
+        spacer7.setAlignment(QtCore.Qt.AlignLeft)
+        spacer7.setFixedWidth(80)
+        
+        layoutSeven.addWidget(spacer7)
+        layoutSeven.addWidget(self.regOptsLabel)
+        layoutSeven.addStretch()
+        
+        # Option Eight and Nine
+        layoutEight = QtWidgets.QHBoxLayout()
+        spacer8 = QtWidgets.QLabel(" ")
+        spacer8.setAlignment(QtCore.Qt.AlignLeft)
+        spacer8.setFixedWidth(150)
+        
+        layoutNine = QtWidgets.QHBoxLayout()
+        spacer9 = QtWidgets.QLabel(" ")
+        spacer9.setAlignment(QtCore.Qt.AlignLeft)
+        spacer9.setFixedWidth(150)
+        
+        self.exCameras  = QtWidgets.QCheckBox("Maya Cameras as X3D Viewpoints")
+        self.exLights   = QtWidgets.QCheckBox("Maya Lights as X3D Lights")
+        self.exCameras.setFixedWidth(250)
+        self.exLights.setFixedWidth(250)
+        
+        self.exSounds   = QtWidgets.QCheckBox("RawKee Sound as X3D Sound")
+        self.exMetadata = QtWidgets.QCheckBox("RawKee Metadata as X3D Metadata")
+        self.exSounds.setFixedWidth(250)
+        self.exMetadata.setFixedWidth(250)
+        
+        layoutEight.addWidget(spacer8)
+        layoutEight.addWidget(self.exCameras)
+        layoutEight.addWidget(self.exLights)
+        layoutEight.addStretch()
+        
+        layoutNine.addWidget(spacer9)
+        layoutNine.addWidget(self.exSounds)
+        layoutNine.addWidget(self.exMetadata)
+        layoutNine.addStretch()
+        
+        
+        # Option Ten
+        layoutTen = QtWidgets.QHBoxLayout()
+        self.rpdLabel = QtWidgets.QLabel("RawKee Project Directory:")
+        self.rpdLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.rpdLabel.setFixedWidth(250)
+        
+        self.rkProjectDir = QtWidgets.QLineEdit()
+        self.rkProjectDir.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkProjectDir.setFixedWidth(300)
+        
+        self.rkPrjDirButton = QtWidgets.QPushButton()
+        self.rkPrjDirButton.setIcon(QtGui.QIcon(":folder-open.png"))
+        self.rkPrjDirButton.setContentsMargins(0,0,0,0)
+        self.rkPrjDirButton.setFixedSize(20,20)
+        
+        layoutTen.addWidget(self.rpdLabel)
+        layoutTen.addWidget(self.rkProjectDir)
+        layoutTen.addWidget(self.rkPrjDirButton)
+        layoutTen.addStretch()
+        
+        
+        # Option Eleven
+        layoutEleven = QtWidgets.QHBoxLayout()
+        self.bDomLabel = QtWidgets.QLabel("Base Web Domain:")
+        self.bDomLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.bDomLabel.setFixedWidth(250)
+        
+        self.rkBaseDomain = QtWidgets.QLineEdit()
+        self.rkBaseDomain.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkBaseDomain.setFixedWidth(300)
+        
+        
+        layoutEleven.addWidget(self.bDomLabel)
+        layoutEleven.addWidget(self.rkBaseDomain)
+        layoutEleven.addStretch()
+        
+        
+        # Option Twelve
+        layoutTwelve = QtWidgets.QHBoxLayout()
+        self.basePathLabel = QtWidgets.QLabel("Base Path:")
+        self.basePathLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.basePathLabel.setFixedWidth(250)
+        
+        self.rkBasePath = QtWidgets.QLineEdit()
+        self.rkBasePath.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkBasePath.setFixedWidth(300)
+        
+        
+        layoutTwelve.addWidget(self.basePathLabel)
+        layoutTwelve.addWidget(self.rkBasePath)
+        layoutTwelve.addStretch()
+        
+        
+        # Option Thirteen
+        layoutThirteen = QtWidgets.QHBoxLayout()
+        self.imagePathLabel = QtWidgets.QLabel("Image Path:")
+        self.imagePathLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.imagePathLabel.setFixedWidth(250)
+        
+        self.rkImagePath = QtWidgets.QLineEdit()
+        self.rkImagePath.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkImagePath.setFixedWidth(300)
+        
+        
+        layoutThirteen.addWidget(self.imagePathLabel)
+        layoutThirteen.addWidget(self.rkImagePath)
+        layoutThirteen.addStretch()
+        
+        
+        # Option Fourteen
+        layoutFourteen = QtWidgets.QHBoxLayout()
+        self.audioPathLabel = QtWidgets.QLabel("Audio Path:")
+        self.audioPathLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.audioPathLabel.setFixedWidth(250)
+        
+        self.rkAudioPath = QtWidgets.QLineEdit()
+        self.rkAudioPath.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkAudioPath.setFixedWidth(300)
+        
+        
+        layoutFourteen.addWidget(self.audioPathLabel)
+        layoutFourteen.addWidget(self.rkAudioPath)
+        layoutFourteen.addStretch()
+        
+        
+        # Option Fifteen
+        layoutFifteen = QtWidgets.QHBoxLayout()
+        self.inlinePathLabel = QtWidgets.QLabel("Inline Path:")
+        self.inlinePathLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.inlinePathLabel.setFixedWidth(250)
+        
+        self.rkInlinePath = QtWidgets.QLineEdit()
+        self.rkInlinePath.setAlignment(QtCore.Qt.AlignLeft)
+        self.rkInlinePath.setFixedWidth(300)
+        
+        
+        layoutFifteen.addWidget(self.inlinePathLabel)
+        layoutFifteen.addWidget(self.rkInlinePath)
+        layoutFifteen.addStretch()
+        
+        
+        ##### Setting up the main layout #####
+
+        # Section Header
+        textureSection = QtWidgets.QLabel("Texture Options")
+        generalSection = QtWidgets.QLabel("RawKee Project Options")
+        pathSection    = QtWidgets.QLabel("Domain & Path Options")
+        
+        
+        separator1 = QtWidgets.QFrame()
+        separator1.setFrameShape(QtWidgets.QFrame.Shape.HLine)
+        separator1.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
+        separator2 = QtWidgets.QFrame()
+        separator2.setFrameShape(QtWidgets.QFrame.Shape.HLine)
+        separator2.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+
+        layout.addWidget(generalSection)
+        layout.addLayout(layoutFour)
+        layout.addLayout(layoutFourB)
+        layout.addLayout(layoutSix)
+        
+        layout.addLayout(layoutThreeAlpha)
+        layout.addLayout(layoutThreeBravo)
+        layout.addLayout(layoutThreeCharlie)
+
+        layout.addLayout(layoutSeven)
+        layout.addLayout(layoutEight)
+        layout.addLayout(layoutNine)
+
+        layout.addWidget(separator1)
+
+        layout.addWidget(textureSection)
+        layout.addLayout(layoutOne)
+        layout.addLayout(layoutTwo)
+        layout.addLayout(layoutThree)
+        layout.addLayout(layoutFive)
+        layout.addLayout(layoutFiveB)
+
+        layout.addWidget(separator2)
+
+        layout.addWidget(pathSection)
+        layout.addLayout(layoutTen)
+        layout.addLayout(layoutEleven)
+        layout.addLayout(layoutTwelve)
+        layout.addLayout(layoutThirteen)
+        layout.addLayout(layoutFourteen)
+        layout.addLayout(layoutFifteen)
+        
+        layout.addStretch()
+        
+        return layout
+        
     def printMessages(self):
         print("Blah")
         
@@ -127,6 +464,23 @@ class RKFOptsDialog(QtWidgets.QDialog):
         pass
         
     def createConnections(self):
+        pass
+        
+    def getOptionVarString(self, optionName):
+        optStr = ""
+        
+        return optStr
+        
+    def setOptionVarString(self, strVal):
+        pass
+        
+    def getOptionVarInt(self, optionName):
+        
+        optInt = 0
+        
+        return optInt
+        
+    def setOptionVarInt(self, intVal):
         pass
         
         

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -20,7 +20,9 @@ import subprocess        as sp         ###
 
 from rawkee import RKOrganizer
 from rawkee import RKSceneEditor
-from rawkee.RKUtils import *
+from rawkee.RKFOptsDialog import RKFOptsDialog
+
+#from rawkee.RKUtils import *
 
 import x3d              as rkx3d
 
@@ -73,8 +75,6 @@ class RKWeb3D():
         # Setup the main 'RawKee X3D' plugin menu
         self.rkMenuName ="rawkee_menu"
 
-        self.rawKeeMenu = ""
-
         #Populate the RawKee X3D Menu
         self.addRawKeeMenu()
         
@@ -125,6 +125,7 @@ class RKWeb3D():
         '''
         print("Add Menu Ran")
     
+        
         #TODO: Implement Connections to function calls ##############
         #cmds.window(query=True, mainMenuBar=True)
         self.rawKeeMenu = cmds.menu(self.rkMenuName, label = 'RawKee (X3D)', tearOff=True, p='MayaWindow')#QMenu("RawKee (X3D)", self.mayaWin)
@@ -141,7 +142,6 @@ class RKWeb3D():
         self.x3dImport       = cmds.menuItem(label='Import X3D Files',      command='maya.cmds.rkX3DImport()')                      #self.rawKeeMenu.addAction(self.x3dImport)
         self.x3dImportOpt    = cmds.menuItem(image=':menu_options.png',     command='maya.cmds.rkX3DImportOp()',    optionBox=True) #self.rawKeeMenu.addAction(self.x3dImportOpt)
 #        self.x3dExport.addAction("Export Scene Prep")# -c "x3dPrepareSceneForExport";
-
 
         #--------------------------------------------------------------------
         # Finishing off the  X3D Plug-in menu
@@ -173,6 +173,7 @@ class RKWeb3D():
         cmds.menuItem(label='Test Function', command='maya.cmds.rkTestIt()')
         ###################################################
     
+        mel.eval('addRawKeeMenuItemsToFileMenu()')
     
     
     # Destroy "RawKee (X3D)" - main plugin menu
@@ -180,12 +181,15 @@ class RKWeb3D():
         '''
         Remove and destroy the RawKee Primary Menu
         '''
-        #self.mayaWin.menuBar().removeAction(self.rawKeeMenu.menuAction())
-        if  cmds.menu(self.rkMenuName,  label = 'RawKee (X3D)', p='MayaWindow') != 0:
-            cmds.deleteUI(cmds.menu(self.rkMenuName,  label = 'RawKee (X3D)', e=1, dai=1))
+        
+        try:
             cmds.deleteUI(self.rkMenuName)     
             cmds.refresh()
-            print("Removing Menus")
+            mel.eval('removeRawKeeMenuItemsFromFileMenu()')
+        except:
+            print("An error occured when attempting to remove the RawKee menubar menu, and rawkee items from the 'File' menu.")
+
+        print("Removing Menus")
     
     def printTheGlobal(self):
         print("The Global")
@@ -289,11 +293,31 @@ class RKWeb3D():
 
     # Export Options Function
     def activateExportOptions(self):
+        dTitle = "X3D Export Options"
+        try:
+            self.openIODialog.close()
+            self.openIODialog.deleteLater()
+        except:
+            pass
+            
+        self.openIODialog = RKFOptsDialog(dialogTitle=dTitle)
+        self.openIODialog.show()
+        
         print("TODO: Implement Export Options Window")
         
     
     # Export Options Function
     def activateSelExportOptions(self):
+        dTitle = "X3D Export Selected Options"
+        try:
+            self.openIODialog.close()
+            self.openIODialog.deleteLater()
+        except:
+            pass
+            
+        self.openIODialog = RKFOptsDialog(dialogTitle=dTitle)
+        self.openIODialog.show()
+        
         print("TODO: Implement Select Export Options Window")
         
     
@@ -314,13 +338,60 @@ class RKWeb3D():
     
     # Import Options Function
     def activateImportOptions(self):
+        dTitle = "X3D Import Options"
+        try:
+            self.openIODialog.close()
+            self.openIODialog.deleteLater()
+        except:
+            pass
+            
+        self.openIODialog = RKFOptsDialog(dialogTitle=dTitle)
+        self.openIODialog.show()
+
         print("TODO: Implement Import Options Window")
+        
+    # Options for Castle Game Engine Export All - Send
+    def activateCastleExportOptions(self):
+        dTitle = "Castle Export All - Options"
+        try:
+            self.openIODialog.close()
+            self.openIODialog.deleteLater()
+        except:
+            pass
+            
+        self.openIODialog = RKFOptsDialog(dialogTitle=dTitle)
+        self.openIODialog.show()
+        
+    
+    # Options for Castle Game Engine Export Selected Items - Send
+    def activateCastleSelExportOptions(self):
+        dTitle = "Castle Export Selected - Options"
+        try:
+            self.openIODialog.close()
+            self.openIODialog.deleteLater()
+        except:
+            pass
+            
+        self.openIODialog = RKFOptsDialog(dialogTitle=dTitle)
+        self.openIODialog.show()
+        
     
     # File Import/Export Options Window
     def activateFOptsDialog(self):
         pass
         
+    
+    def setCastleProjectDirectory(self):
+        prjVal = cmds.optionVar( query = 'rkCastlePrjDir')
         
+        directoryResult = QtWidgets.QFileDialog.getExistingDirectory(self.mayaWin,  QtCore.QObject.tr("Set Castle Game Engine Project"), prjVal)
+        
+        if directoryResult:
+            cmds.optionVar(sv=('rkCastlePrjDir', directoryResult))
+        else:
+            print("Directory Selection Cancelled.")
+            
+        #getOpenFileName(self.mayaWin, QtCore.QObject.tr("RawKee - Select File to Import"), self.fullPath, QtCore.QObject.tr(self.x3dfilters))
 
 # Creating the MEL Command for the RawKee's Command to add a switch node
 class RKAddCollision(aom.MPxCommand):


### PR DESCRIPTION
This pull request introduces several new commands and menu items to the RawKee plugin for Maya, enhancing its functionality for exporting and managing X3D projects. Additionally, it includes some refactoring and improvements to the plugin initialization and option variables.

### New Commands and Menu Items:

* Added new commands for managing Castle Project directories and export options:
  - [`RKX3DCastleProject`](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R224-R281): Sets the Castle Project directory.
  - [`RKX3DCastleExportOp`](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R224-R281): Activates Castle export options.
  - [`RKX3DCastleSelExportOp`](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R224-R281): Activates Castle selected export options.

* Registered new commands in the plugin initialization and deregistration:
  - Registered `RKX3DCastleProject`, `RKX3DCastleExportOp`, and `RKX3DCastleSelExportOp` in `initializePlugin`.
  - Deregistered the new commands in `uninitializePlugin`.

### Menu Enhancements:

* Introduced new menu items in Maya's File menu for RawKee X3D export options:
  - Added menu items for exporting all, exporting selected, and setting Castle Project.

### Refactoring and Improvements:

* Modified the `processMayaMesh` method to use a boolean flag for `getConnectedSetsAndMembers` instead of an integer.
* Updated the plugin initialization message for better readability.
* Imported `MFn` from `maya.api.OpenMaya` in `RKOrganizer.py` for better code clarity.