### PR TITLE
Removed the need to have the user do a pip install of x3d.py. It was …

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Some tutorials for RawKee C++ Edition (v 1.1.0/1.2.0) can be found at the Intern
 
 ## Required Python Packages in addition to standard Maya Python API 1.0/2.0 packages (mayapy).
 Some of the packages listed may require a pip install regarless of what the list below explicitly states.
-- x3d           (pip install required)
 - pillow        (pip install required)
 - ffmpeg-python (pip install required)
 - nodejs-bin    (pip install required) -- Required by Sunrize Editor, Will be optional.

--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -18,7 +18,7 @@ from rawkee import RKSceneTraversal
 import xmltodict
 import json
 import io
-from x3d import *                                    ###
+from rawkee.x3d import *                                    ###
 #from rawkee.RKPseudoNode import *                    ###
 ########################################################
 

--- a/rawkee/RKSceneTraversal.py
+++ b/rawkee/RKSceneTraversal.py
@@ -1,7 +1,7 @@
 import sys
 import os
-import x3d
-from x3d import *
+import rawkee.x3d
+from rawkee.x3d import *
 from rawkee.RKPseudoNode import *
 from typing import Final
 

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -24,7 +24,7 @@ from rawkee.RKFOptsDialog import RKFOptsDialog
 
 #from rawkee.RKUtils import *
 
-import x3d              as rkx3d
+import rawkee.x3d              as rkx3d
 
 try:
     from PySide2           import QtCore

--- a/rawkee/RKXScene.py
+++ b/rawkee/RKXScene.py
@@ -1,5 +1,5 @@
 import sys
-import x3d as rkx
+import rawkee.x3d as rkx
 from rawkee.RKGraphics import RKGraphicsScene
 
 class RKXScene(rkx.Scene):# class X3D_Transform (aom.MPxNode, x3d.Transform):

--- a/rawkee/nodes/x3dSound.py
+++ b/rawkee/nodes/x3dSound.py
@@ -1,4 +1,4 @@
-import x3d
+import rawkee.x3d
 
 import maya.api.OpenMaya as aom
 import maya.api.OpenMayaUI as aomui


### PR DESCRIPTION
This pull request includes several changes to update the import paths for the `x3d` module in various files. The changes ensure that the module is imported from the `rawkee` package instead of directly. Additionally, an entry for the `x3d` package has been removed from the `README.md` file.

### Import Path Updates:
* [`rawkee/RKIO.py`](diffhunk://#diff-d69b859a03283b483005c189376362f7c44d1d386f2eec3262510f720e1ec957L21-R21): Changed import statement from `from x3d import *` to `from rawkee.x3d import *`.
* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L3-R4): Changed import statements from `import x3d` and `from x3d import *` to `import rawkee.x3d` and `from rawkee.x3d import *`.
* [`rawkee/RKWeb3D.py`](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL27-R27): Changed import statement from `import x3d as rkx3d` to `import rawkee.x3d as rkx3d`.
* [`rawkee/RKXScene.py`](diffhunk://#diff-c304453c245e33621b3d3cee4b0848610742684101df548e63969149aef7001bL2-R2): Changed import statement from `import x3d as rkx` to `import rawkee.x3d as rkx`.
* [`rawkee/nodes/x3dSound.py`](diffhunk://#diff-1c3aa85fb8a3ed135e5c40a1a5370383c86357fc694dd109faf6727649144f54L1-R1): Changed import statement from `import x3d` to `import rawkee.x3d`.

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23): Removed the `x3d` package from the list of required Python packages.…an old version. The latest version of x3d.py is included with the rawkee python files.