### PR TITLE
Changes to Readme that let people know where they can find tutorials …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# RawKee Python - X3D Plugin 2.0.0 for Maya 2025+
+# RawKee Python Edition - X3D Plugin 2.X.X for Maya 2025+
 
 For the latest version of the RawKee Python X3D Plugin, visit the [GitHub repository](https://github.com/und-dream-lab/rawkee).
 
 For C++ versions of the plugin (1.2.0) supporting Maya 2019 - Maya 2024, please refer to the [GitHub page](https://github.com/und-dream-lab/rawkee/tree/v1.2.0).
 
 For C++ versions of the plugin (1.1.0) supporting Maya 6.0 - Maya 2008, please refer to the [SourceForge page](https://sourceforge.net/projects/rawkee/).
+
+Text-based Tutorials for the RawKee C++ Edition (versions 1.1.0 and 1.2.0) can be found at the Internet Wayback Machine.
+[IWM - Old Tutorials for RawKee 1.1.0 - 1.2.0](https://web.archive.org/web/20100105142454/http://rawkee.sourceforge.net/tutorials/)
 
 ## Usage of 'pip' with 'mayapy' requires installation of 'pip'.
 1. Download the 'get-pip.py' installer file. More information about this can be found here:


### PR DESCRIPTION
This pull request includes changes to the `README.md` file to update the versioning and links for the RawKee Python Edition X3D Plugin, as well as adding a new resource link for text-based tutorials.

The most important changes include:

Updates to versioning and naming:
* Updated the plugin name from "RawKee Python - X3D Plugin 2.0.0" to "RawKee Python Edition - X3D Plugin 2.X.X" to accommodate future versions.

Additional resources:
* Added a link to text-based tutorials for the RawKee C++ Edition (versions 1.1.0 and 1.2.0) available on the Internet Wayback Machine.…for the older versions of RawKee.