### PR TITLE
RawKee Python Edition 2.0.0 release update. Includes revised shader a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
-# RawKee Python Edition (PE) - X3D Plugin 2.x.x for Maya 2025 and Beyond!
+# RawKee Python Edition (PE) - X3D Plugin 2.x.x for Maya 2023 and Beyond!
 
 This GitHub site supports the latest version of the RawKee X3D exporter plugin for Autodesk Maya. Now available as a Maya Python API 2.0 plugin. RawKee PE is compatible with all versions of Maya newer than Maya 2025 on Windows, Linux, and macOS. RawKee PE may be compatible with versions of Maya on all three operating systems going back to Maya 2023, but this has not been tested.
 
-RawKee Python Edition is currently in a pre-release status, with the official 2.0.0 release scheduled for the 2025 Web3D Conference, which will be co-located with Digital Heritage 2025 in Siena Italy.
+RawKee Python Edition version 2.0.0 is NOW available! See you all at the 2025 Web3D Conference, which is co-located with Digital Heritage 2025 in Siena Italy.
 - [2025 Web3D Conference](https://web3d.siggraph.org/2025/)
 - [Digital Heritage 2025](https://digitalheritage2025.unisi.it/)
 
 ### RawKee Python Edition - YouTube Tutorials Playlist
-- [RPE - YouTube Tutorials Playlist](https://www.youtube.com/@UND-DREAM-Lab/playlists)
+- [RawKee PE - YouTube Tutorials Playlist](https://www.youtube.com/@UND-DREAM-Lab/playlists)
 
 ### Collaborators:
 - [Antony Ward](https://www.antcgi.com/about) - Collaborating to provide RawKee and HAnim compatibility with his [aRT: Modular Rigging Tool](https://www.antcgi.com/store/p/art-modular-rigging-tool).

--- a/RawKee_Python_X3D.py
+++ b/RawKee_Python_X3D.py
@@ -146,6 +146,108 @@ class RKShowNodeSticker(aom.MPxCommand):
         webbrowser.open_new("https://github.com/davidlatwe/NodeSticker")
 
 
+# Creating the MEL Command for showing the Sunrize Editor Website
+class RKShowSunrize(aom.MPxCommand):
+    kPluginCmdName = "rkShowSunrize"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowSunrize()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://create3000.github.io/sunrize/")
+
+
+# Creating the MEL Command for showing the RawKee Help Wiki
+class RKShowX_ITE(aom.MPxCommand):
+    kPluginCmdName = "rkShowX_ITE"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowX_ITE()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://create3000.github.io/x_ite/")
+
+
+# Creating the MEL Command for showing the RawKee Help Wiki
+class RKShowCGE(aom.MPxCommand):
+    kPluginCmdName = "rkShowCGE"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowCGE()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://castle-engine.io/")
+
+
+class RKShowX3DOM(aom.MPxCommand):
+    kPluginCmdName = "rkShowX3DOM"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowX3DOM()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://www.x3dom.org/")
+
+
+class RKShowART(aom.MPxCommand):
+    kPluginCmdName = "rkShowART"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowART()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://www.antcgi.com/store/p/art-modular-rigging-tool")
+
+
+class RKShowAdvSkel(aom.MPxCommand):
+    kPluginCmdName = "rkShowAdvSkel"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowAdvSkel()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://animationstudios.com.au/")
+
+
+# Creating the MEL Command for showing the RawKee Help Wiki
+class RKShowHelpWiki(aom.MPxCommand):
+    kPluginCmdName = "rkShowHelpWiki"
+    
+    def __init__(self):
+        aom.MPxCommand.__init__(self)
+        
+    @staticmethod
+    def cmdCreator():
+        return RKShowHelpWiki()
+        
+    def doIt(self, args):
+        webbrowser.open_new("https://github.com/und-dream-lab/rawkee/wiki")
+
+
 # Creating the MEL Command for showing the RawKee GitHub Website
 class RKShowRawKee(aom.MPxCommand):
     kPluginCmdName = "rkShowRawKee"
@@ -631,6 +733,13 @@ def initializePlugin(plugin):
         pluginFn.registerCommand(RKASBackupClipBoard.kPluginCmdName,   RKASBackupClipBoard.cmdCreator)
         pluginFn.registerCommand(RKASRestoreClipBoard.kPluginCmdName, RKASRestoreClipBoard.cmdCreator)
         
+        pluginFn.registerCommand(    RKShowAdvSkel.kPluginCmdName,      RKShowAdvSkel.cmdCreator)
+        pluginFn.registerCommand(        RKShowART.kPluginCmdName,          RKShowART.cmdCreator)
+        pluginFn.registerCommand(      RKShowX3DOM.kPluginCmdName,        RKShowX3DOM.cmdCreator)
+        pluginFn.registerCommand(        RKShowCGE.kPluginCmdName,          RKShowCGE.cmdCreator)
+        pluginFn.registerCommand(      RKShowX_ITE.kPluginCmdName,        RKShowX_ITE.cmdCreator)
+        pluginFn.registerCommand(    RKShowSunrize.kPluginCmdName,      RKShowSunrize.cmdCreator)
+        pluginFn.registerCommand(   RKShowHelpWiki.kPluginCmdName,     RKShowHelpWiki.cmdCreator)
         pluginFn.registerCommand(RKShowNodeSticker.kPluginCmdName,  RKShowNodeSticker.cmdCreator)
         pluginFn.registerCommand(     RKShowRawKee.kPluginCmdName,       RKShowRawKee.cmdCreator)
         pluginFn.registerCommand(   RKShowDreamLab.kPluginCmdName,     RKShowDreamLab.cmdCreator)
@@ -1017,6 +1126,55 @@ def uninitializePlugin(plugin):
         pluginFn.deregisterCommand(RKShowNodeSticker.kPluginCmdName)
     except Exception as e:
         sys.stderr.write("RKShowNodeSticker - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(   RKShowHelpWiki.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowHelpWiki - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(    RKShowSunrize.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowSunrize - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(      RKShowX_ITE.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowX_ITE - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(        RKShowCGE.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowCGE - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(      RKShowX3DOM.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowX3DOM - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(      RKShowART.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowX3DOM - Failed to unregister a plugin command.\n")
+        print(f"Exception Type: {type(e).__name__}")
+        print(f"Exception Message: {e}")
+
+    try:
+        pluginFn.deregisterCommand(      RKShowAdvSkel.kPluginCmdName)
+    except Exception as e:
+        sys.stderr.write("RKShowX3DOM - Failed to unregister a plugin command.\n")
         print(f"Exception Type: {type(e).__name__}")
         print(f"Exception Message: {e}")
 

--- a/rawkee/RKSceneTraversal.py
+++ b/rawkee/RKSceneTraversal.py
@@ -159,6 +159,26 @@ class RKSceneTraversal():
                     if sIdx > -1 and jIdx > -1 and sIdx > jIdx and hasDEF == True:
                         mNodeList[jIdx] = "skeleton"
                         mNodeList[sIdx] = "joints"
+                        
+            elif nType == "Appearance":
+                bIdx = -1
+                fIdx = -1
+                
+                for idx in range(len(sNodeList)):
+                    if   sNodeList[idx] == "backMaterial":
+                        bIdx = idx
+                    elif sNodeList[idx] == "material":
+                        fIdx = idx
+                    
+                hasUSE = False
+                if bIdx != -1:
+                    bMat = getattr(node, "backMaterial")
+                    if bMat.USE != None and bMat.USE != '':
+                        hasUSE = True
+
+                if fIdx > -1 and bIdx > -1 and fIdx > bIdx and hasUSE == True:
+                    sNodeList[bIdx] = "material"
+                    sNodeList[fIdx] = "backMaterial"
             
         compNode = None
                     
@@ -841,7 +861,6 @@ class RKSceneTraversal():
             self.itabs()
             self.writeLine("<Scene>")
             self.itabs()
-            self.writeLine("<Background skyColor='0.2 0.2 0.2'></Background>")
 
     def writeFooter(self):
         if   self.enc == encx:

--- a/rawkee/RKWeb3D.py
+++ b/rawkee/RKWeb3D.py
@@ -74,8 +74,13 @@ class RKWeb3D():
         self.dirPath  = ""
         self.fullPath = ""
         self.selectedFilter = ""
-        #                       self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D Binary (*.x3db);;X3D Enhanced Binary (*.x3de);;X3D JSON (*.x3dj);;X3D JSON (*.json);;VRML97 (*.wrl);;Web3D Files (*.x3d *.x3db *.x3de *.x3dj *.x3dv *.json *.wrl)"
-        self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D JSON (*.x3dj);;X3D JSON (*.json);;X3D HTML5 (*.html);;Web3D Files (*.x3d *.x3dv *.x3dj *.json *.html)"
+
+        #####################################################################################################################################
+        # *.html export will remain temporarily unsupported because of the increasing complexity of the code necessary to support 
+        # custom node and field features unique to X3DOM's shader, material, and texture implementation.
+        #####################################################################################################################################
+        # self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D JSON (*.x3dj);;X3D JSON (*.json);;X3D HTML5 (*.html);;Web3D Files (*.x3d *.x3dv *.x3dj *.json *.html)"
+        self.x3dfilters = "X3D XML (*.x3d);;X3D Classic (*.x3dv);;X3D JSON (*.x3dj);;X3D JSON (*.json);;Web3D Files (*.x3d *.x3dv *.x3dj *.json)"
         
         # Setup the main 'RawKee X3D' plugin menu
         self.rkMenuName ="rawkee_menu"
@@ -136,13 +141,21 @@ class RKWeb3D():
     
         
         # Set the MainWindow MenuBar Menu for RawKee
-        self.rawKeeMenu = cmds.menu(self.rkMenuName, label = 'RawKee (X3D)', tearOff=True, p='MayaWindow')#QMenu("RawKee (X3D)", self.mayaWin)
+        self.rawKeeMenu = cmds.menu(self.rkMenuName, label = 'RawKee PE (X3D)', tearOff=True, p='MayaWindow')#QMenu("RawKee (X3D)", self.mayaWin)
 
         '''
         cmds.menuItem(label='RawKee Tutorials')#self.rawKeeMenu.addAction("RawKee Tutorials")# -command "showX3DTutorials";
         cmds.menuItem(label='RawKee Documentation')#self.rawKeeMenu.addAction("RawKee Documentation")# -command "showX3DTutorials";
         '''
+        cmds.menuItem(divider=True, dividerLabel='RawKee - Version 2.0.0 - Python Edition')
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(label='RawKee Help Wiki',                             command='maya.cmds.rkShowHelpWiki()')
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
         cmds.menuItem(divider=True, dividerLabel='File - Import/Export' )                                                           #self.rawKeeMenu.addSection("File - Import/Export")
+        cmds.menuItem(divider=True)
         self.x3dExport       = cmds.menuItem(label='Export All - X3D',      command='maya.cmds.rkX3DExport()')
         self.x3dExportOpt    = cmds.menuItem(image=':menu_options.png',     command='maya.cmds.rkX3DExportOp()',    optionBox=True) #self.rawKeeMenu.addAction(self.x3dExportOpt)
         self.x3dSelExport    = cmds.menuItem(label='Export Selected - X3D', command='maya.cmds.rkX3DSelExport()')
@@ -155,15 +168,47 @@ class RKWeb3D():
         # Finishing off the  X3D Plug-in menu
         #--------------------------------------------------------------------
         cmds.setParent(self.rkMenuName, menu=True)
-        cmds.menuItem(divider=True, dividerLabel='RawKee Editors and Tools')
-        cmds.menuItem(label='X3D Interaction Editor',             command='maya.cmds.rkShowSceneEditor()'    )                # -command "showX3DIEditor";
-        cmds.menuItem(label='X3D Character and Animation Editor', command='maya.cmds.rkShowCharacterEditor()')                # -command "x3dCharacterEditor";
-        cmds.menuItem(label='X3D General Animation Editor')                  # -command "x3dAnimationEditor";
 
-        cmds.menuItem(divider=True, dividerLabel='Code Repositories')
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True, dividerLabel='RawKee Editors and Tools')
+        cmds.menuItem(divider=True)
+        ### --- will be part of future release --- ### cmds.menuItem(label='X3D Interaction Editor',             command='maya.cmds.rkShowSceneEditor()'    )                # -command "showX3DIEditor";
+        cmds.menuItem(label='X3D Character and Animation Editor', command='maya.cmds.rkShowCharacterEditor()')                # -command "x3dCharacterEditor";
+        ### --- will be part of next release --- ### cmds.menuItem(label='X3D General Animation Editor')                  # -command "x3dAnimationEditor";
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True, dividerLabel='Get Compatible 3rd Party Character Tools')
+        cmds.menuItem(divider=True)
+        cmds.menuItem(label="Antony Ward's Modular Rigging Tool (aRT)", command='maya.cmds.rkShowART()')
+        cmds.menuItem(label='Advanced Skeleton',                        command='maya.cmds.rkShowAdvSkel()')
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True, dividerLabel='Learn About 3rd Party X3D Editors')
+        cmds.menuItem(divider=True)
+        cmds.menuItem(label='Sunrize - A Multi-Platform X3D Editor',    command='maya.cmds.rkShowSunrize()')
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True, dividerLabel='Learn About 3rd Party X3D Viewers')
+        cmds.menuItem(divider=True)
+        cmds.menuItem(label='X_ITE X3D Browser',                        command='maya.cmds.rkShowX_ITE()')
+        cmds.menuItem(label='Castle Game Engine',                       command='maya.cmds.rkShowCGE()')
+        cmds.menuItem(label='X3DOM - Instant 3D the HTML way!',         command='maya.cmds.rkShowX3DOM()')
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True, dividerLabel='Visit Related Code Repositories')
+        cmds.menuItem(divider=True)
         cmds.menuItem(label='RawKee GitHub Python Repo',                command='maya.cmds.rkShowRawKee()')
         cmds.menuItem(label='Node Sticker - GitHub Repo / MIT License', command='maya.cmds.rkShowNodeSticker()')
+
+        cmds.menuItem(divider=True)
+        cmds.menuItem(divider=True)
         cmds.menuItem(divider=True, dividerLabel='Websites')
+        cmds.menuItem(divider=True)
         cmds.menuItem(label='Univ. of North Dakota - DREAM Lab',        command='maya.cmds.rkShowDreamLab()')
         cmds.menuItem(label='Web3D Consortium',                         command='maya.cmds.rkShowWeb3D()')
         cmds.menuItem(label='Metaverse Standards Forum',                command='maya.cmds.rkShowMSF()')
@@ -203,6 +248,10 @@ class RKWeb3D():
         x3dVersion  = "4.0"
         x3dDoc = rkx3d.X3D(profile=profileType, version=x3dVersion)
         x3dDoc.Scene = rkx3d.Scene()
+        background = rkx3d.Background()
+        background.DEF = "DefaultBackground"
+        background.skyColor = (0.2, 0.2, 0.2)
+        x3dDoc.Scene.children.append(background)
 
         #############################################
         # Get File Path From QFileDialog File Chooser
@@ -251,8 +300,12 @@ class RKWeb3D():
                 exEncoding = "x3dj"
             elif fext == ".json":
                 exEncoding = "json"
-            elif fext == ".html":
-                exEncoding = "html"
+            #####################################################################################################################################
+            # *.html export will remain temporarily unsupported because of the increasing complexity of the code necessary to support 
+            # custom node and field features unique to X3DOM's shader, material, and texture implementation.
+            #####################################################################################################################################
+            # elif fext == ".html":
+            #    exEncoding = "html"
 
             # Traverse DAG and map node data to X3D
             rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion, self.fullPath, exEncoding)
@@ -283,6 +336,10 @@ class RKWeb3D():
         x3dVersion  = "4.0"
         x3dDoc = rkx3d.X3D(profile=profileType, version=x3dVersion)
         x3dDoc.Scene = rkx3d.Scene()
+        background = rkx3d.Background()
+        background.DEF = "DefaultBackground"
+        background.skyColor = (0.2, 0.2, 0.2)
+        x3dDoc.Scene.children.append(background)
 
         #############################################
         # Get File Path From QFileDialog File Chooser
@@ -331,8 +388,12 @@ class RKWeb3D():
                 exEncoding = "x3dj"
             elif fext == ".json":
                 exEncoding = "json"
-            elif fext == ".html":
-                exEncoding = "html"
+            #####################################################################################################################################
+            # *.html export will remain temporarily unsupported because of the increasing complexity of the code necessary to support 
+            # custom node and field features unique to X3DOM's shader, material, and texture implementation.
+            #####################################################################################################################################
+            # elif fext == ".html":
+            #    exEncoding = "html"
                 
             # Traverse DAG and map node data to X3D
             rko.maya2x3d(x3dDoc.Scene, parentDagPaths, topDagNodes, self.pVersion, self.fullPath, exEncoding)


### PR DESCRIPTION
…nd material export with support for Appearance - backMaterial along with Material, PhysicalMaterial, and UnlitMaterial nod
This pull request introduces several improvements to both the user interface and export functionality of the RawKee Python Edition (PE) X3D plugin for Maya. The most significant changes include the addition of new MEL commands for accessing third-party tools and documentation, enhancements to the RawKee menu for better organization and discoverability, and updates to the export logic to consistently include a default background and clarify the status of HTML export support.

### User Interface and Menu Improvements

* Added new MEL commands (`rkShowHelpWiki`, `rkShowSunrize`, `rkShowX_ITE`, `rkShowCGE`, `rkShowX3DOM`, `rkShowART`, `rkShowAdvSkel`) that open relevant third-party tool websites and documentation directly from Maya. These commands are registered and deregistered in the plugin lifecycle. [[1]](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R149-R250) [[2]](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R736-R742) [[3]](diffhunk://#diff-8a8bb4791a7eab5b48ea876b1259f2c01befe52834fd9a797f1af5b166e13b65R1132-R1180)
* Enhanced the RawKee menu in Maya to include new sections for help, third-party editors, character tools, viewers, and code repositories, improving organization and user navigation. Menu items now directly invoke the new MEL commands. [[1]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL139-R158) [[2]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aR171-R211)

### Export Functionality and Format Support

* Updated the export logic to always include a default `Background` node with a sky color in both full and selected X3D exports, ensuring consistency across exported scenes. [[1]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aR251-R254) [[2]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aR339-R342)
* Clarified that HTML (*.html) export is temporarily unsupported due to the complexity of supporting X3DOM-specific features, and removed it from the file filter and export logic. [[1]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL77-R83) [[2]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL254-R308) [[3]](diffhunk://#diff-7a0a264da9c13c7113393660e6ebe4c39cd05855521e68fd37cc49af733b028aL334-R396)

### Scene Traversal and Appearance Node Handling

* Improved handling of `Appearance` nodes during scene traversal to correctly swap `material` and `backMaterial` fields when appropriate, ensuring proper export of materials with `USE` references.

### Documentation Updates

* Updated the `README.md` to reflect support for Maya 2023 and above, announce the availability of version 2.0.0, and clarify tutorial links and collaborator information.

### Miscellaneous

* Removed the default `<Background>` element from the scene header writer, as this is now handled in the export logic.es.