### PR TITLE
Completed basic mesh export methods. Successfully tested with complex…

### DIFF
--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -526,7 +526,8 @@ class RKIO():
         if isinstance(nodeField, list):
             nodeField.append(x3dNode)
         else:
-            nodeField = x3dNode
+            setattr(x3dParentNode, x3dFieldName, x3dNode)
+#            nodeField = x3dNode
             
     def createNodeFromString(self, x3dType):
         x3dNodeMapping = {


### PR DESCRIPTION
This pull request includes a small but significant change to the `useDecl` method in the `rawkee/RKIO.py` file. The change ensures that the `x3dNode` is correctly set as an attribute of `x3dParentNode` when `nodeField` is not a list.

* [`rawkee/RKIO.py`](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957L529-R530): Modified the `useDecl` method to use `setattr` to set `x3dNode` as an attribute of `x3dParentNode` instead of directly assigning it to `nodeField`.… mesh of water pump bottom.