### PR TITLE
Eliminated unnecessary methods in RKOrganizer and fully expanded Phys…

### DIFF
--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -229,34 +229,7 @@ class RKWeb3D():
             # data in the maya scen to be 
             # copied into the X3D Document object
             rko = RKOrganizer.RKOrganizer()
-        
-            #########################################
-            # Rethink if we want this code here
-            # Commenting it out for now.
-            '''
-            # Setup Basic File Path Info
-            self.rko.fileName = self.fullPath
-            idx = self.rko.fileName.rfind("/")
-            self.rko.localPath = self.rko.fileName[:idx+1]
-            print(self.rko.localPath)
-            
-            
-            ###############################################
-            #x3dEO.setFileSax3dWriter(tempFile);
-            self.rko.rkio.fullPath = self.rko.fileName
-            
-            #x3dEO.setExportStyle(filter());
-            self.rko.setExportStyle(self.selectedFilter)
-            '''
-
-            ###############################################
-            # Commenting this out for now. But will 
-            # probably will still use it at some point,
-            # though it may be called from another lcoation
-            # in the code.
-            #############################
-            rko.organizeExport() # TODO - Required to keep the scene traversal from crashing, becauese the 'ignore' methods are called here.
-            #############################
+            rko.prepForSceneTraversal()
 
             # Grab Transforms parented to the real root.
             parentDagPaths, topDagNodes = rko.getAllTopDagNodes()
@@ -336,34 +309,7 @@ class RKWeb3D():
             # data in the maya scen to be 
             # copied into the X3D Document object
             rko = RKOrganizer.RKOrganizer()
-        
-            #########################################
-            # Rethink if we want this code here
-            # Commenting it out for now.
-            '''
-            # Setup Basic File Path Info
-            self.rko.fileName = self.fullPath
-            idx = self.rko.fileName.rfind("/")
-            self.rko.localPath = self.rko.fileName[:idx+1]
-            print(self.rko.localPath)
-            
-            
-            ###############################################
-            #x3dEO.setFileSax3dWriter(tempFile);
-            self.rko.rkio.fullPath = self.rko.fileName
-            
-            #x3dEO.setExportStyle(filter());
-            self.rko.setExportStyle(self.selectedFilter)
-            '''
-
-            ###############################################
-            # Commenting this out for now. But will 
-            # probably will still use it at some point,
-            # though it may be called from another lcoation
-            # in the code.
-            #############################
-            rko.organizeExport() # TODO - Required to keep the scene traversal from crashing, becauese the 'ignore' methods are called here.
-            #############################
+            rko.prepForSceneTraversal()
 
             # Grab Transforms parented to the real root.
             parentDagPaths, topDagNodes = rko.getSelectedDagNodes()


### PR DESCRIPTION
This pull request includes changes to the `rawkee/RKWeb3D.py` file to clean up and simplify the code by removing commented-out sections and replacing a method call with a more appropriate one. The most important changes are:

Code cleanup and simplification:

* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL232-R232): Removed large blocks of commented-out code in the `activateExportFunctions` method.
* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL339-R312): Removed large blocks of commented-out code in the `activateSelExportFunctions` method.

Method call updates:

* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL232-R232): Replaced the `rko.organizeExport()` call with `rko.prepForSceneTraversal()` in the `activateExportFunctions` method.
* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL339-R312): Replaced the `rko.organizeExport()` call with `rko.prepForSceneTraversal()` in the `activateSelExportFunctions` method.…icalMaterial export for aiStandardSurface, StandardSurface, usdPreviewSurface, and StringrayPBS shaders