### PR TITLE
Siggraph 2026 Prep - Maya 2023 thru 2027 compatiblity fixes by claude.

### DIFF
--- a/maya_rawkee_install_v2.1.0.py
+++ b/maya_rawkee_install_v2.1.0.py
@@ -1,0 +1,239 @@
+"""
+RawKee Maya Plugin Installer v2.1.0
+------------------------------------
+Drag and drop this file into the Maya viewport to install.
+
+The script will:
+  1. Detect the repo root from this file's location.
+  2. Find Maya's user modules directory for the current OS.
+  3. Write a RawKee.mod file there pointing back to the repo root.
+
+No manual path editing required. Works on Windows, macOS, and Linux.
+Restart Maya after running to load the plugin via the Plugin Manager.
+"""
+
+import os
+import sys
+
+
+def _get_repo_root():
+    """Return the absolute path to the repo root (same folder as this script)."""
+    try:
+        return os.path.dirname(os.path.abspath(__file__))
+    except NameError:
+        # __file__ is not defined in some Maya drag-and-drop contexts.
+        # Fall back to the current working directory as a best effort.
+        return os.path.abspath(os.getcwd())
+
+
+def _get_modules_dir():
+    """
+    Return the path to Maya's user modules directory.
+    Uses Maya's own API when available (most reliable cross-platform method).
+    Falls back to well-known OS-specific paths when run outside Maya.
+    """
+    try:
+        import maya.cmds as cmds
+        # internalVar(userAppDir=True) returns the Maya user directory
+        # e.g. ~/maya/ on Linux, ~/Library/Preferences/Autodesk/maya/ on macOS,
+        #      %USERPROFILE%\Documents\maya\ on Windows.
+        maya_app_dir = cmds.internalVar(userAppDir=True).rstrip("/\\")
+    except ImportError:
+        platform = sys.platform
+        if platform == "win32":
+            base = os.environ.get("USERPROFILE", os.path.expanduser("~"))
+            maya_app_dir = os.path.join(base, "Documents", "maya")
+        elif platform == "darwin":
+            maya_app_dir = os.path.expanduser(
+                "~/Library/Preferences/Autodesk/maya"
+            )
+        else:
+            # Linux
+            maya_app_dir = os.path.expanduser("~/maya")
+
+    return os.path.join(maya_app_dir, "modules")
+
+
+def _write_mod_file(modules_dir, repo_root):
+    """Write RawKee.mod into modules_dir, pointing at repo_root."""
+    # .mod files accept forward slashes on all platforms.
+    repo_root_fwd = repo_root.replace("\\", "/")
+
+    mod_content = (
+        "+ RawKee_PythonEdition_X3D 2.1.0 {root}\n"
+        "PYTHONPATH+:=.\n"
+        "MAYA_PLUG_IN_PATH+:=.\n"
+        "MAYA_SCRIPT_PATH+:=rawkee/maya/mel\n"
+    ).format(root=repo_root_fwd)
+
+    mod_path = os.path.join(modules_dir, "RawKee.mod")
+    with open(mod_path, "w") as f:
+        f.write(mod_content)
+
+    return mod_path
+
+
+def _notify(title, message):
+    """Show a Maya confirm dialog when inside Maya, otherwise just print."""
+    print(message)
+    try:
+        import maya.cmds as cmds
+        cmds.confirmDialog(title=title, message=message, button=["OK"])
+    except Exception:
+        pass
+
+
+def _find_mayapy():
+    """
+    Return the path to the mayapy executable.
+
+    When running inside Maya, sys.executable already points at mayapy.
+    Outside Maya, search common installation directories for the current OS.
+    Returns None if mayapy cannot be located.
+    """
+    import subprocess
+
+    # If we're already running inside mayapy, use the current interpreter.
+    if "mayapy" in sys.executable.lower():
+        return sys.executable
+
+    # Build a list of candidate paths from well-known Maya install locations.
+    candidates = []
+    if sys.platform == "win32":
+        for program_dir in [
+            r"C:\Program Files\Autodesk",
+            r"C:\Program Files (x86)\Autodesk",
+        ]:
+            if os.path.isdir(program_dir):
+                for entry in sorted(os.listdir(program_dir), reverse=True):
+                    if entry.lower().startswith("maya"):
+                        candidates.append(
+                            os.path.join(program_dir, entry, "bin", "mayapy.exe")
+                        )
+    elif sys.platform == "darwin":
+        for year in range(2030, 2018, -1):
+            candidates.append(
+                "/Applications/Autodesk/maya{}/Maya.app/Contents/bin/mayapy".format(year)
+            )
+    else:
+        for year in range(2030, 2018, -1):
+            candidates.append("/usr/autodesk/maya{}/bin/mayapy".format(year))
+
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+
+    # Last resort: check PATH.
+    try:
+        result = subprocess.run(
+            ["where" if sys.platform == "win32" else "which", "mayapy"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            first_line = result.stdout.strip().splitlines()[0].strip()
+            if first_line:
+                return first_line
+    except Exception:
+        pass
+
+    return None
+
+
+def _ensure_python_modules():
+    """
+    Verify that cv2, imageio.v3, ffmpeg, and PIL are importable by mayapy.
+    Any module that cannot be imported is installed via mayapy's pip.
+
+    Import names and their corresponding pip package names differ for some
+    of these distributions, so both are tracked explicitly.
+
+    Returns a dict mapping each import name to one of:
+      'ok'        – already importable
+      'installed' – was missing and installed successfully
+      'failed'    – install attempt failed
+      'no_mayapy' – mayapy could not be located
+    """
+    import subprocess
+
+    # (import_name, pip_package_name)
+    modules = [
+        ("cv2",        "opencv-python"),
+        ("imageio.v3", "imageio"),
+        ("ffmpeg",     "ffmpeg-python"),
+        ("PIL",        "Pillow"),
+    ]
+
+    mayapy = _find_mayapy()
+    if mayapy is None:
+        print("RawKee: Could not locate mayapy — skipping module checks.")
+        return {import_name: "no_mayapy" for import_name, _ in modules}
+
+    results = {}
+    for import_name, pip_package in modules:
+        # Check whether the module is already importable.
+        check = subprocess.run(
+            [mayapy, "-c", "import {}".format(import_name)],
+            capture_output=True,
+        )
+        if check.returncode == 0:
+            print("RawKee: module '{}' is already available in mayapy.".format(import_name))
+            results[import_name] = "ok"
+            continue
+
+        # Module is missing — attempt to install via pip.
+        print("RawKee: module '{}' not found — installing '{}' via mayapy pip...".format(
+            import_name, pip_package
+        ))
+        install_proc = subprocess.run(
+            [mayapy, "-m", "pip", "install", pip_package],
+            capture_output=True,
+            text=True,
+        )
+        if install_proc.returncode == 0:
+            print("RawKee: '{}' installed successfully.".format(pip_package))
+            results[import_name] = "installed"
+        else:
+            print(
+                "RawKee: Failed to install '{}'.\n{}".format(
+                    pip_package, install_proc.stderr.strip()
+                )
+            )
+            results[import_name] = "failed"
+
+    return results
+
+
+def install():
+    _ensure_python_modules()
+
+    repo_root   = _get_repo_root()
+    modules_dir = _get_modules_dir()
+
+    # Verify we're actually pointing at a RawKee repo before doing anything.
+    plugin_file = os.path.join(repo_root, "Maya_RawKee_Python_X3D.py")
+    if not os.path.isfile(plugin_file):
+        _notify(
+            "RawKee Installer — Error",
+            "Could not locate Maya_RawKee_Python_X3D.py in:\n  {}\n\n"
+            "Make sure you are running this script from inside the cloned "
+            "RawKee repository.".format(repo_root),
+        )
+        return
+
+    os.makedirs(modules_dir, exist_ok=True)
+    mod_path = _write_mod_file(modules_dir, repo_root)
+
+    _notify(
+        "RawKee Installer — Success",
+        (
+            "RawKee installation complete.\n\n"
+            "  Plugin source : {root}\n"
+            "  Module file   : {mod}\n\n"
+            "Please restart Maya, then load the plugin through:\n"
+            "  Windows > Settings/Preferences > Plug-in Manager"
+        ).format(root=repo_root, mod=mod_path),
+    )
+
+
+install()

--- a/rawkee/__init__.py
+++ b/rawkee/__init__.py
@@ -1,10 +1,25 @@
+dcc=0 # Python
+
 try:
+    import maya.cmds
+    dcc=1 #Maya
+except ImportError:
+    try:
+        import bpy
+        dcc=2 #Blender
+        from . import blender
+    except ImportError:
+        pass
+
+if   dcc == 1:
     from . import maya
     from . import editor
     from . import io
     print("Is Maya - Plugin")
-except:
+elif dcc == 2:
     from . import blender
     from . import editor
     from . import io
     print("Is Blender - AddOn")
+else:
+    print("Is neither mayapy or bpy, Plugin/AddOn - Failure to load.")

--- a/rawkee/editor/RKGraphics.py
+++ b/rawkee/editor/RKGraphics.py
@@ -5,7 +5,7 @@ try:
 
     from PySide2.QtCore    import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtGui     import *
     from PySide6.QtWidgets import *

--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -13,7 +13,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/editor/RKXContentWidget.py
+++ b/rawkee/editor/RKXContentWidget.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/editor/RKXGraphicsNode.py
+++ b/rawkee/editor/RKXGraphicsNode.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/editor/RKXGraphicsSocket.py
+++ b/rawkee/editor/RKXGraphicsSocket.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/maya/RKBindPoseEditor.py
+++ b/rawkee/maya/RKBindPoseEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -15,7 +15,7 @@ try:
     
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKCharacterAnimationClipEditor.py
+++ b/rawkee/maya/RKCharacterAnimationClipEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -14,7 +14,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKCharacterEditor.py
+++ b/rawkee/maya/RKCharacterEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -14,7 +14,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKFOptsDialog.py
+++ b/rawkee/maya/RKFOptsDialog.py
@@ -7,7 +7,7 @@ try:
     from PySide2.QtWidgets import QAction
     from PySide2.QtWidgets import QMenu
     from PySide2.QtCore    import QUrl
-    from PySide2.QtQui     import QDesktopServices
+    from PySide2.QtGui     import QDesktopServices
 
     from PySide2.QtGui     import QIntValidator, QDoubleValidator
 
@@ -15,7 +15,7 @@ try:
 
     from shiboken2         import wrapInstance
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKGraphics.py
+++ b/rawkee/maya/RKGraphics.py
@@ -5,7 +5,7 @@ try:
 
     from PySide2.QtCore    import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtGui     import *
     from PySide6.QtWidgets import *

--- a/rawkee/maya/RKHAnimHumanoidSetupEditor.py
+++ b/rawkee/maya/RKHAnimHumanoidSetupEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -14,7 +14,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKInterfaces.py
+++ b/rawkee/maya/RKInterfaces.py
@@ -25,7 +25,7 @@ import ffmpeg
 # Needed for WebP Images
 try:
     import PIL as pil
-except:
+except ImportError:
     pass
 
 import maya.api.OpenMaya as aom

--- a/rawkee/maya/RKMaterialXEditor.py
+++ b/rawkee/maya/RKMaterialXEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -15,7 +15,7 @@ try:
     
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKSceneEditor.py
+++ b/rawkee/maya/RKSceneEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -13,7 +13,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets

--- a/rawkee/maya/RKWeb3D.py
+++ b/rawkee/maya/RKWeb3D.py
@@ -26,7 +26,7 @@ try:
     from PySide2.QtWidgets import QPushButton
     from shiboken2         import wrapInstance
 
-except:
+except ImportError:
     from PySide6           import QtCore
     from PySide6           import QtWidgets
     from PySide6           import QtGui

--- a/rawkee/maya/RKXContentWidget.py
+++ b/rawkee/maya/RKXContentWidget.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/maya/RKXGraphicsNode.py
+++ b/rawkee/maya/RKXGraphicsNode.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/maya/RKXGraphicsSocket.py
+++ b/rawkee/maya/RKXGraphicsSocket.py
@@ -4,7 +4,7 @@ try:
     from PySide2.QtCore    import *
     from PySide2.QtGui     import *
 
-except:
+except ImportError:
     #Qt6
     from PySide6.QtWidgets import *
     from PySide6.QtCore    import *

--- a/rawkee/maya/RKmGearSetupEditor.py
+++ b/rawkee/maya/RKmGearSetupEditor.py
@@ -5,7 +5,7 @@ try:
     from PySide2.QtWebEngineWidgets import *
     from PySide2           import QtGui
     from PySide2.QtGui     import *
-    from PySide2           import QMenu
+    from PySide2.QtWidgets import QMenu
     from PySide2.QtWidgets import *
     from PySide2.QtWidgets import QGraphicsItem as rkgItem
     from PySide2.QtCore    import *
@@ -14,7 +14,7 @@ try:
     from shiboken2         import wrapInstance
     from shiboken2         import getCppPointer
 
-except:
+except ImportError:
     #Qt6
     from PySide6           import QtCore
     from PySide6           import QtWidgets


### PR DESCRIPTION
This pull request introduces a new, user-friendly installer script for the RawKee Maya plugin and improves cross-platform and cross-DCC (Digital Content Creation) environment compatibility throughout the codebase. Additionally, it cleans up and standardizes import statements, particularly for PySide2/PySide6 and shiboken2, to ensure better error handling and compatibility. Below are the most important changes:

**Installer and Environment Detection:**

* Added a new standalone installer script `maya_rawkee_install_v2.1.0.py` that automatically detects the RawKee repo root, finds the correct Maya modules directory for the user's OS, writes a `.mod` file to register the plugin, and ensures required Python modules are available in Maya's Python environment. This greatly simplifies installation for end users.
* Enhanced DCC environment detection in `rawkee/__init__.py` to distinguish between Maya, Blender, and plain Python, loading the appropriate modules and printing a clear message if neither environment is detected.

**Cross-Version and Cross-Platform Compatibility:**

* Standardized exception handling for PySide2/PySide6 imports across multiple files by replacing bare `except:` with explicit `except ImportError:`. This ensures only import errors are caught and improves compatibility with both PySide2 and PySide6. [[1]](diffhunk://#diff-4ca471833f8102b5ad989109ddb3d960cf020491fea7f64bc805b8d0d96b71d6L8-R8) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L8-R16) [[3]](diffhunk://#diff-8d74d7164a0e3876bc9f7d357cc3eeca9b2ebe9903184629a7db34857b135679L7-R7) [[4]](diffhunk://#diff-bf6613550ef2f2f9adf76f9fbe587ad3593368f2157ea8418c5d01247513660cL7-R7) [[5]](diffhunk://#diff-5671bbc93912dcdd25f4443d1be860f03b93aa449e5ea3a5c519d2bb997f7acfL7-R7) [[6]](diffhunk://#diff-cfe8f40e61ec2e93b29833689eaaf1002951739317715099885bd7d88dbe55feL18-R18) [[7]](diffhunk://#diff-39a22c3c3db97d1dbac4cf56b6245a9fb1c5d76258fcb3578e7ffe7ae6185aecL17-R17) [[8]](diffhunk://#diff-6c6c18b65a056d36ed9384a201370cce25ff4b98eec3a21bb6ea373b1f822be3L17-R17) [[9]](diffhunk://#diff-64c647e1de8a031a0667156cac232b39259875108e57293fb513edc457d7d2ebL17-R17) [[10]](diffhunk://#diff-4f2c8677f2ee2ee4a2d4fc9e5434b934b92a141ec2b1a7c16a155d68684967c4L18-R18) [[11]](diffhunk://#diff-596226f47d1e82d4c4f7c041849a311160c2b43969d783fa3ba0d29d679fe78eL29-R29)

**Import Statement Corrections:**

* Fixed incorrect import of `QMenu` from `PySide2` to `PySide2.QtWidgets` in several Maya editor files, ensuring compatibility with newer PySide2 versions. [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L8-R16) [[2]](diffhunk://#diff-cfe8f40e61ec2e93b29833689eaaf1002951739317715099885bd7d88dbe55feL8-R8) [[3]](diffhunk://#diff-39a22c3c3db97d1dbac4cf56b6245a9fb1c5d76258fcb3578e7ffe7ae6185aecL8-R8) [[4]](diffhunk://#diff-6c6c18b65a056d36ed9384a201370cce25ff4b98eec3a21bb6ea373b1f822be3L8-R8) [[5]](diffhunk://#diff-64c647e1de8a031a0667156cac232b39259875108e57293fb513edc457d7d2ebL8-R8) [[6]](diffhunk://#diff-4f2c8677f2ee2ee4a2d4fc9e5434b934b92a141ec2b1a7c16a155d68684967c4L8-R8)
* Corrected a typo in the import of `QDesktopServices` from `PySide2.QtQui` to `PySide2.QtGui` in `rawkee/maya/RKFOptsDialog.py`.

**General Error Handling Improvements:**

* Updated exception handling for PIL import in `rawkee/maya/RKInterfaces.py` from a bare `except:` to `except ImportError:`, improving reliability and clarity.

These changes collectively improve the ease of installation, robustness, and maintainability of the RawKee plugin across different platforms and DCC environments.