### PR TITLE
Fixed bug with Normal node export. And added a print statement giving…

### DIFF
--- a/rawkee/RKFOptsDialog.py
+++ b/rawkee/RKFOptsDialog.py
@@ -986,8 +986,8 @@ class RKFOptsDialog(QtWidgets.QDialog):
     
     def saveOptionsExportX3D(self):
         self.saveOptions()
-        self.exportX3D()
         self.close()
+        self.exportX3D()
         
     def saveOptions(self):
         #print("Options Saved!")
@@ -1041,8 +1041,11 @@ class RKFOptsDialog(QtWidgets.QDialog):
         
     def exportX3D(self):
         #print("X3D Exported!") TODO
-        #rkX3DExport
-        #rkX3DSelExport
+        if self.rkExportMode == 0:
+            if self.dialogTitle == "X3D Export Options":
+                cmds.rkX3DExport()
+            else:
+                cmds.rkX3DExportOp()
         #rawkeeCASExport - TODO - at least stub it
         #rawkeeCASSelExport - TODO - at least stub it
         pass

--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -184,14 +184,28 @@ class RKIO():
         print(self.fullPath)
         print(self.exEncoding)
         
-        if   self.exEncoding == X3DXENC:
-            print(x3dDoc.XML())
-        elif self.exEncoding == X3DVENC:
-            print(x3dDoc.VRML())
-        elif self.exEncoding == X3DJENC:
-            print(json.dumps(xmltodict.parse(x3dDoc.XML()), indent=4))
+        with open(fullPath, "w") as self.exFile:
+            if   self.exEncoding == "x3d":
+                self.exFile.write(x3dDoc.XML())
+                
+            elif self.exEncoding == "x3dv":
+                self.exFile.write(x3dDoc.VRML())
+                
+            elif self.exEncoding == "x3dj":
+                self.exFile.write(json.dumps(xmltodict.parse(x3dDoc.XML()), indent=4))
+                
+            elif self.exEncoding == "json":
+                self.exFile.write(json.dumps(xmltodict.parse(x3dDoc.XML()), indent=4))
+                
+            elif self.exEncoding == "html":
+                htmlHeader  = '<html>\n\t<head>\n'
+                htmlHeader += '\t\t<meta charset="utf-8">\n\t\t<script src="x3dom-1.8.3/x3dom-full.js"></script>\n'
+                htmlHeader += '\t\t<link rel="stylesheet" href="x3dom-1.8.3/x3dom.css">\n\t</head>\n\t<body>\n'
+                htmlHeader += '\t\t<div style="width: 600px; height: 600px;">\n'
+                self.exFile.write(htmlHeader)
+                self.exFile.write(x3dDoc.HTML5())
+                htmlFooder = "\n\t</body>\n</html>"
 
-        #with open(fullPath, "w") as self.exFile:
         #    self.startDocument()
 
     def profileDecl(self):

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -70,7 +70,7 @@ class RKWeb3D():
         self.fullPath = ""
         self.selectedFilter = ""
         #                       self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D Binary (*.x3db);;X3D Enhanced Binary (*.x3de);;X3D JSON (*.x3dj);;X3D JSON (*.json);;VRML97 (*.wrl);;Web3D Files (*.x3d *.x3db *.x3de *.x3dj *.x3dv *.json *.wrl)"
-        self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;VRML 97 (*.wrl);;X3D JSON (*.x3dj);;X3D JSON (*.json);;Web3D Files (*.x3d *.x3dv *.wrl *.x3dj *.json)"
+        self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D JSON (*.x3dj);;X3D JSON (*.json);;X3D HTML5 (*.html);;Web3D Files (*.x3d *.x3dv *.x3dj *.json *.html)"
         
         # Setup the main 'RawKee X3D' plugin menu
         self.rkMenuName ="rawkee_menu"
@@ -260,10 +260,15 @@ class RKWeb3D():
             
             # Write the X3D data to a file.
             exEncoding     = "x3d"
-            if   self.selectedFilter == "X3D Classic (*.x3dv)":
+            fext = os.path.splitext(self.fullPath)[1]
+            if   fext == ".x3dv":
                 exEncoding = "x3dv"
-            elif self.selectedFilter == "X3D JSON (*.x3dj)"     or self.selectedFilter == "X3D JSON (*.json)":
+            elif fext == ".x3dj":
                 exEncoding = "x3dj"
+            elif fext == ".json":
+                exEncoding = "json"
+            elif fext == ".html":
+                exEncoding = "html"
 
             rko.rkio.x3d2disk(x3dDoc, self.fullPath, exEncoding)
             


### PR DESCRIPTION
This pull request includes multiple changes across several files in the `rawkee` project, focusing on improving the export functionality, refining node processing, and adding support for new file formats.

### Export Functionality Enhancements:

* [`rawkee/RKIO.py`](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957L187-L194): Enhanced the `x3d2disk` method to support additional export formats such as JSON and HTML. This includes writing appropriate headers and footers for HTML files.

### Node Processing Improvements:

* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR914-R971): Added detailed comments and improved the logic in `processBasicNodeAddition` to handle DEF/USE attributes more effectively.
* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2067-R2103): Refined the `processForGeometry` method to handle normal options correctly and removed deprecated texture coordinate processing. [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2067-R2103) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2077-L2084)
* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2137-R2164): Updated the `processForColorNode` and `processForNormalNode` methods to use lists for indexing and added detailed logging for normal generation. [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2137-R2164) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2197-R2254)

### File Format Support:

* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL73-R73): Updated the file filters to include support for HTML5 and adjusted the export function to determine encoding based on file extension. [[1]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL73-R73) [[2]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL263-R271)

### Bug Fixes:

* [`rawkee/RKFOptsDialog.py`](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57L989-R990): Fixed the order of operations in `saveOptionsExportX3D` to ensure options are saved before exporting.
* [`rawkee/RKFOptsDialog.py`](diffhunk://#diff-8e26261e7b640ee262683a0d70b30568c638aa641d0606840147f734f08fbf57L1044-R1048): Corrected the `exportX3D` method to handle different export modes based on dialog title.… user feedback on long normal generation times.