### PR TITLE
Major fix for HAnim skin weight issues. Segment and Skin HAnim mostly…

### DIFF
--- a/rawkee/RKIO.py
+++ b/rawkee/RKIO.py
@@ -424,6 +424,21 @@ class RKIO():
         a value of True if a match for a node name is found
         in this List
     '''
+    
+    def getGeneratedX3D(self, namedDEF):
+        foundNode = None
+        
+        for xNode in self.generatedX3D:
+            try:
+                if xNode.DEF == namedDEF:
+                    foundNode = xNode
+                    break
+            except Exception as e:
+                #print(f"An error occurred: {e}. Skipping node...")
+                pass
+                
+        return foundNode
+    
     def checkIfHasBeen(self, nodeName):
         
         for aName in self.haveBeenNodes:


### PR DESCRIPTION
This pull request introduces significant updates to the `rawkee` package, primarily focusing on enhancing the handling of skinning and skeletal data in `RKOrganizer.py` and adding new utility methods in `RKIO.py`. The changes aim to improve the management of skin weights, streamline the processing of joints and meshes, and enhance error handling and debugging capabilities.

### New Utility Methods
* Added `getGeneratedX3D` in `RKIO.py` to retrieve X3D nodes by their `DEF` attribute, improving modularity and reusability.

### Enhancements to Skinning and Mesh Processing
* Introduced `processSkinWeights` and `collectSkinWeightsForMesh` in `RKOrganizer.py` to centralize and refine the collection and assignment of skin weights. These methods improve the accuracy of weight mapping and add detailed debugging output. [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL890-R1022) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL977-R1173)
* Added `getIntermediateMesh` in `RKOrganizer.py` to retrieve intermediate mesh objects, ensuring correct mesh data is used for skinning operations.

### Improvements to Joint Processing
* Enhanced `processHAnimJoint` in `RKOrganizer.py` to include joint binding positions, rotations, and scales. This provides more detailed and accurate representation of joint transformations.
* Updated the method signature of `processHAnimJoint` to include a `jOffset` parameter, enabling better handling of joint offsets during hierarchy traversal.

### Refactoring and Debugging
* Refactored `getSkinCoordinateNode` and `getSkinNormalNode` in `RKOrganizer.py` to include additional checks and debugging output, improving reliability during skin coordinate and normal node generation. [[1]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL953-R1096) [[2]](diffhunk://#diff-47599e53afe7b9feffd85bf34694d94c0d9b7063ff3060dbc58026261d14370eL977-R1173)
* Added `getSkinClusterFromMesh` in `RKOrganizer.py` to retrieve specific skin clusters associated with a mesh, enhancing debugging and error handling for skinning operations.

These changes collectively enhance the robustness and maintainability of the codebase while improving the handling of complex skinning and skeletal data.… working except for rigs complex SkinCluster Dependency Graphs.