### PR TITLE
Removed custom _RK__mapping attribute from TexturTransform export bec…

### DIFF
--- a/rawkee/RKOrganizer.py
+++ b/rawkee/RKOrganizer.py
@@ -2233,7 +2233,7 @@ class RKOrganizer():
         # Set the 'mapping' field of TextureTransform
         try:
             tmVal = place2d.findPlug("x3dTextureMapping", False).asString()
-            x3dtt._RK__mapping = tmVal
+            x3dtt.mapping = tmVal
         except:
             print("x3dTextureMapping is not defined.")
 

--- a/rawkee/RKSceneTraversal.py
+++ b/rawkee/RKSceneTraversal.py
@@ -99,8 +99,8 @@ class RKSceneTraversal():
                     if   keyp[3] == "containerField" and value != "":
                         sFieldsList.append("_RK__containerField")
                         
-                    elif keyp[3] == "mapping" and value != "":
-                        sFieldsList.append("_RK__mapping")
+#                    elif keyp[3] == "mapping" and value != "":
+#                        sFieldsList.append("_RK__mapping")
                     
                 elif keyp[1] == nType:
                     if pastMeta == False:
@@ -224,9 +224,10 @@ class RKSceneTraversal():
         mnlLen = len(mNodeList)
         for fIdx in range(sflLen):
             tField = sFieldList[fIdx]
-            if   tField == "_RK__mapping":
-                tField  =  "mapping"
-            elif tField == "_RK__containerField":
+#            if   tField == "_RK__mapping":
+#                tField  =  "mapping"
+#            elif tField == "_RK__containerField":
+            if tField == "_RK__containerField":
                 tField  =  "containerField"
                 ####################################################
                 # 'containerField' does not get used in VRML export,
@@ -351,9 +352,10 @@ class RKSceneTraversal():
         mnlLen = len(mNodeList)
         for fIdx in range(sflLen):
             tField = sFieldList[fIdx]
-            if   tField == "_RK__mapping":
-                tField  =  "mapping"
-            elif tField == "_RK__containerField":
+#            if   tField == "_RK__mapping":
+#                tField  =  "mapping"
+#            elif tField == "_RK__containerField":
+            if tField == "_RK__containerField":
                 tField  =  "containerField"
                 ####################################################
                 # 'containerField' does not get used in JSON export,
@@ -489,9 +491,10 @@ class RKSceneTraversal():
         mainline = "<" + nType
         for field in sFieldList:
             tField = field
-            if   field == "_RK__mapping":
-                tField =  "mapping"
-            elif field == "_RK__containerField":
+#            if   field == "_RK__mapping":
+#                tField =  "mapping"
+#            elif field == "_RK__containerField":
+            if field == "_RK__containerField":
                 tField =  "containerField"
                 
                 # It may not be adventageous to always add the containerField
@@ -595,9 +598,10 @@ class RKSceneTraversal():
         mainline = "<" + nType
         for field in sFieldList:
             tField = field
-            if   field == "_RK__mapping":
-                tField =  "mapping"
-            elif field == "_RK__containerField":
+#            if   field == "_RK__mapping":
+#                tField =  "mapping"
+#            elif field == "_RK__containerField":
+            if field == "_RK__containerField":
                 tField =  "containerField"
                 
                 # It may not be adventageous to always add the containerField


### PR DESCRIPTION
This pull request includes changes to the `rawkee` package, specifically focusing on the handling of the `mapping` field in various methods. The changes primarily involve updating the way the `mapping` field is processed and removing its references where it is no longer needed.

### Updates to `mapping` field handling:

* [`rawkee/RKOrganizer.py`](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL2236-R2236): Updated the `setTextureTransformFields` method to set the `mapping` field directly instead of using a private attribute.

* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L102-R103): Commented out the handling of the `mapping` field in the `processNode` method.
* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L227-R230): Commented out the conversion of `_RK__mapping` to `mapping` in the `processNodeAsVRML` method.
* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L354-R358): Commented out the conversion of `_RK__mapping` to `mapping` in the `processNodeAsJSON` method.
* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L492-R497): Commented out the conversion of `_RK__mapping` to `mapping` in the `processNodeAsXML` method.
* [`rawkee/RKSceneTraversal.py`](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L598-R604): Commented out the conversion of `_RK__mapping` to `mapping` in the `processNodeAsHTML` method.…ause the latest version of x3d.py already has the mapping attribute.