### PR TITLE
Refined Character Editor UI to support configuring mGear character fo…

### DIFF
--- a/maya_rawkee_install_v2.1.0.py
+++ b/maya_rawkee_install_v2.1.0.py
@@ -63,7 +63,7 @@ def _write_mod_file(modules_dir, repo_root):
         "+ RawKee_PythonEdition_X3D 2.1.0 {root}\n"
         "PYTHONPATH+:=.\n"
         "MAYA_PLUG_IN_PATH+:=.\n"
-        "MAYA_SCRIPT_PATH+:=rawkee/maya/mel\n"
+        "MAYA_SCRIPT_PATH+:=rawkee4maya/maya/mel\n"
     ).format(root=repo_root_fwd)
 
     mod_path = os.path.join(modules_dir, "RawKee.mod")

--- a/rawkee4maya/maya/RKCharacterEditor.py
+++ b/rawkee4maya/maya/RKCharacterEditor.py
@@ -104,7 +104,7 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         self.hanimCS  = None
         self.haNameEd = None
         self.haLOA    = None
-        self.rotCBGN  = None
+        #self.rotCBGN  = None
         self.rotCBHA  = None
         self.rotCBAS  = None
         
@@ -165,7 +165,7 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         
         self.cDupButton = None
         self.sDupIPose  = None
-        self.transToDup = None
+        #self.transToDup = None
         
         self.sAnimPack   = None
         
@@ -259,7 +259,7 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             genericGUIFile = QtCore.QFile(self.genericPath)
             genericGUIFile.open(QtCore.QFile.ReadOnly)
             self.genericSkeletonPanel = loader.load(genericGUIFile)
-        self.tab_widget.addTab(self.genericSkeletonPanel, "Generic X3D/HAnim Skeleton Functions")
+        self.tab_widget.addTab(self.genericSkeletonPanel, "Configure mGear Character for HAnim X3D Export")
 
         # antCGI Rigging Toolkit
         try:
@@ -328,13 +328,13 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         self.haNameEd = self.findChild(QtWidgets.QLineEdit,   'haNameEdit'         )
         self.haLOA    = self.findChild(QtWidgets.QComboBox,   'loaComboBox'        )
         self.rotCBAS  = self.findChild(QtWidgets.QComboBox,   'rotOrderComboBoxAS' )
-        self.rotCBGN  = self.findChild(QtWidgets.QComboBox,   'rotOrderComboBoxGN' )
+        #self.rotCBGN  = self.findChild(QtWidgets.QComboBox,   'rotOrderComboBoxGN' )
         self.rotCBHA  = self.findChild(QtWidgets.QComboBox,   'rotOrderComboBoxHA' )
         
         # Generic Skeleton - Tab
         self.cDupButton = self.findChild(QtWidgets.QPushButton, 'createDuplicate')
-        self.cDupIPose  = self.findChild(QtWidgets.QPushButton, 'setDuplicateIPose')
-        self.transToDup = self.findChild(QtWidgets.QPushButton, 'transferToDuplicate')
+        #self.cDupIPose  = self.findChild(QtWidgets.QPushButton, 'setDuplicateIPose')
+        #self.transToDup = self.findChild(QtWidgets.QPushButton, 'transferToDuplicate')
         
         # Advanced Skeleton - Tab
         adString = "AdvancedSkeleton"
@@ -409,13 +409,11 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
         
         # HAnim Joint Rotation Order
         self.rotCBAS.currentIndexChanged.connect(self.setRotOrderValue)
-        self.rotCBGN.currentIndexChanged.connect(self.setRotOrderValue)
+        #self.rotCBGN.currentIndexChanged.connect(self.setRotOrderValue)
         self.rotCBHA.currentIndexChanged.connect(self.setRotOrderValue)
         
         # Generic Skeleton - Tab
-        self.cDupButton.clicked.connect(self.genericStep2)
-        self.cDupIPose.clicked.connect(self.genericStep4)
-        self.transToDup.clicked.connect(self.genericStep5)
+        self.cDupButton.clicked.connect(self.buildHAnimHumanoidFromSkeleton)
         
         # Advanced Skeleton - Tab
         # estIPose will be == to None if Advanced Skeleton is not found.
@@ -470,63 +468,67 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
 
 
     #################################################
-    # Generic Create Duplicate Skeleton
+    # Unique Joint Name Generator
     #################################################
-    def genericStep2(self):
-        print("genericStep2")
-        # Create a duplicate skeleton
-        ##################################
-        # Create a HAnimHumanoid transform
-        ##################################
-        self.duplicateRoot = ""
-        
-        rotOrder = self.rotOrderValue
+    def _uniqueJointName(self, baseName):
+        """Return *baseName* unchanged if no scene node with that name exists,
+        otherwise append incrementing integers (baseName1, baseName2, …) until
+        a free name is found."""
+        if not cmds.objExists(baseName):
+            return baseName
+        i = 1
+        candidate = f"{baseName}{i}"
+        while cmds.objExists(candidate):
+            i += 1
+            candidate = f"{baseName}{i}"
+        return candidate
 
-        selectNames = cmds.ls(sl=True, long=False)
-        selectPaths = cmds.ls(sl=True, long=True )
-        if not selectNames:
-            print("selectNames didn't exist.")
-            return
-        sourceName      = selectNames[0]
-        self.sourceRoot = selectPaths[0]
-        print(sourceName)
-        print(self.sourceRoot)
-        
-        actualName = cmds.createNode('transform', ss=True, name='HAnimHumanoid')
-        cmds.addAttr(actualName, longName='x3dGroupType', dataType='string', keyable=False)
-        cmds.setAttr(actualName + '.x3dGroupType', "HAnimHumanoid", type='string', lock=True)
-        cmds.addAttr(actualName, longName='levelOfArticulation', shortName='LOA', attributeType='long', keyable=False, defaultValue=0, minValue=-1, maxValue=4)
-        cmds.addAttr(actualName, longName="skeletalConfiguration", dataType="string")
-        cmds.setAttr(actualName+'.skeletalConfiguration', "BASIC", type="string")
-        try:
-            stk.put(actualName,  "x3dHAnimHumanoid.png")
-        except Exception as e:
-            print(f"Exception Type: {type(e).__name__}")
-            print(f"Exception Message: {e}")                            
-            print("Oops... Node Sticker Didn't work.")
 
-        newRootName = cmds.duplicate(self.sourceRoot, rr=True, rc=False, ic=False, un=False, ilf=True, f=True)
-        
-        #self.removeNonJointNodes(newRootName[0])
-        cmds.parent(newRootName[0], actualName)
-        child = cmds.listRelatives(actualName, children=True, f=True)[0]
-        cmds.rename(child, sourceName)
+    #################################################
+    # Recursive Joint Hierarchy Builder
+    #################################################
+    def _createJointHierarchyUnderParent(self, srcJoint, parentNode, srcToDupMap):
+        """Create one new joint under *parentNode* whose local transform
+        exactly mirrors *srcJoint*, then recurse into each joint child.
 
-        self.duplicateRoot = cmds.listRelatives(actualName, children=True, f=True)[0]
-        print(self.duplicateRoot)
-        
-        self.changeSkeletonRotOrder(self.duplicateRoot, rotOrder)
-        
-        # Assign parentConstraints
-        
-        #jSel = om.MSelectionList()
-        #jSel.add(self.sourceRoot)
-        #jSel.add(self.duplicateRoot)
-        #sRoot = om.MFnDagNode(jSel.getDagPath(0))
-        #nRoot = om.MFnDagNode(jSel.getDagPath(1))
-        
-        #self.addHAnimConstraints(sRoot, nRoot)
-        
+        The new joint's short name is the source short name with a ``_ha``
+        suffix; ``_uniqueJointName`` ensures there are no collisions.
+
+        *srcToDupMap* accumulates {srcFullPath: newJointShortName} entries
+        for every joint created during the recursion."""
+        srcShortName = srcJoint.split('|')[-1]
+        newName      = self._uniqueJointName(srcShortName + '_ha')
+
+        # Read every local transform component from the source so that the
+        # new joint occupies the identical world position.
+        t   = cmds.getAttr(srcJoint + '.translate')[0]
+        r   = cmds.getAttr(srcJoint + '.rotate')[0]
+        jo  = cmds.getAttr(srcJoint + '.jointOrient')[0]
+        ra  = cmds.getAttr(srcJoint + '.rotateAxis')[0]
+        s   = cmds.getAttr(srcJoint + '.scale')[0]
+        ro  = cmds.getAttr(srcJoint + '.rotateOrder')
+        rad = cmds.getAttr(srcJoint + '.radius')
+        opm = cmds.getAttr(srcJoint + '.offsetParentMatrix')
+
+        newJoint = cmds.createNode('joint', name=newName, parent=parentNode)
+
+        cmds.setAttr(newJoint + '.translate',    t[0],  t[1],  t[2])
+        cmds.setAttr(newJoint + '.rotate',       r[0],  r[1],  r[2])
+        cmds.setAttr(newJoint + '.jointOrient', jo[0], jo[1], jo[2])
+        cmds.setAttr(newJoint + '.rotateAxis',  ra[0], ra[1], ra[2])
+        cmds.setAttr(newJoint + '.scale',        s[0],  s[1],  s[2])
+        cmds.setAttr(newJoint + '.rotateOrder', ro)
+        cmds.setAttr(newJoint + '.radius', rad)
+        cmds.setAttr(newJoint + '.offsetParentMatrix', opm, type='matrix')
+
+        srcToDupMap[srcJoint] = newJoint
+
+        children = cmds.listRelatives(srcJoint, children=True, type='joint', fullPath=True) or []
+        for child in children:
+            self._createJointHierarchyUnderParent(child, newJoint, srcToDupMap)
+
+        return newJoint
+
 
     def addHAnimConstraints(self, sLeader, nFollower):
         cmds.parentConstraint(sLeader, nFollower, mo=True, w=1)
@@ -539,56 +541,312 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
 
 
     #################################################
-    # Set Duplicate I-Pose
-    ##################################################
-    def genericStep4(self):
-        print("genericStep4")
+    # Find mGear Rig Root via Dependency Graph
+    #################################################
+    def _findMGearRoot(self, jointFullPath):
+        """Find the mGear rig root transform.
 
-        dSel = om.MSelectionList()
-        dSel.add(self.duplicateRoot)
-        dupDag = om.MFnDagNode(dSel.getDagPath(0))
-        
-        
-        # Remove Constraints
-        constraints = []
-        self.constraintRemover(dupDag, constraints)
-        for con in constraints:
-            if cmds.objExists(con):
-                cmds.delete(con)
-        constraints.clear()
-        
-        # Freeze Joints
-        cmds.makeIdentity(self.duplicateRoot, apply=True, t=True, r=True, s=True, n=False, pn=True, jo=True)
-        
-        # Transfer joint.translate values to joint.opm.translate
-        self.flipTranslateToPMO(self.duplicateRoot)
-        mJoints = cmds.listRelatives(self.duplicateRoot, ad=True, type="joint", f=True)
-        if mJoints:
-            for mJoint in mJoints:
-                self.flipTranslateToPMO(mJoint)
-        
-        # Set BindPose for Duplicate skeleton
-        if mJoints != None:
-            mJoints.append(self.duplicateRoot)
-            cmds.select(mJoints)
-            poseName = cmds.dagPose(save=True, selection=True, name="iPose")
-            cmds.addAttr(poseName, longName='x3dHAnimPose', dataType="string")
-            cmds.setAttr(poseName + ".x3dHAnimPose", "iPose", type="string")
+        Traverses the dependency graph upstream from *jointFullPath*, filtering
+        for transform nodes.  The first transform found that carries the mGear
+        'isCtl' attribute is an mGear control; walking up its DAG chain to the
+        world level yields the rig root.  Falls back to the joint's own topmost
+        DAG ancestor if no controls are reachable."""
+        sel = om.MSelectionList()
+        sel.add(jointFullPath)
+        jointObj = sel.getDependNode(0)
 
-        
-        # Assign new parentConstraints
-        #jSel = om.MSelectionList()
-        #print(self.sourceRoot)
-        #print(self.duplicateRoot)
-        #jSel.add(self.sourceRoot)
-        #jSel.add(self.duplicateRoot)
-        #sRoot = om.MFnDagNode(jSel.getDagPath(0))
-        #nRoot = om.MFnDagNode(jSel.getDagPath(1))
-        
-        #self.addHAnimConstraints(sRoot, nRoot)
-        self.addHAnimConstraints(self.sourceRoot, self.duplicateRoot)
-        
-            
+        dgIter = om.MItDependencyGraph(
+            jointObj,
+            om.MFn.kTransform,
+            om.MItDependencyGraph.kUpstream,
+            om.MItDependencyGraph.kBreadthFirst,
+            om.MItDependencyGraph.kNodeLevel
+        )
+        while not dgIter.isDone():
+            node     = dgIter.currentNode()
+            nodeName = om.MFnDependencyNode(node).name()
+            if cmds.attributeQuery('isCtl', node=nodeName, exists=True):
+                # Found a control — walk up its DAG chain looking for the mGear
+                # rig root, identified by the presence of 'is_rig' or 'gear_version'.
+                current = om.MFnDagNode(node).fullPathName()
+                while True:
+                    if (cmds.attributeQuery('is_rig',      node=current, exists=True) or
+                            cmds.attributeQuery('gear_version', node=current, exists=True)):
+                        return current
+                    parents = cmds.listRelatives(current, parent=True, fullPath=True)
+                    if not parents:
+                        break
+                    current = parents[0]
+            dgIter.next()
+
+        # Fallback: no mGear root found upstream; use the joint's top DAG ancestor.
+        print("_findMGearRoot: no mGear rig root reachable from skeleton DG; using joint's top ancestor.")
+        current = jointFullPath
+        while True:
+            parents = cmds.listRelatives(current, parent=True, fullPath=True)
+            if not parents:
+                return current
+            current = parents[0]
+
+
+    #################################################
+    # Build HAnimHumanoid Container From Existing Skeleton
+    #################################################
+    def buildHAnimHumanoidFromSkeleton(self):
+        print("buildHAnimHumanoidFromSkeleton")
+
+        selectNames = cmds.ls(sl=True, long=False)
+        selectPaths = cmds.ls(sl=True, long=True)
+        if not selectNames:
+            print("buildHAnimHumanoidFromSkeleton: nothing selected.")
+            return
+
+        self.sourceRoot = selectPaths[0]
+
+        # --- 1. Save mGear pose and reset to bind pose so the duplicate
+        #        captures bind-pose joint positions. ---
+        mgearRoot = self._findMGearRoot(self.sourceRoot)
+        charName = cmds.getAttr(f"{mgearRoot}.rig_name")
+        cmds.select(mgearRoot)
+        self.addCustomMGearCtlValues()
+
+        # --- 2. Create HAnimHumanoid container ---
+        actualName = cmds.createNode('transform', ss=True, name=f'HAnim_{charName}')
+        cmds.addAttr(actualName, longName="rkPoseCount", at="long", defaultValue=0)
+        cmds.addAttr(actualName, longName='x3dGroupType', dataType='string', keyable=False)
+        cmds.setAttr(actualName + '.x3dGroupType', "HAnimHumanoid", type='string', lock=True)
+        cmds.addAttr(actualName, longName='levelOfArticulation', shortName='LOA', attributeType='long', keyable=False, defaultValue=0, minValue=-1, maxValue=4)
+        cmds.addAttr(actualName, longName="skeletalConfiguration", dataType="string")
+        cmds.setAttr(actualName + '.skeletalConfiguration', "BASIC", type="string")
+        try:
+            stk.put(actualName, "x3dHAnimHumanoid.png")
+        except Exception as e:
+            print(f"buildHAnimHumanoidFromSkeleton: sticker failed: {e}")
+
+        # --- 3. Create a clean duplicate skeleton under HAnimHumanoid.
+        #        _createJointHierarchyUnderParent copies all TRS values but no
+        #        connections, so makeIdentity runs without fighting live rig values. ---
+        srcToDupShortMap = {}
+        self._createJointHierarchyUnderParent(self.sourceRoot, actualName, srcToDupShortMap)
+
+        dupRootList = cmds.listRelatives(actualName, children=True, type='joint', fullPath=True) or []
+        if not dupRootList:
+            print("buildHAnimHumanoidFromSkeleton: failed to create duplicate root joint.")
+            return
+        dupRoot = dupRootList[0]
+
+        # Full-path source → duplicate map used throughout the rest of the function.
+        srcToFullDupMap = {}
+        self._buildJointMap(self.sourceRoot, dupRoot, srcToFullDupMap)
+
+        # --- 4. Freeze duplicate and push translations into offsetParentMatrix ---
+        cmds.makeIdentity(dupRoot, apply=True, t=True, r=True, s=True, n=False, pn=True, jo=True)
+
+        dupJoints = [dupRoot]
+        dupDescs  = cmds.listRelatives(dupRoot, ad=True, type='joint', fullPath=True) or []
+        dupDescs.sort(key=lambda j: j.count('|'))
+        dupJoints.extend(dupDescs)
+
+        for dj in dupJoints:
+            x = cmds.getAttr(dj + '.translateX')
+            y = cmds.getAttr(dj + '.translateY')
+            z = cmds.getAttr(dj + '.translateZ')
+            cmds.setAttr(dj + '.offsetParentMatrix',
+                         [1,0,0,0, 0,1,0,0, 0,0,1,0, x,y,z,1],
+                         type='matrix')
+            cmds.setAttr(dj + '.translate',   0.0, 0.0, 0.0, type='double3')
+            cmds.setAttr(dj + '.rotateOrder', 0)
+
+        # --- 5. Add a parentConstraint from each source joint to its corresponding
+        #        duplicate joint so the duplicate skeleton follows the source rig. ---
+        for srcJoint, dupJoint in srcToFullDupMap.items():
+            try:
+                cmds.parentConstraint(srcJoint, dupJoint, mo=True, w=1)
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: parentConstraint {srcJoint} \u2192 {dupJoint}: {e}")
+        self.resetMGear(mgearRoot)
+
+        # --- 6. Parent mGear root under HAnimHumanoid ---
+        if cmds.objExists(mgearRoot):
+            result    = cmds.parent(mgearRoot, actualName)
+            mgearRoot = cmds.ls(result[0], long=True)[0]
+            #cmds.reorder(mgearRoot, front=True)
+
+        # --- 7. Collect bound meshes and save skin weights from source skeleton ---
+        skelSel = om.MSelectionList()
+        skelSel.add(self.sourceRoot)
+        srDag   = om.MFnDagNode(skelSel.getDagPath(0))
+        skins   = []
+        self.collectBoundSkins(srDag, skins)
+
+        skinClusters = []
+        for skin in skins:
+            self.collectSkinClusterFromSkin(skin, skinClusters)
+
+        # Map each source influencer to its duplicate counterpart.
+        infDagPaths = []
+        for sc in skinClusters:
+            dupPaths = []
+            for inf in (cmds.skinCluster(sc.name(), q=True, inf=True) or []):
+                try:
+                    iSel = om.MSelectionList()
+                    iSel.add(inf)
+                    srcPath = iSel.getDagPath(0).fullPathName()
+                    dupPath = srcToFullDupMap.get(srcPath)
+                    if dupPath:
+                        dSel = om.MSelectionList()
+                        dSel.add(dupPath)
+                        dupPaths.append(dSel.getDagPath(0))
+                    else:
+                        print(f"buildHAnimHumanoidFromSkeleton: no dup for influencer '{srcPath}'")
+                except Exception as e:
+                    print(f"buildHAnimHumanoidFromSkeleton: influencer '{inf}': {e}")
+            infDagPaths.append(dupPaths)
+
+        meshWeights = []
+        infLengths  = []
+        for i in range(len(skins)):
+            self.getWeightsFromSkin(skins[i], skinClusters[i], meshWeights, infLengths)
+
+        # --- 8. Unbind meshes from source skeleton ---
+        for skin in skins:
+            cmds.skinCluster(skin.name(), edit=True, unbind=True, ubk=True)
+
+        # --- 9. Rebind meshes to the duplicate skeleton ---
+        boundSkins    = []
+        boundWeights  = []
+        boundInfPaths = []
+        for i in range(len(skins)):
+            if not infDagPaths[i]:
+                print(f"buildHAnimHumanoidFromSkeleton: no dup joints for '{skins[i].name()}' — skipping")
+                continue
+            try:
+                cmds.delete(skins[i].fullPathName(), ch=True)
+                jStrings = [dp.fullPathName() for dp in infDagPaths[i]]
+                cmds.skinCluster(jStrings + [skins[i].fullPathName()], tsb=True)
+                boundSkins.append(skins[i])
+                boundWeights.append(meshWeights[i])
+                boundInfPaths.append(infDagPaths[i])
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: rebind '{skins[i].name()}': {e}")
+
+        self.overWriteWeights(boundSkins, boundWeights, boundInfPaths)
+
+        # --- 10. Remove the parentConstraints that were added to the duplicate
+        #         joints in step 6 before the mGear connections are redirected. ---
+        for dupJoint in srcToFullDupMap.values():
+            try:
+                cons = cmds.listRelatives(dupJoint, children=True,
+                                          type='parentConstraint', fullPath=True) or []
+                if cons:
+                    cmds.delete(cons)
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: delete parentConstraint on {dupJoint}: {e}")
+
+        # --- 11. Redirect mGear rig connections from source to duplicate joints.
+        #        Direct connections are rewired; constraint-based connections are
+        #        deleted from source and recreated on the duplicate with mo=True
+        #        so the offset is recalculated for the new (OPM-based) joint pose. ---
+        CONSTRAINT_TYPES = ('parentConstraint', 'orientConstraint',
+                            'pointConstraint',  'scaleConstraint')
+        TRS_ATTRS = [
+            'translate',   'translateX',   'translateY',   'translateZ',
+            'rotate',      'rotateX',      'rotateY',      'rotateZ',
+            'scale',       'scaleX',       'scaleY',       'scaleZ',
+            'jointOrient', 'jointOrientX', 'jointOrientY', 'jointOrientZ',
+            'rotateAxis',  'rotateAxisX',  'rotateAxisY',  'rotateAxisZ',
+        ]
+
+        for srcJoint, dupJoint in srcToFullDupMap.items():
+            # Rewire direct (non-constraint) incoming TRS connections.
+            try:
+                iSel    = om.MSelectionList()
+                iSel.add(srcJoint)
+                mobj    = iSel.getDependNode(0)
+                srcFull = iSel.getDagPath(0).fullPathName()
+                depFn   = om.MFnDependencyNode(mobj)
+                for attrName in TRS_ATTRS:
+                    try:
+                        attr = depFn.attribute(attrName)
+                        plug = om.MPlug(mobj, attr)
+                        if plug.isDestination:
+                            driverNode = plug.source().name().split('.')[0]
+                            if cmds.nodeType(driverNode) not in CONSTRAINT_TYPES:
+                                srcPlugName = plug.source().name()
+                                dstAttr = plug.partialName(includeNodeName=False, useLongNames=True)
+                                cmds.disconnectAttr(srcPlugName, srcFull + '.' + dstAttr)
+                                cmds.connectAttr(srcPlugName, dupJoint + '.' + dstAttr, force=True)
+                    except Exception as e:
+                        print(f"buildHAnimHumanoidFromSkeleton: redirect '{attrName}' on {srcJoint}: {e}")
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: redirect API setup {srcJoint}: {e}")
+
+            # Recreate constraint-based connections on the duplicate joint.
+            try:
+                cons = cmds.listRelatives(srcJoint, children=True,
+                                          type=list(CONSTRAINT_TYPES), fullPath=True) or []
+                for con in cons:
+                    conType = cmds.nodeType(con)
+                    try:
+                        if conType == 'parentConstraint':
+                            targets = cmds.parentConstraint(con, q=True, targetList=True) or []
+                            if targets:
+                                cmds.parentConstraint(targets, dupJoint, mo=True, w=1)
+                        elif conType == 'orientConstraint':
+                            targets = cmds.orientConstraint(con, q=True, targetList=True) or []
+                            if targets:
+                                cmds.orientConstraint(targets, dupJoint, mo=True, w=1)
+                        elif conType == 'pointConstraint':
+                            targets = cmds.pointConstraint(con, q=True, targetList=True) or []
+                            if targets:
+                                cmds.pointConstraint(targets, dupJoint, mo=True, w=1)
+                        elif conType == 'scaleConstraint':
+                            targets = cmds.scaleConstraint(con, q=True, targetList=True) or []
+                            if targets:
+                                cmds.scaleConstraint(targets, dupJoint, mo=True, w=1)
+                    except Exception as e:
+                        print(f"buildHAnimHumanoidFromSkeleton: recreate {conType} on {dupJoint}: {e}")
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: constraint redirect {srcJoint}: {e}")
+
+        # --- 12. Delete source skeleton ---
+        if cmds.objExists(self.sourceRoot):
+            cmds.delete(self.sourceRoot)
+
+        # --- 13. Rename duplicate joints to the original source short names.
+        #         Sort deepest-first so parent renames don't invalidate child paths. ---
+        renameItems = sorted(srcToFullDupMap.items(),
+                             key=lambda p: p[0].count('|'), reverse=True)
+        for srcPath, dupPath in renameItems:
+            srcShortName = srcPath.split('|')[-1]
+            try:
+                if cmds.objExists(dupPath):
+                    cmds.rename(dupPath, srcShortName)
+            except Exception as e:
+                print(f"buildHAnimHumanoidFromSkeleton: rename {dupPath} → {srcShortName}: {e}")
+
+        # Refresh duplicateRoot and sourceRoot to the renamed dup root.
+        dupRootFinal = (cmds.listRelatives(actualName, children=True, type='joint',
+                                           fullPath=True) or [None])[0]
+        self.duplicateRoot = dupRootFinal or dupRoot
+        self.sourceRoot    = self.duplicateRoot
+
+        # --- 14. Save bind pose ---
+        #finalJoints = [self.duplicateRoot]
+        #finalJoints.extend(
+        #    cmds.listRelatives(self.duplicateRoot, ad=True, type='joint', fullPath=True) or []
+        #)
+        #cmds.select(finalJoints)
+        #poseName = cmds.dagPose(save=True, selection=True, name="iPose")
+        #cmds.addAttr(poseName, longName='x3dHAnimPose', dataType="string")
+        #cmds.setAttr(poseName + ".x3dHAnimPose", "iPose", type="string")
+
+        # --- 15. Restore mGear pose ---
+        self.setMGearPose(0, root=actualName)
+
+        print("buildHAnimHumanoidFromSkeleton: complete.")
+
+
     def flipTranslateToPMO(self, nodeName):
         x = cmds.getAttr(nodeName + ".translateX")
         y = cmds.getAttr(nodeName + ".translateY")
@@ -621,125 +879,28 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
 
 
     #################################################
-    # Transfer Bound Skin to Duplicate Skeleton
+    # Build Source-to-Duplicate Joint Mapping
     ##################################################
-    def genericStep5(self):
-        print("genericStep5")
-        
-        # Collect Bound Meshes
-        skelSel = om.MSelectionList()
-        skelSel.add(self.sourceRoot)
-        srDag = om.MFnDagNode(skelSel.getDagPath(0))
-        skins = []
-        self.collectBoundSkins(srDag, skins)
-        
-        '''
-        for skin in skins:
-            scs = cmds.ls(cmds.listHistory(skin.name()), type='skinCluster')
-            if scs:
-                for sc in scs:
-                    # Use the unbindKeepHistory flag (ubk)
-                    cmds.skinCluster(scs, edit=True, unbindKeepHistory=True)
-                    
-                rels = cmds.listRelatives(skin.name(), parent=True)#, fullPath=True)
-                if rels:
-                    pv=[0, 0, 0]
-                    cmds.parent(rels[0], world=True)
-                    cmds.xform(rels[0], pivots=pv, worldSpace=True)
-                    cmds.makeIdentity(rels[0], apply=True, t=True, r=True, s=True, n=False, pn=True, jo=True)
-                    
-                cmds.select(self.duplicateRoot)
-                cmds.select(cmds.listRelatives(self.duplicateRoot, allDescendents=True, type='joint', f=True), add=True)
-                cmds.select(skin.name(), add=True)
+    def _buildJointMap(self, srcRootPath, dupRootPath, mapping):
+        """Walk the source and duplicate joint hierarchies in parallel and
+        populate *mapping* with entries of the form:
+            source_joint_full_path -> duplicate_joint_full_path
 
-                cmds.skinCluster(tsb=True)
-        
-        return
-        '''
-        
-        #Collect Skin Clusters
-        skinClusters = []
-        for skin in skins:
-            self.collectSkinClusterFromSkin(skin, skinClusters)
-        
-        #Collect lists of potential Duplicate influencer dag paths per skin cluster
-        #for future reattachement. 
-        infDagPaths = []
-        for sc in skinClusters:
-            skDags = om.MDagPathArray()
-            
-            jtSels = om.MSelectionList()
-            jtSels.add(self.duplicateRoot)
-            fullDupRootName = jtSels.getDagPath(0).fullPathName()
-            jtSels.clear()
-            
-            curInf = []
-            curInf = cmds.skinCluster(sc.name(), q=True, inf=True)
-            for tinf in curInf:
-                cons = []
-                cons = cmds.listConnections(tinf, fnn=True, type='parentConstraint')
-                if cons != None:
-                    if fullDupRootName in cons[0]:
-                        #This add the parentConstraint's DAG parent to the MSelectionList, which allows us to get the parent's DagPath later
-                        jtSels.add(cons[0].rsplit("|", 1)[0])
-            
-            for i in range(jtSels.length()):
-                skDags.append(jtSels.getDagPath(i))
-                
-            infDagPaths.append(skDags)
-                
-            #self.getAllInfluencesForSkinCluster(sc, infDagPaths)
-        
-        meshWeights = []
-        infLengths  = []
-        for i in range(len(skins)):
-            self.getWeightsFromSkin(skins[i], skinClusters[i], meshWeights, infLengths)
-        
-        #Select All Bound Meshes
-        actList = om.MSelectionList()
-        for skin in skins:
-            actList.add(skin.fullPathName())
-        om.MGlobal.setActiveSelectionList(actList)
-        
-        #Unbined Meshes
-        #cmds.DetachSkin(unbindAll=True, deleteHistroy=True)
-        
-        #Make skins identity in worldspace.
-        for skin in skins:
-            cmds.skinCluster(skin.name(), edit=True, unbind=True, ubk=True)
-            
-            rels = cmds.listRelatives(skin.name(), parent=True)#, fullPath=True)
-            ##########################################################
-            # Insert code to check if parent transform is keyed.
-            # if it is, break connections.
-            connections = cmds.listConnections(rels[0], c=True, p=True)
-            
-            if connections:
-                cLen = len(connections)
-                cIter = 0
-                while cIter < cLen:
-                    if "translate" in connections[cIter] or "rotate" in connections[cIter] or "scale" in connections[cIter]:
-                        try:
-                            cmds.disconnectAttr(connections[cIter+1], connections[cIter])
-                        except:
-                            print("disconnectAttr failed")
-                    cIter += 2
-                
-            # Format the mesh within the transform properly
-            pv=[0, 0, 0]
-            cmds.parent(rels[0], world=True)
-            cmds.xform(rels[0], pivots=pv, worldSpace=True)
-            cmds.makeIdentity(rels[0], apply=True, t=True, r=True, s=True, n=False, pn=True, jo=True)
-        
-        #Rebind Meshes to Duplicate Skeleton
-        for i in range(len(skins)):
-            cmds.delete(skins[i].fullPathName(), ch=True)
-            cmds.skinCluster(infDagPaths[i], skins[i].fullPathName(), tsb=True)
-            
-            #self.bindSkinToSpecificInfluencers(skins[i], infDagPaths[i])
-            
-        #Set Skin weights of source skeleton to new skeleton
-        self.overWriteWeights(skins, meshWeights, infDagPaths)
+        The duplicate skeleton must have been created by duplicating the source
+        skeleton (via buildHAnimHumanoidFromSkeleton), so both hierarchies are structurally
+        identical even though joint names may differ due to Maya auto-numbering
+        collisions at duplication time (e.g. ``root`` -> ``root1``)."""
+        srcSel = om.MSelectionList()
+        dupSel = om.MSelectionList()
+        srcSel.add(srcRootPath)
+        dupSel.add(dupRootPath)
+        mapping[srcSel.getDagPath(0).fullPathName()] = dupSel.getDagPath(0).fullPathName()
+
+        srcChildren = cmds.listRelatives(srcRootPath, children=True, type='joint', fullPath=True) or []
+        dupChildren = cmds.listRelatives(dupRootPath, children=True, type='joint', fullPath=True) or []
+
+        for i in range(min(len(srcChildren), len(dupChildren))):
+            self._buildJointMap(srcChildren[i], dupChildren[i], mapping)
 
 
     def overWriteWeights(self, skins, weights, infPaths):
@@ -1581,18 +1742,18 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             pivot = [0.0, 0.902462, -0.01797304]
 
             cmds.setAttr(mayaJointName + '.offsetParentMatrix', 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, pivot[0], pivot[1], pivot[2], 1.0, type='matrix')
-            cmds.setAttr(mayaJointName + '.rotateOrder', rotOrder)
+            cmds.setAttr(mayaJointName + '.rotateOrder', self.rotOrderValue)
             
         elif loaValue == 1 or loaValue == 2 or loaValue == 3 or loaValue == 4:
             isMore = True
 
         if isMore == True:
-            #self.uiPaths
+            melPath = self.uiPaths.replace('\\', '/').replace('\\', '/')
             melCmd  = 'file -import -type "mayaBinary" -ignoreVersion -ra true '
-            melCmd += '-mergeNamespacesOnClash false -namespace ' + haNodeName + ' '#"rawkeeImport" '
+            melCmd += '-mergeNamespacesOnClash false -namespace ' + haNodeName + ' '
             melCmd += '-options "v=0;" -pr -importFrameRate false -importTimeRange "keep" '
-            melCmd += '"' + self.uiPaths + 'hanimLOA' + str(loaValue) + '_HumanoidFullSkeleton.mb";'
-            
+            melCmd += '"' + melPath + 'hanimLOA' + str(loaValue) + '_HumanoidFullSkeleton.mb";'
+            print("Importing: " + melCmd)
             result = mel.eval(melCmd)
             
             tSelect = cmds.ls(haNodeName + "*:hanim_LOA" + str(loaValue))
@@ -2644,3 +2805,90 @@ class RKCharacterEditor(MayaQWidgetDockableMixin, QWidget):
             
         #myID = cmds.getAttr(nodeObj.name() + ".rkMessageId")
         #om.MMessage.removeCallback(myID)
+
+
+    ##################################
+    # Bind Pose Functions
+    ##################################
+    def addCustomMGearCtlValues(self):
+        selected = cmds.ls(sl=True, type="transform")
+        if not selected:
+            print("addCustomMGearCtlValues: no transform selected.")
+            return
+        root        = selected[0]
+        descendants = cmds.listRelatives(root, allDescendents=True, type="transform", fullPath=True) or []
+        controls    = [n for n in descendants
+                       if cmds.attributeQuery("isCtl", node=n, exists=True)]
+
+        for ctl in controls:
+            #if not cmds.attributeQuery("rkPoseCount", node=ctl, exists=True):
+            #    cmds.addAttr(ctl, longName="rkPoseCount", at="long", defaultValue=0)
+            #rkPCount = cmds.getAttr(f"{ctl}.rkPoseCount")
+            #rkPCount += 1
+            #cmds.setAttr(f"{ctl}.rkPoseCount", rkPCount)
+
+            for attr in (cmds.listAttr(ctl, keyable=True) or []):
+                try:
+                    attrValue = cmds.getAttr(f"{ctl}.{attr}")
+                    if not isinstance(attrValue, (int, float)):
+                        continue
+                    if cmds.attributeQuery(f"rkPose_{attr}_0", node=ctl, exists=True):
+                        cmds.setAttr(f"{ctl}.rkPose_{attr}_0", attrValue)
+                    else:
+                        #cmds.addAttr(ctl, longName=f"rkPose_{attr}_{rkPCount}", defaultValue=attrValue, hidden=True)
+                        cmds.addAttr(ctl, longName=f"rkPose_{attr}_0", at="double",
+                                     defaultValue=attrValue, hidden=True)
+                except Exception as e:
+                    print(f"addCustomMGearCtlValues: skipped '{ctl}.{attr}': {e}")
+
+
+    def setMGearPose(self, poseIndex, root=None):
+        if root is None:
+            selected = cmds.ls(sl=True, type="transform")
+            if not selected:
+                print("setMGearPose: no transform selected.")
+                return
+            root = selected[0]
+        descendants = cmds.listRelatives(root, allDescendents=True, type="transform", fullPath=True) or []
+        controls    = [n for n in descendants
+                       if cmds.attributeQuery("isCtl", node=n, exists=True)]
+        for ctl in controls:
+            for attr in (cmds.listAttr(ctl, keyable=True) or []):
+                try:
+                    poseAttr = f"rkPose_{attr}_{poseIndex}"
+                    if cmds.attributeQuery(poseAttr, node=ctl, exists=True):
+                        poseValue = cmds.getAttr(f"{ctl}.{poseAttr}")
+                        if isinstance(poseValue, (int, float)):
+                            cmds.setAttr(f"{ctl}.{attr}", poseValue)
+                except Exception as e:
+                    print(f"setMGearPose: skipped '{ctl}.{attr}': {e}")
+
+
+    def resetMGear(self, mgearRoot):
+        root = mgearRoot
+        if root is None:
+            print("resetMGear: no mgearRoot was provided.")
+            return
+        descendants = cmds.listRelatives(root, allDescendents=True, type="transform", fullPath=True) or []
+        controls    = [n for n in descendants
+                       if cmds.attributeQuery("isCtl", node=n, exists=True)]
+        for ctl in controls:
+            for attr in (cmds.listAttr(ctl, keyable=True) or []):
+                try:
+                    default = cmds.attributeQuery(attr, node=ctl, listDefault=True)
+                    if default is not None:
+                        cmds.setAttr(f"{ctl}.{attr}", default[0])
+                except:
+                    pass
+
+
+    def resetToBindPose(self, rootJoint):
+        if cmds.objExists(rootJoint):
+            cmds.select(rootJoint, hi=True, replace=True)
+            cmds.dagPose(load=True, bindPose=True)
+
+
+    def setBindPose(self, rootJoint):
+        if cmds.objExists(rootJoint):
+            cmds.select(rootJoint, hi=True, replace=True)
+            cmds.dagPose(save=True, bindPose=True)

--- a/rawkee4maya/maya/RKFOptsDialog.py
+++ b/rawkee4maya/maya/RKFOptsDialog.py
@@ -205,6 +205,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkSunrizePrjDir = cmds.optionVar( q='rkSunrizePrjDir')
         self.rkPrjDir        = cmds.optionVar( q='rkPrjDir'       )
 
+        self.rkHDRtoPNG      = cmds.optionVar( q='rkHDRtoPNG'     )
+        self.rkHDRbit16PNG   = cmds.optionVar( q='rkHDRbit16PNG'  )
+        self.rkHDRExposure   = cmds.optionVar( q='rkHDRExposure'  )
+        self.rkHDRSaturation = cmds.optionVar( q='rkHDRSaturation')
+        self.rkHDRContrast   = cmds.optionVar( q='rkHDRContrast'  )
+        self.rkHDRSharpenAmount = cmds.optionVar( q='rkHDRSharpenAmount' )
+        
         self.rkImagePath     = cmds.optionVar( q='rkImagePath'    )
         self.rkAudioPath     = cmds.optionVar( q='rkAudioPath'    )
 
@@ -260,6 +267,50 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkDefTexHeightLE.setValidator(thValidator)
         self.rkDefTexHeightLE.setText(str(self.rkDefTexHeight))
 
+        self.rkHDRCheckbox = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkHDRCheckBox')
+        self.rkHDRCheckbox.setChecked(self.rkHDRtoPNG)
+        
+        #self.rkHDRbit16PNG   = cmds.optionVar( q='rkHDRbit16PNG'  )
+        self.rkHDRBitRadio16 = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit16PNG')
+        self.rkHDRBitRadio8 = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit8PNG')
+        
+        if self.rkHDRbit16PNG:
+            self.rkHDRBitRadio16.setChecked(True)
+        else:
+            self.rkHDRBitRadio8.setChecked(True)
+            
+        self.rkExpLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'expText' )
+        self.rkExpSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'exposureSlider')
+        expValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkExpLETest.setValidator(expValidator)
+        self.rkExpLETest.setText(str(self.rkHDRExposure/10.0))
+        self.rkExpSlider.setValue(int(self.rkHDRExposure))
+        self.rkExpSlider.valueChanged.connect(self.setExpText)
+
+        self.rkSatLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'satText' )
+        self.rkSatSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'saturationSlider')
+        satValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkSatLETest.setValidator(satValidator)
+        self.rkSatLETest.setText(str(self.rkHDRSaturation/10.0))
+        self.rkSatSlider.setValue(int(self.rkHDRSaturation))
+        self.rkSatSlider.valueChanged.connect(self.setSatText)
+
+        self.rkConLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'conText' )
+        self.rkConSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'contrastSlider')
+        conValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkConLETest.setValidator(conValidator)
+        self.rkConLETest.setText(str(self.rkHDRContrast/10.0))
+        self.rkConSlider.setValue(int(self.rkHDRContrast))
+        self.rkConSlider.valueChanged.connect(self.setConText)
+        
+        self.rkShaLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'shaText' )
+        self.rkShaSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'sharpenSlider')
+        shaValidator = QDoubleValidator(0.0, 2.0, 1, self.expOptFrame)
+        self.rkShaLETest.setValidator(shaValidator)
+        self.rkShaLETest.setText( str(self.rkHDRSharpenAmount/10.0))
+        self.rkShaSlider.setValue(int(self.rkHDRSharpenAmount))
+        self.rkShaSlider.valueChanged.connect(self.setShaText)
+        
         self.rkConsolidateCheckbox = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkConsolidateCheckbox')
         self.rkConsolidateCheckbox.setChecked(self.rkConsolidate)
         
@@ -335,6 +386,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkDefTexWidthLE         = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'textureWidth'           )
         self.rkDefTexHeightLE        = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'textureHeight'          )
 
+        self.rkHDRBitRadio16           = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit16PNG'       )
+        self.rkHDRCheckbox           = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkHDRCheckBox'          )
+        self.rkExpSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'exposureSlider'         )
+        self.rkSatSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'saturationSlider'       )
+        self.rkConSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'contrastSlider'         )
+        self.rkShaSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'sharpenSlider'          )
+
         self.rkConsolidateCheckbox   = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkConsolidateCheckbox'  )
         self.procTextureComboBox     = self.expOptFrame.findChild(QtWidgets.QComboBox, 'procTextureComboBox'    )
         self.fileTextureComboBox     = self.expOptFrame.findChild(QtWidgets.QComboBox, 'fileTextureComboBox'    )
@@ -390,6 +448,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         cmds.optionVar( iv=('rkTextureHeight', hwi))
 
         cmds.optionVar( iv=('rkConsolidate'  , self.rkConsolidateCheckbox.isChecked()))
+        cmds.optionVar( iv=('rkHDRtoPNG'     , self.rkHDRCheckbox.isChecked()        ))
+        cmds.optionVar( iv=('rkHDRbit16PNG'  , self.rkHDRBitRadio16.isChecked()        ))
+        cmds.optionVar( iv=('rkHDRExposure'  , self.rkExpSlider.value()              ))
+        cmds.optionVar( iv=('rkHDRSaturation'  , self.rkSatSlider.value()            ))
+        cmds.optionVar( iv=('rkHDRContrast'  , self.rkConSlider.value()              ))
+        cmds.optionVar( iv=('rkHDRSharpenAmount'  , self.rkShaSlider.value()         ))
+        
         cmds.optionVar( iv=('rkProcTexType'  , self.procTextureComboBox.currentIndex()))
         cmds.optionVar( iv=('rkFileTexType'  , self.fileTextureComboBox.currentIndex()))
         cmds.optionVar( iv=('rkMovieTexType' , self.movieTextureComboBox.currentIndex()))
@@ -412,6 +477,33 @@ class RKFOptsDialog(QtWidgets.QDialog):
         cmds.optionVar( iv=('rkProcTexFormat', self.procTextureComboBox.currentIndex()))
         cmds.optionVar( iv=('rkFileTexFormat', self.consFormatComboBox.currentIndex())) #self.consFormatComboBox
 
+    def setExpText(self):
+        self.rkExpLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'expText' )
+        self.rkExpSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'exposureSlider')
+        expValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkExpLETest.setValidator(expValidator)
+        self.rkExpLETest.setText(str(self.rkExpSlider.value()/10.0))
+
+    def setSatText(self):
+        self.rkSatLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'satText' )
+        self.rkSatSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'saturationSlider')
+        satValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkSatLETest.setValidator(satValidator)
+        self.rkSatLETest.setText(str(self.rkSatSlider.value()/10.0))
+
+    def setConText(self):
+        self.rkConLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'conText' )
+        self.rkConSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'contrastSlider')
+        conValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
+        self.rkConLETest.setValidator(conValidator)
+        self.rkConLETest.setText(str(self.rkConSlider.value()/10.0))
+
+    def setShaText(self):
+        self.rkShaLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'shaText' )
+        self.rkShaSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'sharpenSlider')
+        shaValidator = QDoubleValidator(0.0, 2.0, 1, self.expOptFrame)
+        self.rkShaLETest.setValidator(shaValidator)
+        self.rkShaLETest.setText(str(self.rkShaSlider.value()/10.0))
 
     def exportX3D(self):
         if self.rkExportMode == 0:

--- a/rawkee4maya/maya/RKInterfaces.py
+++ b/rawkee4maya/maya/RKInterfaces.py
@@ -354,73 +354,58 @@ class RKInterfaces():
 
 
     #def convert_hdr_to_png16(self, hdr_path, png_path, gamma=2.2):
-    def hdri2png(self, hdr_path, png_path, gamma=2.2, bits=16, exposure=1.1, contrast=1.3, saturation=1.5, sharpen_amount=0.5):
+    def hdri2png(self, hdr_path, png_path, gamma=2.2):
         """
-        Converts a 32-bit float HDR image to a 16-bit uint PNG image 
-        with safety checks for channels and invalid numerical values.
+        Converts a 32-bit float HDR image to an 8-bit or 16-bit PNG.
+        Bit depth is determined by the rkHDRbit16PNG option variable.
         """
-        # 1. Read the HDR image (as float32)
-        # IMREAD_ANYDEPTH is critical for reading the 32-bit float data
+        isBit16        = cmds.optionVar(q='rkHDRbit16PNG')
+        exposure       = float(cmds.optionVar(q='rkHDRExposure'))      / 10.0
+        saturation     = float(cmds.optionVar(q='rkHDRSaturation'))    / 10.0
+        contrast       = float(cmds.optionVar(q='rkHDRContrast'))      / 10.0
+        sharpen_amount = float(cmds.optionVar(q='rkHDRSharpenAmount')) / 10.0
 
+        # 1. Load HDR image as float32
         hdr_image = cv2.imread(hdr_path, flags=cv2.IMREAD_ANYDEPTH | cv2.IMREAD_COLOR)
-
         if hdr_image is None:
             print(f"Error: Could not read the HDR image from {hdr_path}")
             return
 
-        # SAFETY CHECK: OpenCV tone mappers require 3-channel CV_32FC3
-        #if len(hdr_image.shape) == 2:  # Handle grayscale
-        #    hdr_image = cv2.cvtColor(hdr_image, cv2.COLOR_GRAY2BGR)
-        #elif hdr_image.shape[2] == 4:  # Handle alpha channel
-        #    hdr_image = cv2.cvtColor(hdr_image, cv2.COLOR_BGRA2BGR)
+        # Ensure 3-channel BGR float32 (required by tone mappers)
         if len(hdr_image.shape) == 2:
             hdr_image = cv2.cvtColor(hdr_image, cv2.COLOR_GRAY2BGR)
         elif hdr_image.shape[2] == 4:
             hdr_image = cv2.cvtColor(hdr_image, cv2.COLOR_BGRA2BGR)
-        
-        # Ensure data type is float32
         hdr_image = hdr_image.astype(np.float32)
 
-        # 2. Tone map to displayable range [0, 1]
-        #tonemap = cv2.createTonemap(gamma=gamma)
-        tonemap = cv2.createTonemapReinhard(gamma=gamma)
-        ldr_float = tonemap.process(hdr_image)
-        
-        ldr_float = np.clip(ldr_float * exposure, 0, 1)
-        ldr_float = np.clip(((ldr_float - 0.5) * contrast) + 0.5, 0, 1)
-        
-        # Saturation
+        # 2. Tone-map to [0, 1]
+        ldr_float = cv2.createTonemapReinhard(gamma=gamma).process(hdr_image)
+        ldr_float = np.clip(ldr_float * exposure, 0.0, 1.0)
+        ldr_float = np.clip((ldr_float - 0.5) * contrast + 0.5, 0.0, 1.0)
+
+        # 3. Saturation adjustment in HSV
         hsv = cv2.cvtColor(ldr_float, cv2.COLOR_BGR2HSV)
-        hsv[:,:,1] *= saturation
+        hsv[:, :, 1] = np.clip(hsv[:, :, 1] * saturation, 0.0, 1.0)
         ldr_float = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
-        
-        # Sharpening
-        if sharpen_amount > 0:
-            blurred = cv2.GaussianBlur(ldr_float, (0,0), 3)
+
+        # 4. Unsharp mask
+        if sharpen_amount > 0.0:
+            blurred = cv2.GaussianBlur(ldr_float, (0, 0), 3)
             ldr_float = cv2.addWeighted(ldr_float, 1.0 + sharpen_amount, blurred, -sharpen_amount, 0)
-        
-        # SAFETY CHECK: Handle NaNs/Infs and clip strictly to [0, 1] 
-        # This prevents the "invalid value encountered in cast" warning
-        ldr_float = np.nan_to_num(ldr_float, nan=0.0, posinf=1.0, neginf=0.0)
-        ldr_float = np.clip(ldr_float, 0.0, 1.0)
 
-        # 3. Scale and convert to 16-bit unsigned integer (0-65535)
-        # Using np.round ensures better precision during the conversion
-        
-        intType = np.uint16
-        intLen  = 65535
-        if bits == 8:
-            intType = np.uint8
-            intLen  = 255
-            
-        png16_image = np.round(ldr_float * intLen).astype(intType)
+        # 5. Sanitize and hard-clip
+        ldr_float = np.clip(np.nan_to_num(ldr_float, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0)
 
-        # 4. Save as 16-bit PNG
-        # OpenCV imwrite supports 16-bit PNG depth natively
-        success = cv2.imwrite(png_path, png16_image)
+        # 6. Quantize and save
+        if isBit16:
+            out_image = np.round(ldr_float * 65535.0).astype(np.uint16)
+            label = "16-bit"
+        else:
+            out_image = np.round(ldr_float * 255.0).astype(np.uint8)
+            label = "8-bit"
 
-        if success:
-            print(f"Successfully converted {hdr_path} to {png_path}")
+        if cv2.imwrite(png_path, out_image):
+            print(f"Successfully converted {hdr_path} to {png_path} ({label})")
         else:
             print(f"Error: Could not write the PNG image to {png_path}")
 

--- a/rawkee4maya/maya/RKOrganizer.py
+++ b/rawkee4maya/maya/RKOrganizer.py
@@ -253,6 +253,7 @@ class RKOrganizer():
 
         self.rkExportMtlxInfo = cmds.optionVar(q='rkExportMtlxInfo')
         self.rkMtlx2Uri       = cmds.optionVar(q='rkMtlx2Uri'      )
+        self.rkHDRtoPNG       = cmds.optionVar( q='rkHDRtoPNG'     )
         self.rkConsolidate    = cmds.optionVar(q='rkConsolidate'   )
         self.rkProcTexType    = cmds.optionVar(q='rkProcTexType'   )
         self.rkFileTexType    = cmds.optionVar(q='rkFileTexType'   )
@@ -1103,7 +1104,7 @@ class RKOrganizer():
                 fileExt  = os.path.splitext(fileName)[1]
                 fileName = os.path.splitext(fileName)[0]
                 
-                if self.rkFileTexFormat > 0:
+                if self.rkHDRtoPNG > 0:
                     fileName = fileName + ".png"
                     localTexWrite   = localTexWrite + fileName
                     self.rkint.hdri2png(filePath, localTexWrite, bits=8)
@@ -1154,7 +1155,7 @@ class RKOrganizer():
                     fileExt  = os.path.splitext(fileName)[1]
                     fileName = os.path.splitext(fileName)[0]
                     
-                    if self.rkFileTexFormat > 0:
+                    if self.rkHDRtoPNG > 0:
                         fileName = fileName + ".png"
                         localTexWrite   = localTexWrite   + fileName
                         self.rkint.hdri2png(filePath, localTexWrite)

--- a/rawkee4maya/maya/auxilary/RKCharacterEditorGenericSkeletonPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterEditorGenericSkeletonPanel.ui
@@ -68,7 +68,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Steps for making a compliant HAnim Skeleton from existing Source Skeleton.</string>
+          <string>Steps for making a compliant HAnim Skeleton from existing mGear Skeleton.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -123,7 +123,7 @@
        <item>
         <widget class="QLabel" name="genSelRootLabel">
          <property name="text">
-          <string>Select Root Joint of Source Skeleton</string>
+          <string>Manipulate the mGear Character Rig into I-Pose or desired default pose.</string>
          </property>
         </widget>
        </item>
@@ -170,68 +170,19 @@
         <widget class="QLabel" name="rotOrderLabelEX">
          <property name="minimumSize">
           <size>
-           <width>200</width>
+           <width>350</width>
            <height>24</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>200</width>
+           <width>350</width>
            <height>24</height>
           </size>
          </property>
          <property name="text">
-          <string>Choose Joint Rotation Order</string>
+          <string>Select Root Joint of the mGear Character's Skeleton</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="rotOrderComboBoxGN">
-         <property name="minimumSize">
-          <size>
-           <width>60</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>60</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>XYZ</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>YZX</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>ZXY</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>XZY</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>YXZ</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>ZYX</string>
-          </property>
-         </item>
         </widget>
        </item>
        <item>
@@ -283,18 +234,18 @@
         <widget class="QPushButton" name="createDuplicate">
          <property name="minimumSize">
           <size>
-           <width>150</width>
+           <width>180</width>
            <height>24</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>150</width>
+           <width>180</width>
            <height>24</height>
           </size>
          </property>
          <property name="text">
-          <string>Create Duplicate Skeleton</string>
+          <string>Convert to HAnimHumanoid</string>
          </property>
         </widget>
        </item>
@@ -307,189 +258,6 @@
           <size>
            <width>40</width>
            <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_10">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>40</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="genStep4">
-         <property name="minimumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Step 4:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="genSourceLabel">
-         <property name="text">
-          <string>Position Source Skeleton in an HAnim I-Pose (or other desired default pose).</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_10">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>24</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>40</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="genStep5">
-         <property name="minimumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Step 5:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="setDuplicateIPose">
-         <property name="minimumSize">
-          <size>
-           <width>120</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>120</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Set Duplicate I-Pose</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>40</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="genStep6">
-         <property name="minimumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Step 6:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="transferToDuplicate">
-         <property name="minimumSize">
-          <size>
-           <width>180</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>180</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Transfer Bound Skin to Duplicate</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>24</height>
           </size>
          </property>
         </spacer>

--- a/rawkee4maya/maya/auxilary/RKGeneralExportOptions.ui
+++ b/rawkee4maya/maya/auxilary/RKGeneralExportOptions.ui
@@ -306,14 +306,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="h2pCheckBox">
+          <widget class="QCheckBox" name="rkHDRCheckBox">
            <property name="text">
             <string>Convert to PNG Image</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QRadioButton" name="bit16">
+          <widget class="QRadioButton" name="rkHDRbit16PNG">
            <property name="minimumSize">
             <size>
              <width>60</width>
@@ -335,7 +335,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QRadioButton" name="bit8">
+          <widget class="QRadioButton" name="rkHDRbit8PNG">
            <property name="minimumSize">
             <size>
              <width>60</width>
@@ -412,6 +412,15 @@
              <height>24</height>
             </size>
            </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>30</number>
+           </property>
+           <property name="value">
+            <number>11</number>
+           </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -432,7 +441,7 @@
             </size>
            </property>
            <property name="text">
-            <string>0.0</string>
+            <string>1.1</string>
            </property>
            <property name="readOnly">
             <bool>true</bool>
@@ -472,6 +481,15 @@
              <height>24</height>
             </size>
            </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>30</number>
+           </property>
+           <property name="value">
+            <number>13</number>
+           </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -492,7 +510,7 @@
             </size>
            </property>
            <property name="text">
-            <string>0.0</string>
+            <string>1.3</string>
            </property>
           </widget>
          </item>
@@ -555,6 +573,15 @@
              <height>24</height>
             </size>
            </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>30</number>
+           </property>
+           <property name="value">
+            <number>15</number>
+           </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -575,7 +602,7 @@
             </size>
            </property>
            <property name="text">
-            <string>0.0</string>
+            <string>1.5</string>
            </property>
           </widget>
          </item>
@@ -612,6 +639,15 @@
              <height>24</height>
             </size>
            </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>20</number>
+           </property>
+           <property name="value">
+            <number>5</number>
+           </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -632,7 +668,7 @@
             </size>
            </property>
            <property name="text">
-            <string>0.0</string>
+            <string>0.5</string>
            </property>
           </widget>
          </item>

--- a/rawkee4maya/maya/mel/x3d.mel
+++ b/rawkee4maya/maya/mel/x3d.mel
@@ -261,6 +261,42 @@ global proc setDefRKOptVars()
         optionVar -iv rkConsolidate 0;
     }
     
+    //Convert HDR Files to PNG Files
+    if(`optionVar -exists "rkHDRtoPNG"`){
+    }else{
+        optionVar -iv rkHDRtoPNG 0;
+    }
+    
+    //SET Bit Level for HDR PNGs
+    if(`optionVar -exists "rkHDRbit16PNG"`){
+    }else{
+        optionVar -iv rkHDRbit16PNG 1;
+    }
+    
+    //SET Exposure for HDR PNGs
+    if(`optionVar -exists "rkHDRExposure"`){
+    }else{
+        optionVar -iv rkHDRExposure 11;
+    }
+
+    //SET Saturation for HDR PNGs
+    if(`optionVar -exists "rkHDRSaturation"`){
+    }else{
+        optionVar -iv rkHDRSaturation 15;
+    }
+
+    //SET Contrast for HDR PNGs
+    if(`optionVar -exists "rkHDRContrast"`){
+    }else{
+        optionVar -iv rkHDRContrast 13;
+    }
+
+    //SET SharpenAmount for HDR PNGs
+    if(`optionVar -exists "rkHDRSharpenAmount"`){
+    }else{
+        optionVar -iv rkHDRSharpenAmount 5;
+    }
+
     // Determines the format of Maya Proceedural Textures
     // when saved as a PNG/JPG
     // QComboBox in GUI - 0/1 Values


### PR DESCRIPTION
This pull request introduces significant improvements to HDR image export options and their integration in the RawKee Maya plugin, as well as updates to the character editor UI to better support mGear skeleton workflows. The main changes include new HDR export controls in the options dialog, enhanced image processing logic, and UI text/flow improvements.

### HDR Export Options and Pipeline Integration

**UI and Option Variables:**
* Added new HDR export controls (bit depth, exposure, saturation, contrast, sharpen) to the export options dialog, with corresponding `optionVar` entries for persistent user settings (`rawkee4maya/maya/RKFOptsDialog.py`). [[1]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R208-R214) [[2]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R270-R313) [[3]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R389-R395) [[4]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R451-R457)
* Integrated loading and saving of these new options, ensuring they are respected across sessions and used throughout the export pipeline (`rawkee4maya/maya/RKOrganizer.py`).

**Image Processing Logic:**
* Refactored `hdri2png` to dynamically use the new option variables for bit depth and tone mapping parameters, making the export process more flexible and user-driven (`rawkee4maya/maya/RKInterfaces.py`).
* Updated environment light export logic to use the new HDR-to-PNG conversion flag instead of a generic file format flag, ensuring correct format selection (`rawkee4maya/maya/RKOrganizer.py`). [[1]](diffhunk://#diff-aa2bd279bcf99a0edcf3bbe5cc5df329045fcc8028469d7c241e05d63110416dL1106-R1107) [[2]](diffhunk://#diff-aa2bd279bcf99a0edcf3bbe5cc5df329045fcc8028469d7c241e05d63110416dL1157-R1158)

### UI/UX Improvements

**Character Editor Panel:**
* Updated instructional text and workflow in the Generic Skeleton panel to focus on mGear skeletons, clarified steps, and removed the rotation order combo box for a cleaner, more specific UI (`rawkee4maya/maya/auxilary/RKCharacterEditorGenericSkeletonPanel.ui`). [[1]](diffhunk://#diff-f546ecba738e5fdfa65d30fc033c790fabf6a850064f0db31e3d6c45fad11666L71-R71) [[2]](diffhunk://#diff-f546ecba738e5fdfa65d30fc033c790fabf6a850064f0db31e3d6c45fad11666L126-R126) [[3]](diffhunk://#diff-f546ecba738e5fdfa65d30fc033c790fabf6a850064f0db31e3d6c45fad11666L173-L236)

**Other Minor Improvements**

* Updated the `.mod` file path for MEL scripts to match the new directory structure (`maya_rawkee_install_v2.1.0.py`).

These changes collectively provide users with more control over HDR image export and streamline the character skeleton editing process for mGear rigs.…r HAnim export.