### PR TITLE
Fixed a bug that caused x3dv and x3dj exports to fail when exporting …

### DIFF
--- a/rawkee/RKSceneTraversal.py
+++ b/rawkee/RKSceneTraversal.py
@@ -228,10 +228,15 @@ class RKSceneTraversal():
     def processNodeAsVRML(self, nType, node, showCF, sFieldList, mFieldList, sNodeList, mNodeList, isMulti):
         mainline = ""
         
+        if nType == "ROUTE":
+            self.processROUTEAsVRML(node, sFieldList)
+            return
+            
         if isMulti == True:
             self.writeLine(     "DEF " + node.DEF + " " + nType + " {")
         else:
             self.writeRemaining("DEF " + node.DEF + " " + nType + " {")
+
         self.itabs()
         
         sflLen = len(sFieldList)
@@ -352,9 +357,17 @@ class RKSceneTraversal():
         self.writeLine("}")
 
 
+    def processROUTEAsVRML(self, node, sFieldList):
+        self.writeLine("ROUTE " + getattr(node, sFieldList[1]) + "." + getattr(node, sFieldList[0]) + " TO " + getattr(node, sFieldList[3]) + "." + getattr(node, sFieldList[2]))
+
 
     def processNodeAsJSON(self, nType, node, showCF, sFieldList, mFieldList, sNodeList, mNodeList, isMulti, addComma):
         mainline = ''
+
+        if nType == "ROUTE":
+            self.processROUTEAsJSON(node, sFieldList, isMulti, addComma)
+            return
+
         if isMulti == True:
             self.writeLine(     '{ "' + nType + '":')
         else:
@@ -368,8 +381,6 @@ class RKSceneTraversal():
         snlLen = len(sNodeList)  # snlLen
         mnlLen = len(mNodeList)  # mnlLen
         for fIdx in range(sflLen):
-            
-            
             tField = sFieldList[fIdx]
 
             if tField == "_RK__containerField":
@@ -515,6 +526,33 @@ class RKSceneTraversal():
         else:
             self.writeLine('}')
 
+
+    def processROUTEAsJSON(self, node, sFieldList, isMulti, addComma):# 
+        if isMulti == True:
+            self.writeLine(     '{ "ROUTE":')
+        else:
+            self.writeRemaining('{ "ROUTE":')
+        self.itabs()
+        self.writeLine('{')
+        self.itabs()
+
+        fromNode  = '"@' + sFieldList[1] + '": "' + getattr(node, sFieldList[1]) + '",'
+        fromField = '"@' + sFieldList[0] + '": "' + getattr(node, sFieldList[0]) + '",'
+        toNode    = '"@' + sFieldList[3] + '": "' + getattr(node, sFieldList[3]) + '",'
+        toField   = '"@' + sFieldList[2] + '": "' + getattr(node, sFieldList[2]) + '"'
+        self.writeLine(fromNode)
+        self.writeLine(fromField)
+        self.writeLine(toNode)
+        self.writeLine(toField)
+
+        self.dtabs()
+        self.writeLine('}')
+        self.dtabs()
+        #self.writePrefix('}')
+        if addComma == True:
+            self.writeLine('},')
+        else:
+            self.writeLine('}')
 
 
     def processNodeAsXML( self, nType, node, showCF, sFieldList, mFieldList, sNodeList, mNodeList):


### PR DESCRIPTION
This pull request adds explicit handling for `ROUTE` node types in the `RKSceneTraversal.py` file, ensuring that these nodes are properly processed and output in both VRML and JSON formats. The changes introduce specialized methods for formatting `ROUTE` nodes and update the main processing functions to delegate to these methods when appropriate.

**ROUTE node handling improvements:**

* Added a new method `processROUTEAsVRML` to output `ROUTE` nodes in VRML format, and updated `processNodeAsVRML` to delegate to this method when `nType` is `"ROUTE"`. [[1]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R231-R239) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R360-R370)
* Introduced `processROUTEAsJSON` for formatting `ROUTE` nodes in JSON, and modified `processNodeAsJSON` to use this method for `ROUTE` nodes. [[1]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R360-R370) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R530-R556)

These changes make the codebase more robust and maintainable by isolating the logic for handling `ROUTE` nodes and ensuring consistent output formats.…ROUTE information.