### PR TITLE
Added non-standard CommonSurfaceShader node that is not part of the X…

### DIFF
--- a/mel/x3d.mel
+++ b/mel/x3d.mel
@@ -286,16 +286,19 @@ global proc setDefRKOptVars()
 	
 	if(`optionVar -exists "rkColorOpts"`){
 	}else{
-    //bool
 		optionVar -iv rkColorOpts 0;
 	}
 
 	if(`optionVar -exists "rkNormalOpts"`){
 	}else{
-    //bool
 		optionVar -iv rkNormalOpts 0;
 	}
-
+    
+	if(`optionVar -exists "rkHtmlShaderOpts"`){
+	}else{
+		optionVar -iv rkHtmlShaderOpts 0;
+	}
+    
 	if(`optionVar -exists "rkFrontLoadExt"`){
 	}else{
     //bool

--- a/rawkee/RKFOptsDialog.py
+++ b/rawkee/RKFOptsDialog.py
@@ -224,6 +224,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkDefTexHeight    = cmds.optionVar( q='rkDefTexHeight'   )
         self.rkColorOpts       = cmds.optionVar( q='rkColorOpts'      )
         self.rkNormalOpts      = cmds.optionVar( q='rkNormalOpts'     )
+        self.rkHtmlShaderOpts  = cmds.optionVar( q='rkHtmlShaderOpts' )
         
         self.rkFrontLoadExt    = cmds.optionVar( q='rkFrontLoadExt'   )
         
@@ -823,7 +824,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
         layoutSixteen.addStretch()
         
         
-        # Option Sixteen
+        # Option Seventeen
         layoutSeventeen = QtWidgets.QHBoxLayout()
         self.colorLabel = QtWidgets.QLabel("Mesh Color Per Vertex Options:")
         self.colorLabel.setAlignment(QtCore.Qt.AlignRight)
@@ -843,24 +844,65 @@ class RKFOptsDialog(QtWidgets.QDialog):
         layoutSeventeen.addWidget(self.colorOptions)
         layoutSeventeen.addStretch()
         
+        # Option Eighteen
+        layoutEighteen = QtWidgets.QHBoxLayout()
+        self.matLabel  = QtWidgets.QLabel("Maya Shader Options:")
+        self.matSuffix = QtWidgets.QLabel("(HTML Encoding Only)")
+        self.matLabel.setAlignment(QtCore.Qt.AlignRight)
+        self.matSuffix.setAlignment(QtCore.Qt.AlignLeft)
+        self.matLabel.setFixedWidth(250)
+        self.matSuffix.setFixedWidth(150)
+        self.matLabel.setObjectName("RKOptPanel")
+        self.matSuffix.setObjectName("RKOptPanel")
+        
+        self.matOptions = QtWidgets.QComboBox()
+        self.matOptions.addItems(["Export as CommonSurfaceShader", "Export as Material (Old School)", "Export as Material (X3D 4.0)"])
+        self.matOptions.setFixedWidth(250)
+        ##############################################################
+        # For HTML export only (aka X3DOM) Set the how basic Maya Phong, PhongE, Blinn, and Lambert shaders will exported.
+        # Common     - These shaders will be exported as an extended X3DOM node called a CommonSurfaceShader per the example found
+        # Surface      on the X3DOM Documentation Site - https://doc.x3dom.org/tutorials/lighting/commonSurfaceShaderNode/index.html
+        # Shader       Only extures identified from examing upstream connections to the shader attributes of 'color', 'specularColor', 
+        #              'reflectedColor', and 'normalCamera' will be exported to the following corresponding CommonSurfaceShader fields
+        #              of 'diffuseTexture', specularTexture', 'shininessTexture', and 'normalTexture'. All other attributes with 
+        #              upstream connections to textures will be ignored. All other non-texture attributes will be exported as appropriate
+        #
+        # Old School - The only texture to be exported, will be the one that is connected to the 'color' attribute. This 
+        #              texture will be the added to the 'texture' field of an Appearance node. The only other attributes 
+        #              values that will be exported will be ones that do not have textures connected to them. These attribute 
+        #              values will be exported as fields of a Material node from a spec before texture fields were added to the
+        #              Material node.
+        #
+        # Material   - This is included for future spec compatibility, but is not currently recommended for use as X3DOM does not support
+        # (X3D 4.0)    it. Textures will be exported in the same manner as they are for XML, VRML, and JSON encodings.
+        # 
+        self.matOptions.setCurrentIndex(self.rkHtmlShaderOpts)
+        self.matOptions.setObjectName("RKOptPanel")
+        # Add change method here
+        
+        layoutEighteen.addWidget(self.matLabel)
+        layoutEighteen.addWidget(self.matOptions)
+        layoutEighteen.addWidget(self.matSuffix)
+        layoutEighteen.addStretch()
+        
         
         ##### Setting up the main layout #####
 
         # Section Header
-        textureSection = QtWidgets.QLabel("Texture Options")
-        textureSection.setObjectName("RKOptPanel")
-
         generalSection = QtWidgets.QLabel("Media & Node Options")
         generalSection.setObjectName("RKOptPanel")
+
+        meshSection    = QtWidgets.QLabel("Mesh/Shape & Shader/Material Options")
+        meshSection.setObjectName("RKOptPanel")
+        
+        textureSection = QtWidgets.QLabel("Texture Options")
+        textureSection.setObjectName("RKOptPanel")
 
         pathLabelText  = "Domain & Path Options"
         if self.rkExportMode == 1:
             pathLabelText  = "Game Engine Path Options"
         pathSection    = QtWidgets.QLabel(pathLabelText)
         pathSection.setObjectName("RKOptPanel")
-        
-        meshSection    = QtWidgets.QLabel("Mesh & Shape Options")
-        meshSection.setObjectName("RKOptPanel")
         
         convLayout = QtWidgets.QHBoxLayout()
         spaceConv  = QtWidgets.QLabel(" ")
@@ -911,6 +953,8 @@ class RKFOptsDialog(QtWidgets.QDialog):
         layout.addWidget(meshSection)
         layout.addLayout(layoutSixteen)
         layout.addLayout(layoutSeventeen)
+        #if self.rkExportMode == 0:
+        #    layout.addLayout(layoutEighteen)
 
         layout.addWidget(separator2)
 
@@ -1034,6 +1078,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
         
         cmds.optionVar( iv=('rkColorOpts',       self.colorOptions.currentIndex()           ))
         cmds.optionVar( iv=('rkNormalOpts',      self.normalOptions.currentIndex()          ))
+        cmds.optionVar( iv=('rkHtmlShaderOpts',  self.matOptions.currentIndex()             ))
         
         cmds.optionVar( iv=('rkFrontLoadExt',    self.frontLoadURICheckBox.isChecked()      ))
         

--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -19,6 +19,7 @@ import xmltodict
 import json
 import io
 from x3d import *                                    ###
+#from rawkee.RKPseudoNode import *                    ###
 ########################################################
 
 

--- a/rawkee/RKPseudoNode.py
+++ b/rawkee/RKPseudoNode.py
@@ -1,0 +1,40 @@
+import sys
+
+class CommonSurfaceShader():
+    def __init__(self):                                     # X3D 3.0 Material Node             # X3D 4.0 Material Node
+        
+        self.DEF                          = ''
+        self.USE                          = ''
+        self._RK__containerField          = ''
+        self.alphaFactor                  = 1.0             # transparency     0.0              # transparency            0.0           # transparency = 1 - alphaFactor;
+        self.alphaTexture                 = None            # -----------NA------------         # -----------NA------------
+        self.ambientFactor                = (0.2, 0.2, 0.2) # ambientIntensity 0.2              # ambientIntensity        0.2
+        self.ambientTexture               = None            # -----------NA------------         # ambientTexture          None
+        self.ambientTextureCoordinateId   = 0               # -----------NA------------         # ambientTextureMapping   ''
+        self.diffuseFactor                = (0.8, 0.8, 0.8) # diffuseColor     0.8 0.8 0.8      # diffuseColor            0.8 0.8 0.8
+        self.diffuseTexture               = None            # -----------NA------------         # diffuseTexture          None
+        self.diffuseTextureCoordinateId   = 0               # -----------NA------------         # diffuseTextureMapping   ''
+        self.emissiveFactor               = (0.0, 0.0, 0.0) # emissiveColor    0.0 0.0 0.0      # emissiveColor           0.0 0.0 0.0
+        self.emissiveTexture              = None            # -----------NA------------         # emissiveTexture         None
+        self.emissiveTextureCoordinateId  = 0               # -----------NA------------         # emissiveTextureMapping  ''
+        self.metadata                     = None            # metadata         None             # metadata                None
+        self.normalScale                  = (2.0, 2.0, 2.0) # -----------NA------------         # normalScale             1.0
+        self.normalTexture                = None            # -----------NA------------         # normalTexture           None
+        self.normalTextureCoordinateId    = 0               # -----------NA------------         # normalTextureMapping    ''
+        # -----------NA------------                         # -----------NA------------         # occlusionStrength       1.0
+        # -----------NA------------                         # -----------NA------------         # occlusionTexture        None
+        # -----------NA------------                         # -----------NA------------         # occulsionTextureMapping ''
+        self.shininessFactor              = 0.2             # shininess        0.2              # shininess               0.2
+        self.shininessTexture             = None            # -----------NA------------         # shininessTexture        None
+        self.shininessTextureCoordianteId = 0               # -----------NA------------         # shininessTextureMapping ''
+        self.specularFactor               = (0.0, 0.0, 0.0) # specularColor    0.0 0.0 0.0      # specularColor           0.0 0.0 0.0
+        self.specularTexture              = None            # -----------NA------------         # specularTexture         None
+        self.specularTextureCoordianteId  = 0               # -----------NA------------         # specualrTextureMapping  ''
+        
+
+#Only for code development
+if __name__ == "__main__":
+    cssNode = CommonSurfaceShader()
+    print(vars(cssNode))
+
+        

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -261,9 +261,6 @@ class RKWeb3D():
             # Grab Transforms parented to the real root.
             parentDagPaths, topDagNodes = rko.getAllTopDagNodes()
             
-            # Traverse DAG and map node data to X3D
-            rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion, self.fullPath)
-            
             # Write the X3D data to a file.
             exEncoding     = "x3d"
             fext = os.path.splitext(self.fullPath)[1]
@@ -276,6 +273,10 @@ class RKWeb3D():
             elif fext == ".html":
                 exEncoding = "html"
 
+            # Traverse DAG and map node data to X3D
+            rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion, self.fullPath, exEncoding)
+
+            # Write X3D Scenegraph to Disk
             rko.rkio.x3d2disk(x3dDoc, self.fullPath, exEncoding)
             
             # Delete the RKOrganizer object.
@@ -367,9 +368,6 @@ class RKWeb3D():
             # Grab Transforms parented to the real root.
             parentDagPaths, topDagNodes = rko.getSelectedDagNodes()
             
-            # Traverse DAG and map node data to X3D
-            rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion)
-            
             # Write the X3D data to a file.
             exEncoding     = "x3d"
             fext = os.path.splitext(self.fullPath)[1]
@@ -382,6 +380,10 @@ class RKWeb3D():
             elif fext == ".html":
                 exEncoding = "html"
                 
+            # Traverse DAG and map node data to X3D
+            rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion, exEncoding)
+
+            # Write X3D Scenegraph to disk.
             rko.rkio.x3d2disk(x3dDoc, self.fullPath, exEncoding)
             
             # Delete the RKOrganizer object.


### PR DESCRIPTION
This pull request introduces changes to support HTML shader options in the RawKee plugin. The key changes involve adding new option variables, updating the user interface to include the new options, and modifying the export logic to handle HTML encoding for shaders.

### New Option Variables:
* Added `rkHtmlShaderOpts` option variable to `setDefRKOptVars` in `mel/x3d.mel`.
* Updated `loadOptionVars` in `rawkee/RKFOptsDialog.py` to load `rkHtmlShaderOpts`.
* Updated `saveOptions` in `rawkee/RKFOptsDialog.py` to save `rkHtmlShaderOpts`.

### User Interface Updates:
* Added new UI elements for HTML shader options in `buildX3DExportPanel` in `rawkee/RKFOptsDialog.py`.
* Updated the layout and section headers in `buildX3DExportPanel` to accommodate the new options.

### Export Logic Modifications:
* Modified `processForAppearance` in `rawkee/RKOrganizer.py` to handle HTML encoding for shaders, including setting appropriate fields and handling texture coordinates [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL1573-R1601) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL1602-R1630) [[3]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR1658-R1715) [[4]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR1724-R1727) [[5]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR1745-R1796) [[6]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eR1961).
* Added `exEncoding` parameter to `maya2x3d` in `rawkee/RKOrganizer.py` to specify the export encoding type.

### Miscellaneous:
* Included `rawkee/RKPseudoNode` import in `rawkee/RKOrganizer.py`.
* Removed commented-out import in `rawkee/RKIO.py`.…3D spec to better support output compatibility with X3DOM. This node is only used for HTML encoded export.