### PR TITLE
Completed texture conversion methods, DataURI methods, Procedural/Lay…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Some of the packages listed may require a pip install regarless of what the list
 - base64
 - mimetypes
 - ctypes
+- ntpath
 
 <!--
 ### Steps:

--- a/mel/x3d.mel
+++ b/mel/x3d.mel
@@ -296,6 +296,12 @@ global proc setDefRKOptVars()
 		optionVar -iv rkNormalOpts 0;
 	}
 
+	if(`optionVar -exists "rkFrontLoadExt"`){
+	}else{
+    //bool
+		optionVar -iv rkFrontLoadExt 0;
+	}
+
 	if(`optionVar -exists "rkExportMode"`){
 	}else{
     //bool

--- a/rawkee/RKFOptsDialog.py
+++ b/rawkee/RKFOptsDialog.py
@@ -224,6 +224,9 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkDefTexHeight    = cmds.optionVar( q='rkDefTexHeight'   )
         self.rkColorOpts       = cmds.optionVar( q='rkColorOpts'      )
         self.rkNormalOpts      = cmds.optionVar( q='rkNormalOpts'     )
+        
+        self.rkFrontLoadExt    = cmds.optionVar( q='rkFrontLoadExt'   )
+        
         self.rkExportMode      = cmds.optionVar( q='rkExportMode'     )
         
         self.rkCreaseAngle     = cmds.optionVar( q='rkCreaseAngle'    )
@@ -447,6 +450,25 @@ class RKFOptsDialog(QtWidgets.QDialog):
         layoutFourC.addWidget(self.movieURICheckBox)
         layoutFourC.addWidget(self.audioURICheckBox)
         layoutFourC.addStretch()
+        
+        # Option Four D
+        layoutFourD = QtWidgets.QHBoxLayout()
+        spacer4D = QtWidgets.QLabel(" ")
+        spacer4D.setAlignment(QtCore.Qt.AlignRight)
+        spacer4D.setFixedWidth(150)
+        spacer4D.setObjectName("RKOptPanel")
+
+        self.frontLoadURICheckBox = QtWidgets.QCheckBox("Front Load External Content")
+        self.frontLoadURICheckBox.setObjectName("RKOptPanel")
+        ###############################################################
+        # Set URL field value of node to a DataURI
+        self.frontLoadURICheckBox.setChecked(self.rkFrontLoadExt)
+        # Add change method here.
+        
+        layoutFourD.addWidget(spacer4D)
+        layoutFourD.addWidget(self.frontLoadURICheckBox)
+        layoutFourD.addStretch()
+        
         
         # Option Five
         layoutFive = QtWidgets.QHBoxLayout()
@@ -756,13 +778,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         
         # Option Sixteen
         layoutSixteen = QtWidgets.QHBoxLayout()
-        self.normalLabel = QtWidgets.QLabel("     Normal Options:")
+        self.normalLabel = QtWidgets.QLabel("Mesh Based Normal Options:")
         self.normalLabel.setAlignment(QtCore.Qt.AlignRight)
         self.normalLabel.setFixedWidth(250)
         self.normalLabel.setObjectName("RKOptPanel")
         
         self.normalOptions = QtWidgets.QComboBox()
-        self.normalOptions.addItems(["Map + Crease Angle + Per Vertex", "Map + Crease Angle", "Map + Per Vertex", "Map", "Crease Angle + Per Vertex", "Crease Angle", "Per Vertex"])
+        self.normalOptions.addItems(["Use Default X3D Field Values", "Use Per Vertex Info and Set Crease Angle", "Use Per Polygon Info and Set Crease Angle", "Only Set Crease Angle", "Use Only Per Vertex Info", "Use Only Per Polygon Info"])
         self.normalOptions.setFixedWidth(250)
         ###############################################################
         # Set the type of X3D Normal information exported by RawKee
@@ -803,13 +825,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         
         # Option Sixteen
         layoutSeventeen = QtWidgets.QHBoxLayout()
-        self.colorLabel = QtWidgets.QLabel("     Color Options:")
+        self.colorLabel = QtWidgets.QLabel("Mesh Color Per Vertex Options:")
         self.colorLabel.setAlignment(QtCore.Qt.AlignRight)
         self.colorLabel.setFixedWidth(250)
         self.colorLabel.setObjectName("RKOptPanel")
         
         self.colorOptions = QtWidgets.QComboBox()
-        self.colorOptions.addItems(["Textures + Per Vertex", "Textures", "Per Vertex"])
+        self.colorOptions.addItems(["Use Default X3D Field Values", "Color Node for CP-Vertex", "ColorRGBA Node for CP-Vertex", "Color Node for CP-Face", "ColorRGBA Node for CP-Face"])
         self.colorOptions.setFixedWidth(250)
         ###############################################################
         # Set the type of X3D Color information exported by RawKee
@@ -872,6 +894,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
         layout.addLayout(layoutFour)
         layout.addLayout(layoutFourB)
         layout.addLayout(layoutFourC)
+        layout.addLayout(layoutFourD)
         layout.addLayout(layoutSix)
         
         layout.addLayout(convLayout)
@@ -1012,7 +1035,9 @@ class RKFOptsDialog(QtWidgets.QDialog):
         cmds.optionVar( iv=('rkColorOpts',       self.colorOptions.currentIndex()           ))
         cmds.optionVar( iv=('rkNormalOpts',      self.normalOptions.currentIndex()          ))
         
-        cmds.optionVar( fv=('rkCreaseAngle',     float(self.creaseAngle.text())))
+        cmds.optionVar( iv=('rkFrontLoadExt',    self.frontLoadURICheckBox.isChecked()      ))
+        
+        cmds.optionVar( fv=('rkCreaseAngle',     float(self.creaseAngle.text())             ))
         
     def exportX3D(self):
         #print("X3D Exported!") TODO

--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -150,13 +150,20 @@ class RKIO():
         self.x3dVersion  = "4.0"
         
         
-        self.comments = []
-        self.commentNames = []
+        self.comments      = []
+        self.commentNames  = []
         self.additionalComps = []
         self.additionalCompsLevels = []
-        self.ignoredNodes = []
+        self.ignoredNodes  = []
         self.haveBeenNodes = []
-        self.generatedX3D = []
+        self.generatedX3D  = []
+        
+        # Thought this was needed, but the 'processForGeometry' method already has access to the 
+        # associated shader engine, regardless of whether the shaderEngine has already been processed
+        # as an Appearance node. There is no need to store this information separately
+        #self.shaderNames   = []
+        #self.texTransLists = []
+
         
         self.fullPath = ""
         
@@ -447,6 +454,13 @@ class RKIO():
         self.ignoredNodes.clear()
         self.haveBeenNodes.clear()
         self.generatedX3D.clear()
+
+        # Thought this was needed, but the 'processForGeometry' method already has access to the 
+        # associated shader engine, regardless of whether the shaderEngine has already been processed
+        # as an Appearance node. There is no need to store this information separately
+        #self.shaderNames.clear()
+        #self.texTransLists.clear()
+
              
     '''
         This method checks the List that holds the names
@@ -477,16 +491,33 @@ class RKIO():
         in this List
     '''
     def checkIfHasBeen(self, nodeName):
-        hasBeen = False
+        
+        for aName in self.haveBeenNodes:
+            if nodeName == aName:
+                return True
+        '''        
         hbLength = len(self.haveBeenNodes)
         i = 0
 
         while i < hbLength and hasBeen == False:
             if nodeName == self.haveBeenNodes[i]:
-                hasBeen = True
+                return True
             i = i + 1
-            
-        return hasBeen
+        ''' 
+        return False
+    
+    # Thought this was needed, but the 'processForGeometry' method already has access to the 
+    # associated shader engine, regardless of whether the shaderEngine has already been processed
+    # as an Appearance node. There is no need to store this information separately
+    #def trackTextureTransforms(self, shaderName, texTransList):
+    #    self.shaderNames.append(shaderName)
+    #    self.texTransLists.append(texTransList)
+        
+    #def getTexTransList(self, shaderName):
+    #    for idx in range(len(self.shaderNames)):
+    #        if shaderName == self.shaderNames[idx]:
+    #            return self.texTransLists[idx]
+    #    return None
     
     def useDecl(self, x3dNode, nodeName, x3dParentNode, x3dFieldName):
         x3dNode.USE = nodeName

--- a/rawkee/RKInterfaces.py
+++ b/rawkee/RKInterfaces.py
@@ -21,6 +21,8 @@ import PIL as pil
 
 import maya.api.OpenMaya as aom
 
+import ntpath
+
 #Python implementation of C++ web3dExportMethods
 
 X3D_TRANS:     Final[str] = "transform"
@@ -318,21 +320,22 @@ class RKInterfaces():
                 media.filter('scale', nW, nH).output(outpath, vcodec='mpeg4',      acodec='alac'      ).run()
             elif newFormat == "OGG":
                 media.filter('scale', nW, nH).output(outPath, vcodec='libtheora',  acodec='libvorbis' ).run()
-            elif newFormat == "WebM":
+            elif newFormat == "WEBM":
                 media.filter('scale', nW, nH).output(outPath, vcodec='libvpx-vp9', acodec='libopus'   ).run()
             elif newFormat == "AVI":
                 media.filter('scale', nW, nH).output(outPath, vcodec='libxvid',    acodec='pcm_s16le' ).run()
                 
         except:
-            return False
+            pass
+            #return False
             
-        return True
+        #return True
 
     
-    def image2pixel(self, fileNode):
+    def image2pixel(self, fileNodeObj):
         pixelData = ()
         
-        fImage = aom.MImage.readFromTextureNode(fileNode)
+        fImage = aom.MImage.readFromTextureNode(fileNodeObj)
         w, h = fImage.getSize()
 
         rkAdjTexSize   = cmds.optionVar( q='rkAdjTexSize'  )
@@ -383,7 +386,22 @@ class RKInterfaces():
                 
         return dataURI
 
-
+    def copyFile(self, inPath, outPath):
+        try:
+            with open(inPath, 'rb') as inFile, open(outPath, 'wb') as outFile:
+                while True:
+                    chunk = inFile.read(4096)
+                    if not chunk:
+                        break
+                    outFile.write(chunk)
+        except FileNotFoundError:
+            print("Input File not Found.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+        
+    def getFileName(self, inPath):
+        head, tail = ntpath.split(inPath)
+        return tail
 
 
 

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -408,7 +408,7 @@ class RKWeb3D():
 
 
     def setMyStyleSheet(self, qssBasePath):
-        print("Loading Qt Style Sheet and applying it to Maya UI. Please be patient, this applicaiton may take 2-3 seconds.")
+        print("Loading Qt Style Sheet and applying it to Maya UI. Please be patient, this applicaiton may take 2-3 seconds.", end="")
         stylesheet_filename = qssBasePath + "/auxilary/rkNodeStyle.qss"
         
         file = QtCore.QFile(stylesheet_filename)
@@ -416,6 +416,8 @@ class RKWeb3D():
         stylesheet = file.readAll()
         
         QtWidgets.QApplication.instance().setStyleSheet(str(stylesheet, encoding='utf-8'))
+        print("")
+        print("Qt Style Sheet Applied", end="")
 
 
 


### PR DESCRIPTION
This pull request includes several changes to the `rawkee` package, focusing on adding new options, modifying existing options, and cleaning up the codebase. The most important changes include the addition of a new option for front loading external content, updates to normal and color options, and various code cleanups and enhancements.

### New Options and Features:

* Added a new option `rkFrontLoadExt` to the settings, including its initialization, loading, saving, and UI elements in `rawkee/RKFOptsDialog.py` and `mel/x3d.mel`. [[1]](diffhunk://#diff-b2e64a6d4ad054219e0e962388b9d801c9b5a9dfceef949d8e9f39d65fb1981fR299-R304) [[2]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57R227-R229) [[3]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57R454-R472) [[4]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57R897) [[5]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57R1038-R1039)
* Introduced a new method `copyFile` and `getFileName` in `rawkee/RKInterfaces.py` to handle file operations.

### Modifications to Existing Options:

* Updated the labels and items for normal and color options in `rawkee/RKFOptsDialog.py` to provide more descriptive choices. [[1]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57L759-R787) [[2]](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57L806-R834)

### Code Cleanups and Enhancements:

* Removed unnecessary commented-out code and added some comments explaining why certain code is not needed in `rawkee/RKIO.py`. [[1]](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957R161-R167) [[2]](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957R458-R464) [[3]](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957L480-R520)
* Changed the print statement in `rawkee/RKWeb3D.py` to avoid creating a new line and added a completion message.

### Minor Changes:

* Added `ntpath` to the imports in `rawkee/RKInterfaces.py` and `README.md`. [[1]](diffhunk://#diff-659c9f76209611fc74f2c4136397e6ebf35072cb540a3f682946ff4564df7eedR24-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38)
* Modified the movie format conversion method to handle "WEBM" format and commented out the return statements in `rawkee/RKInterfaces.py`.…ered Texture export methods, and updated geometry related export functions for coordinates, colors, and normals.