### PR TITLE
Fixed erroneous interpolator key calculations that clipped animation …

### DIFF
--- a/rawkee/RKPseudoNode.py
+++ b/rawkee/RKPseudoNode.py
@@ -6,8 +6,6 @@ class CommonSurfaceShader():
         self.DEF                          = ''
         self.USE                          = ''
         
-        self._RK__containerField          = ''
-        
         self.alphaFactor                  = 1.0             # transparency     0.0              # transparency            0.0           # transparency = 1 - alphaFactor;
         self.alphaTexture                 = None            # -----------NA------------         # -----------NA------------
         self.alphaTextureChannelMask      = 'a'


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of the `containerField` attribute in the X3D export pipeline, refactors joint naming logic for HAnim nodes, and adds a utility for joint type mapping. The changes streamline how node relationships are encoded and exported across XML, HTML, and JSON formats, and enhance semantic clarity in joint naming for humanoid models.

### Export pipeline improvements (containerField handling):

* Refactored the export logic in `RKSceneTraversal.py` to pass the `containerField` as an explicit parameter (`cField`) instead of relying on the `_RK__containerField` attribute, ensuring accurate and consistent node relationship encoding for XML, HTML, and HTML exports. This affects methods like `processNode`, `processSortedNode`, `processUsed`, `processNodeAsXML`, and `processNodeAsHTML`. [[1]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L43-R48) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L169-R190) [[3]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L219-R210) [[4]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L558-R532) [[5]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R558-R561) [[6]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L653-R636) [[7]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R662-R665) [[8]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L757-R724)
* Removed `_RK__containerField` from node definitions, simplifying node data structures and eliminating redundant attribute checks during export. [[1]](diffhunk://#diff-ed6d2a5e30c2d880ae01bedc820a321b9aca14fbc0e364f63437549626661ab1L9-L10) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L98-L101) [[3]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L249-R238) [[4]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L386-R366)

### HAnim joint naming and type mapping:

* Refactored `processHAnimJoint` to construct joint names using side and type information, improving semantic clarity and supporting Level Of Articulation (LOA) conventions. Added logic to prepend side information (Center/Left/Right or l_/r_) and use either the `otherType` attribute or a mapped type string.
* Added a new utility method `getJointType` to map joint type values to descriptive string names, supporting the new joint naming logic.

### Interpolator data collection improvements:

* Improved calculation of key fractions and frame steps for interpolators in `collectInterpolatorData`, ensuring correct key placement and value collection for animation export.
* Added placeholder for future support of MFVec4f field animation in interpolators.

### Miscellaneous export and formatting changes:

* Updated XML and HTML export headers for standards compliance and added HTML DOCTYPE declaration. [[1]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L794-R757) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206R801) [[3]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L852-L854)
* Minor formatting and logic corrections in JSON export and node field handling. [[1]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L424-R395) [[2]](diffhunk://#diff-27556d8ead401a7dd2f9b2119d3019f873874ca3e7a5dcdea3b4d70a04883206L205-L209)

These changes collectively improve the reliability, maintainability, and semantic clarity of the X3D export and animation handling pipeline.…playback in browser and removed the need for the custom _RK_containerField attribute on the x3d.py nodes. Made changes regarding X3D doctypes.