### PR TITLE
Updated the ReadMe to reflect additional import json requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Some of the packages listed may require a pip install regarless of what the list
 - mimetypes
 - ctypes
 - ntpath
+- json 
 
 <!--
 ### Steps:


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change adds `json` to the list of packages that may require a pip install.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39): Added `json` to the list of packages that may require a pip install.