### PR TITLE
John Carlson found a bug where the character animation timer group was being exported to the skeleton field in the HAnimHumanoid node, but should be exported to the skin field. This has been fixed.

### DIFF
--- a/rawkee/RKOrganizer.py
+++ b/rawkee/RKOrganizer.py
@@ -1092,7 +1092,7 @@ class RKOrganizer():
             
 
     def processRKAnimPacks(self, dragPath, rkAPNodes, x3dHumanoid):
-        bna = self.processBasicNodeAddition(None, x3dHumanoid, "skeleton", "Group", x3dHumanoid.DEF + "_TimerGroup")
+        bna = self.processBasicNodeAddition(None, x3dHumanoid, "skin", "Group", x3dHumanoid.DEF + "_TimerGroup")
         if bna[0] == False:
             for apNode in rkAPNodes:
                 apType = cmds.getAttr(apNode.name() + ".mimickedType")


### PR DESCRIPTION
This pull request includes a targeted update to the animation pack processing logic in `rawkee/RKOrganizer.py`. The change modifies the node type used when adding a timer group to an X3D humanoid, which affects how animation packs are organized and associated with the humanoid.

Animation pack node type update:

* Changed the node type argument from `"skeleton"` to `"skin"` in the call to `processBasicNodeAddition`, which will now create a timer group under the `"skin"` node instead of `"skeleton"` for the X3D humanoid.…s being to the skeleton field in the HAnimHumanoid node, but should be exported to the skin field. This has been fixed.