### PR TITLE
Rewrote major parts of the processForAppearance method to accomodate …

### DIFF
--- a/rawkee/RKPseudoNode.py
+++ b/rawkee/RKPseudoNode.py
@@ -5,31 +5,97 @@ class CommonSurfaceShader():
         
         self.DEF                          = ''
         self.USE                          = ''
+        
         self._RK__containerField          = ''
+        
         self.alphaFactor                  = 1.0             # transparency     0.0              # transparency            0.0           # transparency = 1 - alphaFactor;
         self.alphaTexture                 = None            # -----------NA------------         # -----------NA------------
+        self.alphaTextureChannelMask      = 'a'
+        self.alphaTextureCoordinatesId    = 0
+        self.alphaTextureId               = -1
+        
         self.ambientFactor                = (0.2, 0.2, 0.2) # ambientIntensity 0.2              # ambientIntensity        0.2
         self.ambientTexture               = None            # -----------NA------------         # ambientTexture          None
-        self.ambientTextureCoordinateId   = 0               # -----------NA------------         # ambientTextureMapping   ''
+        self.ambientTextureChannelMask    = 'rgb'
+        self.ambientTextureCoordinatesId  = 0               # -----------NA------------         # ambientTextureMapping   ''
+        self.ambientTextureId             = -1
+        
+        self.binormalTextureCoordinatesId = -1
+        
+        self.diffuseDisplacementTexture   = None
+        
         self.diffuseFactor                = (0.8, 0.8, 0.8) # diffuseColor     0.8 0.8 0.8      # diffuseColor            0.8 0.8 0.8
         self.diffuseTexture               = None            # -----------NA------------         # diffuseTexture          None
-        self.diffuseTextureCoordinateId   = 0               # -----------NA------------         # diffuseTextureMapping   ''
+        self.diffuseTextureChannelMask    = 'rgb'
+        self.diffuseTextureCoordinatesId  = 0               # -----------NA------------         # diffuseTextureMapping   ''
+        self.diffuseTextureId             = -1
+        
+        self.displacementAxis             = 'y'
+        self.displacementFactor           = 255.0
+        self.displacementTexture          = None
+        self.displacementTextureCoordinatesId = 0
+        self.displacementTextureId        = 0
+        
         self.emissiveFactor               = (0.0, 0.0, 0.0) # emissiveColor    0.0 0.0 0.0      # emissiveColor           0.0 0.0 0.0
         self.emissiveTexture              = None            # -----------NA------------         # emissiveTexture         None
-        self.emissiveTextureCoordinateId  = 0               # -----------NA------------         # emissiveTextureMapping  ''
+        self.emissiveTextureChannelMask   = 'rgb'
+        self.emissiveTextureCoordinatesId = 0               # -----------NA------------         # emissiveTextureMapping  ''
+        self.emissiveTextureId            = -1
+        
+        self.environmentFactor            = (1.0, 1.0, 1.0)
+        self.environmentTexture           = None
+        self.environmentTextureChannelMask = 'rgb'
+        self.environmentTextureCoordinatesId = 0
+        self.environmentTextureId         = -1
+        
+        self.fresnelBlend                 = 0
+        
+        self.invertAlphaTexture           = False
+        
+        self.language                     = ''
+        
         self.metadata                     = None            # metadata         None             # metadata                None
+        
+        self.normalBias                   = (-1.0, -1.0, -1.0)
+        self.normalFormat                 = 'UNORM'
         self.normalScale                  = (2.0, 2.0, 2.0) # -----------NA------------         # normalScale             1.0
+        self.normalSpace                  = 'TANGENT'
         self.normalTexture                = None            # -----------NA------------         # normalTexture           None
-        self.normalTextureCoordinateId    = 0               # -----------NA------------         # normalTextureMapping    ''
+        self.normalTextureChannelMask     = 'rgb'
+        self.normalTextureCoordinatesId   = 0               # -----------NA------------         # normalTextureMapping    ''
+        self.normalTextureId              = -1
+        
+        self.reflectionFactor             = (0.0, 0.0, 0.0)
+        self.reflectionTexture            = None
+        self.reflectionTextureChannelMask = 'rgb'
+        self.reflectionTextureCoordinatesId = 0
+        self.reflectionTextureId          = -1
+        
+        self.relativeIndexOfRefraction    = 1
+        
         # -----------NA------------                         # -----------NA------------         # occlusionStrength       1.0
         # -----------NA------------                         # -----------NA------------         # occlusionTexture        None
         # -----------NA------------                         # -----------NA------------         # occulsionTextureMapping ''
+        
         self.shininessFactor              = 0.2             # shininess        0.2              # shininess               0.2
         self.shininessTexture             = None            # -----------NA------------         # shininessTexture        None
-        self.shininessTextureCoordianteId = 0               # -----------NA------------         # shininessTextureMapping ''
+        self.shininessTextureChannelMask  = 'a'
+        self.shininessTextureCoordiantesId = 0               # -----------NA------------         # shininessTextureMapping ''
+        self.shininessTextureId           = -1
+        
         self.specularFactor               = (0.0, 0.0, 0.0) # specularColor    0.0 0.0 0.0      # specularColor           0.0 0.0 0.0
         self.specularTexture              = None            # -----------NA------------         # specularTexture         None
-        self.specularTextureCoordianteId  = 0               # -----------NA------------         # specualrTextureMapping  ''
+        self.specularTextureChannelMask   = 'rgb'
+        self.specularTextureCoordiantesId = 0               # -----------NA------------         # specularTextureMapping  ''
+        self.specularTextureId            = -1
+        
+        self.tangentTextureCoordinatesId  = -1
+        
+        self.transmissionFactor           = (0.0, 0.0, 0.0)
+        self.transmissionTexture          = None
+        self.transmissionTextureChannelMask = 'rgb'
+        self.transmissionTextureCoordinatesId = 0
+        self.transmissionTextureId        = -1
         
 
 #Only for code development


### PR DESCRIPTION
This pull request includes significant updates to the `__init__` method of the `RKPseudoNode` class in the `rawkee/RKPseudoNode.py` file. The changes primarily focus on adding new texture-related attributes and updating existing ones to enhance the material node's capabilities.

Key changes include:

* **Texture Attributes Addition:**
  * Added new attributes for alpha, ambient, diffuse, emissive, environment, normal, reflection, shininess, specular, and transmission textures, including their respective channel masks, coordinates IDs, and texture IDs.

* **Displacement and Normal Enhancements:**
  * Introduced attributes for displacement axis, factor, texture, and normal bias, format, and space to provide more control over displacement and normal mapping.

* **Miscellaneous Additions:**
  * Added attributes for binormal texture coordinates, diffuse displacement texture, fresnel blend, invert alpha texture, language, reflection factor, relative index of refraction, and transmission factor.

These changes will enhance the material node's flexibility and support for various texture and mapping configurations.…both x3dom and standard X3D CommonSurfaceShader/PhysicalMaterial export. Probably needs more work.