### PR TITLE
Siggraph 2026 Prep

### DIFF
--- a/rawkee/maya/RKCharacterEditor.py
+++ b/rawkee/maya/RKCharacterEditor.py
@@ -457,7 +457,25 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         rotOrder = self.rotOrderValue
         self.changeSkeletonRotOrder("GameSkeletonRoot_M", rotOrder)
         
+
+    def removeNonJointNodes(self, jnode):
+        all_descendants = cmds.listRelatives(jnode, ad=True, fullPath=True) or []
+        to_delete = [node for node in all_descendants if cmds.nodeType(node) != 'joint']
+
+        revDev = cmds.listRelatives(jnode, ad=True) or []
+        allJoints = [node for node in revDev if cmds.nodeType(node) == 'joint']
+        allJoints.append(jnode)
         
+        if to_delete:
+            cmds.delete(to_delete)
+            
+        for j in allJoints:
+            try:
+                cmds.setAttr(j + '.liw', 0)
+            except:
+                pass
+
+
     #################################################
     # Generic Create Duplicate Skeleton
     #################################################
@@ -470,11 +488,17 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         self.duplicateRoot = ""
         
         rotOrder = self.rotOrderValue
-        
-        selectNames = cmds.ls(sl=True)
-        if selectNames == None:
+
+        selectNames = cmds.ls(sl=True, long=False)
+        selectPaths = cmds.ls(sl=True, long=True )
+        if not selectNames:
+            print("selectNames didn't exist.")
             return
-        self.sourceRoot = selectNames[0]
+        sourceName      = selectNames[0]
+        self.sourceRoot = selectPaths[0]
+        print(sourceName)
+        print(self.sourceRoot)
+        
         actualName = cmds.createNode('transform', ss=True, name='HAnimHumanoid')
         cmds.addAttr(actualName, longName='x3dGroupType', dataType='string', keyable=False)
         cmds.setAttr(actualName + '.x3dGroupType', "HAnimHumanoid", type='string', lock=True)
@@ -488,28 +512,37 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             print(f"Exception Message: {e}")                            
             print("Oops... Node Sticker Didn't work.")
 
-        newRootName = cmds.duplicate(self.sourceRoot, rr=True, rc=True)
-        cmds.parent(newRootName, actualName)
+        newRootName = cmds.duplicate(self.sourceRoot, rr=True, rc=False, ic=False, un=False, ilf=True, f=True)
         
-        self.changeSkeletonRotOrder(newRootName, rotOrder)
+        #self.removeNonJointNodes(newRootName[0])
+        cmds.parent(newRootName[0], actualName)
+        child = cmds.listRelatives(actualName, children=True, f=True)[0]
+        cmds.rename(child, sourceName)
+
+        self.duplicateRoot = cmds.listRelatives(actualName, children=True, f=True)[0]
+        print(self.duplicateRoot)
+        
+        self.changeSkeletonRotOrder(self.duplicateRoot, rotOrder)
         
         # Assign parentConstraints
-        self.duplicateRoot = newRootName[0]
         
-        jSel = om.MSelectionList()
-        jSel.add(self.sourceRoot)
-        jSel.add(self.duplicateRoot)
-        sRoot = om.MFnDagNode(jSel.getDagPath(0))
-        nRoot = om.MFnDagNode(jSel.getDagPath(1))
+        #jSel = om.MSelectionList()
+        #jSel.add(self.sourceRoot)
+        #jSel.add(self.duplicateRoot)
+        #sRoot = om.MFnDagNode(jSel.getDagPath(0))
+        #nRoot = om.MFnDagNode(jSel.getDagPath(1))
         
-        self.addHAnimConstraints(sRoot, nRoot)
+        #self.addHAnimConstraints(sRoot, nRoot)
         
 
     def addHAnimConstraints(self, sLeader, nFollower):
-        #cmds.parentConstraint(sLeader.name(), nFollower.name(), mo=True, st=["x","y","z"], w=1)
-        cmds.parentConstraint(sLeader.name(), nFollower.name(), mo=True, w=1)
-        for i in range(sLeader.childCount()):
-            self.addHAnimConstraints(om.MFnDagNode(sLeader.child(i)), om.MFnDagNode(nFollower.child(i)))
+        cmds.parentConstraint(sLeader, nFollower, mo=True, w=1)
+        sChildren = cmds.listRelatives(sLeader,   children=True, type="joint", f=True)
+        if sChildren:
+            nChildren = cmds.listRelatives(nFollower, children=True, type="joint", f=True)
+            if nChildren:
+                for i in range(len(sChildren)):
+                    self.addHAnimConstraints(sChildren[i], nChildren[i])
 
 
     #################################################
@@ -536,8 +569,8 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         
         # Transfer joint.translate values to joint.opm.translate
         self.flipTranslateToPMO(self.duplicateRoot)
-        mJoints = cmds.listRelatives(self.duplicateRoot, ad=True, type="joint")
-        if mJoints != None:
+        mJoints = cmds.listRelatives(self.duplicateRoot, ad=True, type="joint", f=True)
+        if mJoints:
             for mJoint in mJoints:
                 self.flipTranslateToPMO(mJoint)
         
@@ -551,13 +584,16 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
 
         
         # Assign new parentConstraints
-        jSel = om.MSelectionList()
-        jSel.add(self.sourceRoot)
-        jSel.add(self.duplicateRoot)
-        sRoot = om.MFnDagNode(jSel.getDagPath(0))
-        nRoot = om.MFnDagNode(jSel.getDagPath(1))
+        #jSel = om.MSelectionList()
+        #print(self.sourceRoot)
+        #print(self.duplicateRoot)
+        #jSel.add(self.sourceRoot)
+        #jSel.add(self.duplicateRoot)
+        #sRoot = om.MFnDagNode(jSel.getDagPath(0))
+        #nRoot = om.MFnDagNode(jSel.getDagPath(1))
         
-        self.addHAnimConstraints(sRoot, nRoot)
+        #self.addHAnimConstraints(sRoot, nRoot)
+        self.addHAnimConstraints(self.sourceRoot, self.duplicateRoot)
         
             
     def flipTranslateToPMO(self, nodeName):
@@ -565,17 +601,21 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         y = cmds.getAttr(nodeName + ".translateY")
         z = cmds.getAttr(nodeName + ".translateZ")
         
-        opm = []
         opm = cmds.getAttr(nodeName + ".offsetParentMatrix")
+        #print(opm)
+        #print(opm[0])
+        #print(f"Type: {type(res)}")
+        #print(f"Content: {res}")
         
-        opm[12] = opm[12] + x
-        opm[13] = opm[13] + y
-        opm[14] = opm[14] + z
-        cmds.setAttr(nodeName + ".offsetParentMatrix", opm, type="matrix")
+        if opm:
+            opm[12] = opm[12] + x
+            opm[13] = opm[13] + y
+            opm[14] = opm[14] + z
+            cmds.setAttr(nodeName + ".offsetParentMatrix", opm, type="matrix")
     
-        cmds.setAttr(nodeName + ".translateX", 0.0)
-        cmds.setAttr(nodeName + ".translateY", 0.0)
-        cmds.setAttr(nodeName + ".translateZ", 0.0)
+            cmds.setAttr(nodeName + ".translateX", 0.0)
+            cmds.setAttr(nodeName + ".translateY", 0.0)
+            cmds.setAttr(nodeName + ".translateZ", 0.0)
 
         
     def constraintRemover(self, dagNode, constraints):
@@ -599,6 +639,30 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         srDag = om.MFnDagNode(skelSel.getDagPath(0))
         skins = []
         self.collectBoundSkins(srDag, skins)
+        
+        '''
+        for skin in skins:
+            scs = cmds.ls(cmds.listHistory(skin.name()), type='skinCluster')
+            if scs:
+                for sc in scs:
+                    # Use the unbindKeepHistory flag (ubk)
+                    cmds.skinCluster(scs, edit=True, unbindKeepHistory=True)
+                    
+                rels = cmds.listRelatives(skin.name(), parent=True)#, fullPath=True)
+                if rels:
+                    pv=[0, 0, 0]
+                    cmds.parent(rels[0], world=True)
+                    cmds.xform(rels[0], pivots=pv, worldSpace=True)
+                    cmds.makeIdentity(rels[0], apply=True, t=True, r=True, s=True, n=False, pn=True, jo=True)
+                    
+                cmds.select(self.duplicateRoot)
+                cmds.select(cmds.listRelatives(self.duplicateRoot, allDescendents=True, type='joint', f=True), add=True)
+                cmds.select(skin.name(), add=True)
+
+                cmds.skinCluster(tsb=True)
+        
+        return
+        '''
         
         #Collect Skin Clusters
         skinClusters = []
@@ -645,26 +709,28 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         om.MGlobal.setActiveSelectionList(actList)
         
         #Unbined Meshes
-        cmds.DetachSkin(unbindAll=True, deleteHistroy=True)
+        #cmds.DetachSkin(unbindAll=True, deleteHistroy=True)
         
         #Make skins identity in worldspace.
         for skin in skins:
-            rels = cmds.listRelatives(skin.name(), parent=True, fullPath=True)
+            cmds.skinCluster(skin.name(), edit=True, unbind=True, ubk=True)
+            
+            rels = cmds.listRelatives(skin.name(), parent=True)#, fullPath=True)
             ##########################################################
             # Insert code to check if parent transform is keyed.
             # if it is, break connections.
-            connections = []
             connections = cmds.listConnections(rels[0], c=True, p=True)
             
-            cLen = len(connections)
-            cIter = 0
-            while cIter < cLen:
-                if "translate" in connections[cIter] or "rotate" in connections[cIter] or "scale" in connections[cIter]:
-                    try:
-                        cmds.disconnectAttr(connections[cIter+1], connections[cIter])
-                    except:
-                        print("disconnectAttr failed")
-                cIter += 2
+            if connections:
+                cLen = len(connections)
+                cIter = 0
+                while cIter < cLen:
+                    if "translate" in connections[cIter] or "rotate" in connections[cIter] or "scale" in connections[cIter]:
+                        try:
+                            cmds.disconnectAttr(connections[cIter+1], connections[cIter])
+                        except:
+                            print("disconnectAttr failed")
+                    cIter += 2
                 
             # Format the mesh within the transform properly
             pv=[0, 0, 0]
@@ -713,7 +779,9 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             
             skSel = om.MSelectionList()
             skSel.add(skins[i].fullPathName())
+
             skinCluster.setWeights(skSel.getDagPath(0), shape_comp, dpIndices, weights[i], normalize=False, returnOldWeights=False)
+            print("After\n")
 
 
     def bindSkinToSpecificInfluencers(self, skin, jointPaths):
@@ -778,9 +846,9 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
 
 
     def collectSkinClusterFromSkin(self, mNode, skinClusters):
-        smlist = om.MSelectionList()
-        smlist.add(mNode.name())
-        mpath = smlist.getDagPath(0)
+        #smlist = om.MSelectionList()
+        #smlist.add(mNode.name())
+        #mpath = smlist.getDagPath(0)
         
         skClusters = []
         scIter = om.MItDependencyGraph(mNode.object(), rkfn.kSkinClusterFilter, om.MItDependencyGraph.kUpstream, om.MItDependencyGraph.kBreadthFirst, om.MItDependencyGraph.kNodeLevel)
@@ -788,8 +856,11 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             skClusters.append(omAnim.MFnSkinCluster(scIter.currentNode()))
             scIter.next()
         
-        if len(skClusters) > 0:
-            skinClusters.append(skClusters[0])
+        #if len(skClusters) > 0:
+        #    skinClusters.append(skClusters[0])
+        for skc in skClusters:
+            print("Name: " + skc.name())
+            skinClusters.append(skc)
 
         
     def collectBoundSkins(self, joint, skins):
@@ -941,7 +1012,6 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
                 aName = cmds.createNode("rkAnimPack", n=tName, p=hName)
                 self.updateAnimPackAttributes( aName, "mimickedType", atSet)
                 self.populateAnimationPackages()
-
             elif atSet == 1 or atSet == 3 or atSet == 4:
                 aName = cmds.createNode("rkAnimPack", n=tName)
                 self.updateAnimPackAttributes( aName, "mimickedType", atSet)
@@ -2081,8 +2151,8 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         
     def changeSkeletonRotOrder(self, jointName, rotOrder):
         cmds.setAttr(jointName + ".rotateOrder", rotOrder)
-        children = cmds.listRelatives(jointName, children=True)
-        if children != None:
+        children = cmds.listRelatives(jointName, children=True, f=True)
+        if children:
             for child in children:
                 slist = om.MSelectionList()
                 slist.add(child)

--- a/rawkee/maya/RKOrganizer.py
+++ b/rawkee/maya/RKOrganizer.py
@@ -319,22 +319,21 @@ class RKOrganizer():
             parentDagPaths[i] = self.rootName
             self.traverseDownward(parentDagPaths[i], dagNodes[i])
             
-        self.collectInterpolatorData()
         
         ##########################################################
         # Needed for writing animation data at the end of the file
         # 
         # End of Export
         ##########################################################
-        cLen = len(eofScene.children)
-            
+        self.processRKAnimPacks()
+
+        cLen = len(self.eofScene.children)
         for i in range(cLen):
-            x3dScene.children.append(eofScene.children.pop(0))
-                
+            x3dScene.children.append(self.eofScene.children.pop(0))
         self.eofScene = None
             
-        # Reset Animations as best as possible.
-        
+        self.collectInterpolatorData()
+
         #cmds.currentTime(0)
         for bPose in self.bPoseStore:
             cmds.dagPose( bPose, restore=True )
@@ -727,15 +726,20 @@ class RKOrganizer():
                             
                             # Determin if this is an HAnimJoint node or a Skin Transform Node
                             isHAnim = False
-                            cPath = path
+                            cPath = aom.MDagPath(path)
                             while cPath.length() > 0:
-                                pObj = cPath.parent(0)
+                                cPath.pop()
+                                #pObj = cPath.parent(0)
+                                
             
-                                if pObj.isNull():
+                                #if pObj.isNull():
+                                #    break
+                                if cPath.length() == 0:
                                     break
 
                                 # Use an MFnDagNode to check the type of the parent
-                                pDag = aom.MFnDagNode(pObj)
+                                #pDag = aom.MFnDagNode(pObj)
+                                pDag = aom.MFnDagNode(cPath)
             
                                 # Check if the parent is a transform node
                                 if pDag.typeName != "joint":
@@ -1480,17 +1484,19 @@ class RKOrganizer():
             # that mesh is point values are in world coordinates.
             smLen = len(sm)
             snLen = len(sno)
+            stLen = len(sto)
+            print("SM Len: " + str(smLen) + ", SN Len: " + str(snLen) + ", ST Len: " + str(stLen))
             for i in range(smLen):
-                # This is needed if the sno length is zero so as not to throw an out-of-bounds error on the list.
+                # This is needed if the sno and/or sto length is zero so as not to throw an out-of-bounds error on the list.
                 if snLen == 0:
                     sno.append(snLen)
-                if tName != "":
-                    sto.append(None)
+                if stLen == 0:
+                    sto.append(stLen)
                 
                 self.processMayaMesh(humanoid.DEF, aom.MFnDagNode(sm[i].object()), "skin", wio[i], sno[i], sto[i], cName, sName, tName, isAvatar=True)
             
             # Section where we add HAnimMotion, or other timing nodes (aka TimeSensor, AudioClip, and MovieTexture)
-            nonMotionRKAPNodes = []
+            #nonMotionRKAPNodes = []
             for i in range(cNum):
                 dagChild = aom.MFnDagNode(dagNode.child(i))
                 if dagChild.typeName == "rkAnimPack":
@@ -1504,36 +1510,48 @@ class RKOrganizer():
                         
                     # If it's any other type of timing node, append to the non-Motion node list
                     # for later processing.
-                    elif apType == 1 or apType == 3 or apType == 4:
-                        nonMotionRKAPNodes.append(dagChild)
+                    #elif apType == 1 or apType == 3 or apType == 4:
+                    #    nonMotionRKAPNodes.append(dagChild)
             
-            if len(nonMotionRKAPNodes) > 0:
-                self.processRKAnimPacks(humanoid.DEF, nonMotionRKAPNodes, humanoid, "skin")
+#            if len(nonMotionRKAPNodes) > 0:
+#                self.processRKAnimPacks(humanoid.DEF, nonMotionRKAPNodes, humanoid, "skin")
 
 
-    def processRKAnimPacks(self, x3dParentDEF, rkAPNodes, x3dParent, x3dField):
-        parentNode = x3dParent
-        cField = x3dField
+    def processRKAnimPacks(self):#, rkAPNodes, x3dParent, x3dField):
+        #parentNode = x3dParent
+        #cField = x3dField
         
         ######################################################
         # Run this code to export Animation data 
         # at the end of the file is selected.
         ######################################################
-        parentNode = self.eofScene
-        cField = "children"
+        #parentNode = self.eofScene
+        #cField = "children"
+        
+        rkAPNodes = []
+        rkSel = aom.MSelectionList()
+        pkNames = cmds.ls(type="rkAnimPack", long=True)
+        if pkNames:
+            for pkn in pkNames:
+                rkSel.add(pkn)
+            for i in range(rkSel.length()):
+                rkAPNodes.append(aom.MFnDagNode(rkSel.getDagPath(i)))
             
-        bna = self.trv.processBasicNodeAddition(parentNode, cField, "Group", x3dParent.DEF + "_TimerGroup")
-        if bna:
+        #bna = self.trv.processBasicNodeAddition(parentNode, cField, "Group", x3dParent.DEF + "_TimerGroup")
+        #if bna:
             for apNode in rkAPNodes:
                 apType = cmds.getAttr(apNode.name() + ".mimickedType")
                 if apType == 1:
-                    self.processAudioClipNode(   apNode, bna, "children")
+                    #self.processAudioClipNode(   apNode, bna, "children")
+                    self.processAudioClipNode(   apNode, self.eofScene, "children")
                 elif apType == 3:
-                    self.processMovieTextureNode(apNode, bna, "children")
+                    #self.processMovieTextureNode(apNode, bna, "children")
+                    self.processMovieTextureNode(apNode, self.eofScene, "children")
                 elif apType == 4:
-                    self.processTimeSensorNode(  apNode, bna, "children")
+                    #self.processTimeSensorNode(  apNode, bna, "children")
+                    self.processTimeSensorNode(  apNode, self.eofScene, "children")
                     
-
+    '''
     def processSingleRKAnimPack(self, x3dParentDEF, apNode, x3dField="children"):
         x3dParent = self.getX3DParent(apNode, x3dParentDEF) 
         
@@ -1544,18 +1562,18 @@ class RKOrganizer():
             self.processMovieTextureNode(apNode, x3dParent, x3dField)
         elif apType == 4:
             self.processTimeSensorNode(  apNode, x3dParent, x3dField)
+    '''
 
-
-    def processAudioClipNode   (self, apNode, timerGroup, cField):
-        bna = self.trv.processBasicNodeAddition(timerGroup, cField, "AudioClip", apNode.name())
+    def processAudioClipNode   (self, apNode, x3dParent, cField):
+        bna = self.trv.processBasicNodeAddition(x3dParent, cField, "AudioClip", apNode.name())
 
         
-    def processMovieTextureNode(self, apNode, timerGroup, cField):
-        bna = self.trv.processBasicNodeAddition(timerGroup, cField, "MovieTexture", apNode.name())
+    def processMovieTextureNode(self, apNode, x3dParent, cField):
+        bna = self.trv.processBasicNodeAddition(x3dParent, cField, "MovieTexture", apNode.name())
 
     #Processing TimeSensor Node
-    def processTimeSensorNode   (self, apNode, timerGroup, cField):
-        bna = self.trv.processBasicNodeAddition(timerGroup, cField, "TimeSensor", apNode.name())
+    def processTimeSensorNode   (self, apNode, x3dParent, cField):
+        bna = self.trv.processBasicNodeAddition(x3dParent, cField, "TimeSensor", apNode.name())
         if bna:
             ##########################################
             # Store for later collection
@@ -1586,7 +1604,7 @@ class RKOrganizer():
             bna.cycleInterval = frameDistance / fps
             
             #To Be Removed later
-            cmds.setAttr(apNode.name() + ".cycleInterval", bna[1].cycleInterval)
+            cmds.setAttr(apNode.name() + ".cycleInterval", bna.cycleInterval)
             
             bna.description = cmds.getAttr(apNode.name() + ".description")
             bna.resumeTime  = cmds.getAttr(apNode.name() + ".resumeTime")
@@ -1615,7 +1633,7 @@ class RKOrganizer():
             ###### preFrame = cmds.currentTime(query=True)## --- ################
             for tExp in timerExpressions:
                 x3dNodeType = cmds.getAttr(tExp.name() + '.x3dInterpolatorType')
-                bni = self.trv.processBasicNodeAddition(timerGroup, cField, x3dNodeType, tExp.name())
+                bni = self.trv.processBasicNodeAddition(x3dParent, cField, x3dNodeType, tExp.name())
                 if bni:
                     ############################################################################
                     ###### cons   = cmds.listConnections(tExp.name(), p=True, s=True, et=True, sh=True)
@@ -1683,8 +1701,8 @@ class RKOrganizer():
                         if attrParts[1]   == "rotate":
                             setFieldValue += "rotation"
                             
-                    self.generateRoutes(bna.DEF, 'fraction_changed', bni.DEF,   'set_fraction', timerGroup, cField)
-                    self.generateRoutes(bni.DEF, 'value_changed',    attrParts[0], setFieldValue,  timerGroup, cField)
+                    self.generateRoutes(bna.DEF, 'fraction_changed', bni.DEF,     'set_fraction', x3dParent, cField)
+                    self.generateRoutes(bni.DEF, 'value_changed',    attrParts[0], setFieldValue, x3dParent, cField)
                     
             ###### cmds.currentTime(preFrame)
 
@@ -1901,16 +1919,16 @@ class RKOrganizer():
                 stoLen = len(sto)
                 if stolen > 0:
                     offset = offset + sto[stoLen-1]
-            sto.append(offset)
+                sto.append(offset)
 
-        # Need to shift the Tangent offset over, because index 0 should have a
-        # value of 0
-        tNum = len(sto)
-        last = 0
-        for nIdx in range(tNum):
-            tLast = sno[nIdx]
-            sno[nIdx] = last
-            last = tLast
+            # Need to shift the Tangent offset over, because index 0 should have a
+            # value of 0
+            tNum = len(sto)
+            last = 0
+            for nIdx in range(tNum):
+                tLast = sto[nIdx]
+                sto[nIdx] = last
+                last = tLast
             
         return sto, tName
 
@@ -1945,7 +1963,7 @@ class RKOrganizer():
                                     n = smIter.getNormal(i)
                                     normalbna.vector.append((n.x, n.y, n.z))
                                     offset += 1
-                                wmIter.next()
+                                smIter.next()
                     #Normal Per Vertex is False
                     elif self.rkNormalOpts == 2 or self.rkNormalOpts == 5:
                         if self.rkIsTriangles == True:
@@ -1963,19 +1981,19 @@ class RKOrganizer():
                                 normalbna.vector.append((pn.x, pn.y, pn.z))
                                 offset += 1
 
-                slen = len(sno)
-                if slen > 0:
-                    offset = offset + sno[slen-1]
-                sno.append(offset)
+                    slen = len(sno)
+                    if slen > 0:
+                        offset = offset + sno[slen-1]
+                    sno.append(offset)
             
-            # Need to shift the Noraml offset over, because index 0 should have a
-            # value of 0
-            n = len(sno)
-            last = 0
-            for nIdx in range(n):
-                tLast = sno[nIdx]
-                sno[nIdx] = last
-                last = tLast
+                # Need to shift the Noraml offset over, because index 0 should have a
+                # value of 0
+                n = len(sno)
+                last = 0
+                for nIdx in range(n):
+                    tLast = sno[nIdx]
+                    sno[nIdx] = last
+                    last = tLast
 
         return sno, nName
 
@@ -2234,7 +2252,7 @@ class RKOrganizer():
             #################################################t
             # Process CGESkin "shapes" field
             for mesh in allShapes:
-                #cgeShape = self.processMayaMesh(bna[1].DEF, mesh, cField="shapes", isAvatar=True, adjustment=skinSpaceMatrix)
+                #cgeShape = self.processMayaMesh(bna.DEF, mesh, cField="shapes", isAvatar=True, adjustment=skinSpaceMatrix)
                 #bLen = len(bna.shapes)
                 tmc = self.processMayaMesh(bna.DEF, mesh, cField="shapes", isAvatar=True, adjustment=skinSpaceMatrix)
                 for key in tmc:
@@ -2258,7 +2276,7 @@ class RKOrganizer():
                     print(f"Exception Type: {type(e).__name__}")
                     print(f"Exception Message: {e}")                            
 
-            self.populateCGEInverseBindMatrices(bna[1], allJoints, ssm=skinSpaceMatrix)
+            self.populateCGEInverseBindMatrices(bna, allJoints, ssm=skinSpaceMatrix)
 
 
     def populateCGEInverseBindMatrices(self, x3dSkin, allJoints, ssm=aom.MMatrix()):
@@ -2777,6 +2795,9 @@ class RKOrganizer():
             if cNode.typeName == "x3dSound"      and index == 0:
                 hasSound  = True
                 isLeaf    = True
+            # Ignore any transform that has an 'rkAnimPack' node as a child
+            if cNode.typeName == "rkAnimPack":
+                return
                 
         if hasCamera  == True:
             self.processX3DViewpoint(dagNode, x3dPF) #TODO fix the problem.
@@ -2813,8 +2834,8 @@ class RKOrganizer():
                 elif dagNode.typeName == "lodGroup":
                     self.processMayaLOD(x3dParentDEF, dagNode, cField)
                     
-                elif dagNode.typeName == "rkAnimPack":
-                    self.processSingleRKAnimPack(x3dParentDEF, dagNode, cField)
+                #elif dagNode.typeName == "rkAnimPack":
+                #    self.processSingleRKAnimPack(x3dParentDEF, dagNode, cField)
                     
                 elif dagNode.typeName == "joint":
                     if cmds.objExists("rkEPose"):
@@ -5455,7 +5476,7 @@ class RKOrganizer():
                         pass
                 else:
                     spCol = cmds.getAttr(material.name() + ".specularColor")[0]
-                    spcBna[1].specularColor = self.getSFColor(spCol[0], spCol[1], spCol[2])
+                    spcBna.specularColor = self.getSFColor(spCol[0], spCol[1], spCol[2])
             
             iorBna = self.trv.processBasicNodeAddition(physMat, "extensions", "IORMaterialExtension", physMat.DEF + "_IORME")
             if iorBna:
@@ -5655,7 +5676,7 @@ class RKOrganizer():
             geomName = nodeName + suffix
             if index > 1:
                 geomName = geomName + "_" + str(index)
-                
+            
             bna = self.trv.processBasicNodeAddition(x3dParentNode, cField, nodeType, geomName)
             if bna:
                 # TODO: Future code for implementing 'attrib'

--- a/rawkee/maya/nodes/rkAnimPack.py
+++ b/rawkee/maya/nodes/rkAnimPack.py
@@ -9,6 +9,7 @@ import maya.cmds as cmds
 # authored scene, and then use the interaction editor to 
 # route X3D events within the scene.
 class RKAnimPack(aomui.MPxLocatorNode):
+#class RKAnimPack(aom.MPxNode):
     TYPE_NAME = "rkAnimPack"
     
     # This TYPE_ID was registered with Autodesk in 2024 for the 


### PR DESCRIPTION
This pull request makes significant improvements to the handling of skeleton duplication, constraints, and animation package processing in the Maya-to-X3D export workflow. The main changes include more robust and flexible node selection and processing, improved handling of skin clusters and constraints, and a refactor of how animation timing nodes are collected and exported. Debugging output and some unused or error-prone code have also been cleaned up or commented for clarity.

**Skeleton Duplication and Constraint Handling:**
- Improved selection and path handling for source and duplicate skeleton roots in `genericStep2`, ensuring correct long/short name usage and robust assignment of constraints. [[1]](diffhunk://#diff-6c6c18b65a056d36ed9384a201370cce25ff4b98eec3a21bb6ea373b1f822be3L474-R501) [[2]](diffhunk://#diff-6c6c18b65a056d36ed9384a201370cce25ff4b98eec3a21bb6ea373b1f822be3L491-R545)
- Added `removeNonJointNodes` utility to clean up non-joint descendants and unlock joint attributes, improving skeleton compliance.
- Updated `changeSkeletonRotOrder` to use full paths and more robust child handling.
- Updated constraint assignment in `genericStep4` to use direct string paths instead of Maya API objects, simplifying the process and reducing errors.

**Skin Cluster and Weight Handling:**
- Improved unbinding and rebinding of skin clusters, including safer connection breaking and better handling of parent transforms and worldspace identity.
- Updated collection of skin clusters to append all found clusters and provide debug output, improving reliability.
- Minor improvements to weight overwriting, including debug print statements.

**Animation Package Processing:**
- Refactored animation timing node (rkAnimPack) collection and export to process all found nodes at the end of export, rather than per-humanoid, and to add them directly to the end-of-file scene. [[1]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aL322-R335) [[2]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aL1507-R1554)
- Updated `processAudioClipNode`, `processMovieTextureNode`, and `processTimeSensorNode` to use the new export structure, and fixed a bug with setting the `cycleInterval` attribute. [[1]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aR1565-R1576) [[2]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aL1589-R1607) [[3]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aL1618-R1636)

**Other Improvements and Cleanups:**
- Improved traversal and parent type checking in `collectInterpolatorData` for better reliability.
- Added debug output and improved handling of mesh and timing node lists in humanoid processing.
- Cleaned up and commented out unused or experimental code sections for clarity. [[1]](diffhunk://#diff-6c6c18b65a056d36ed9384a201370cce25ff4b98eec3a21bb6ea373b1f822be3R643-R666) [[2]](diffhunk://#diff-1e559fff62491eb5b7eba7ad59e2f0288b916d4e4079cc233c0e57705bce748aL1507-R1554)

These changes collectively make the export process more robust, maintainable, and easier to debug, especially in complex character and animation setups.