### PR TITLE
Added support for extreme dynamic range lighting hdr/exr conversion -…

### DIFF
--- a/rawkee4maya/maya/RKFOptsDialog.py
+++ b/rawkee4maya/maya/RKFOptsDialog.py
@@ -58,8 +58,9 @@ class RKFOptsDialog(QtWidgets.QDialog):
         
         self.dialogTitle = dialogTitle
         self.setWindowTitle(self.dialogTitle)
-        self.setMinimumSize(600,400)
-        self.setFixedWidth(800)
+        self._dpi = QtWidgets.QApplication.primaryScreen().logicalDotsPerInch() / 96.0
+        self.setMinimumSize(int(600 * self._dpi), int(400 * self._dpi))
+        self.setMinimumWidth(int(800 * self._dpi))
         
         # On macOS make the window a Tool to keep it on top of Maya
         if sys.platform == "darwin":
@@ -94,7 +95,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkPrjDirButton = self.expOptFrame.findChild(QtWidgets.QPushButton, 'rkPrjDirButton')
         self.rkPrjDirButton.setIcon(QtGui.QIcon(":folder-open.png"))
         self.rkPrjDirButton.setContentsMargins(0,0,0,0)
-        self.rkPrjDirButton.setFixedSize(20,20)
+        self.rkPrjDirButton.setFixedSize(int(20 * self._dpi), int(20 * self._dpi))
         self.rkPrjDirButton.clicked.connect(self.setProjectFolder)
         
         
@@ -104,9 +105,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
             dialogLayout.addWidget(scrollArea)
             
             buttonRow = QtWidgets.QHBoxLayout()
-            self.buttonSpace = QtWidgets.QLabel(" ")
-            self.buttonSpace.setFixedWidth(400)
-            self.buttonSpace.setAlignment(QtCore.Qt.AlignRight)
             
             self.cancelButton = QtWidgets.QPushButton("Save Options and Close")
             self.cancelButton.setObjectName("RKOptPanel")
@@ -116,7 +114,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
             self.exportButton.setObjectName("RKOptPanel")
             self.exportButton.clicked.connect(self.saveOptionsExportX3D)
             
-            buttonRow.addWidget(self.buttonSpace)
+            buttonRow.addStretch()
             buttonRow.addWidget(self.cancelButton)
             buttonRow.addWidget(self.exportButton)
             dialogLayout.addLayout(buttonRow)
@@ -128,9 +126,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
             dialogLayout.addWidget(scrollArea)
             
             buttonRow = QtWidgets.QHBoxLayout()
-            self.buttonSpace = QtWidgets.QLabel(" ")
-            self.buttonSpace.setFixedWidth(400)
-            self.buttonSpace.setAlignment(QtCore.Qt.AlignRight)
 
             self.cancelButton = QtWidgets.QPushButton("Save Options and Close")
             self.cancelButton.setObjectName("RKOptPanel")
@@ -140,7 +135,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
             self.exportButton.setObjectName("RKOptPanel")
             self.exportButton.clicked.connect(self.saveOptionsExportX3D)
             
-            buttonRow.addWidget(self.buttonSpace)
+            buttonRow.addStretch()
             buttonRow.addWidget(self.cancelButton)
             buttonRow.addWidget(self.exportButton)
             dialogLayout.addLayout(buttonRow)
@@ -154,9 +149,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
             dialogLayout.addWidget(scrollArea)
             
             buttonRow = QtWidgets.QHBoxLayout()
-            self.buttonSpace = QtWidgets.QLabel(" ")
-            self.buttonSpace.setFixedWidth(400)
-            self.buttonSpace.setAlignment(QtCore.Qt.AlignRight)
 
             self.cancelButton = QtWidgets.QPushButton("Save Options and Close")
             self.cancelButton.setObjectName("RKOptPanel")
@@ -166,7 +158,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
             self.exportButton.setObjectName("RKOptPanel")
             self.exportButton.clicked.connect(self.saveOptionsExportX3D)
             
-            buttonRow.addWidget(self.buttonSpace)
+            buttonRow.addStretch()
             buttonRow.addWidget(self.cancelButton)
             buttonRow.addWidget(self.exportButton)
             dialogLayout.addLayout(buttonRow)
@@ -178,9 +170,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
             dialogLayout.addWidget(scrollArea)
             
             buttonRow = QtWidgets.QHBoxLayout()
-            self.buttonSpace = QtWidgets.QLabel(" ")
-            self.buttonSpace.setFixedWidth(400)
-            self.buttonSpace.setAlignment(QtCore.Qt.AlignRight)
 
             self.cancelButton = QtWidgets.QPushButton("Save Options and Close")
             self.cancelButton.setObjectName("RKOptPanel")
@@ -190,7 +179,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
             self.exportButton.setObjectName("RKOptPanel")
             self.exportButton.clicked.connect(self.saveOptionsExportX3D)
             
-            buttonRow.addWidget(self.buttonSpace)
+            buttonRow.addStretch()
             buttonRow.addWidget(self.cancelButton)
             buttonRow.addWidget(self.exportButton)
             dialogLayout.addLayout(buttonRow)
@@ -207,6 +196,7 @@ class RKFOptsDialog(QtWidgets.QDialog):
 
         self.rkConvertHDRI        = cmds.optionVar( q='rkConvertHDRI'       )
         self.rkMaxCubeMapFaceSize = cmds.optionVar( q='rkMaxCubeMapFaceSize')
+        self.rkUseExtreme32BitCubeMap    = cmds.optionVar( q='rkUseExtreme32BitCubeMap'   )
         
         self.rkImagePath     = cmds.optionVar( q='rkImagePath'    )
         self.rkAudioPath     = cmds.optionVar( q='rkAudioPath'    )
@@ -266,51 +256,13 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkHDRCheckbox = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkHDRCheckBox')
         self.rkHDRCheckbox.setChecked(self.rkConvertHDRI)
 
+        self.rkEDRCheckbox = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'extremeDynamicRange')
+        self.rkEDRCheckbox.setChecked(self.rkUseExtreme32BitCubeMap)
+
         self.rkMaxFaceSize = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'cubeTextureSize')
-        faceIntValidator = QIntValidator(1, 2048, self.expOptFrame)
+        faceIntValidator = QIntValidator(1, 4096, self.expOptFrame)
         self.rkMaxFaceSize.setValidator(faceIntValidator)
         self.rkMaxFaceSize.setText(str(self.rkMaxCubeMapFaceSize))
-        
-        #self.rkHDRbit16PNG   = cmds.optionVar( q='rkHDRbit16PNG'  )
-        #self.rkHDRBitRadio16 = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit16PNG')
-        #self.rkHDRBitRadio8 = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit8PNG')
-        
-        #if self.rkHDRbit16PNG:
-        #    self.rkHDRBitRadio16.setChecked(True)
-        #else:
-        #    self.rkHDRBitRadio8.setChecked(True)
-            
-        #self.rkExpLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'expText' )
-        #self.rkExpSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'exposureSlider')
-        #expValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        #self.rkExpLETest.setValidator(expValidator)
-        #self.rkExpLETest.setText(str(self.rkHDRExposure/10.0))
-        #self.rkExpSlider.setValue(int(self.rkHDRExposure))
-        #self.rkExpSlider.valueChanged.connect(self.setExpText)
-
-        #self.rkSatLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'satText' )
-        #self.rkSatSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'saturationSlider')
-        #satValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        #self.rkSatLETest.setValidator(satValidator)
-        #self.rkSatLETest.setText(str(self.rkHDRSaturation/10.0))
-        #self.rkSatSlider.setValue(int(self.rkHDRSaturation))
-        #self.rkSatSlider.valueChanged.connect(self.setSatText)
-
-        #self.rkConLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'conText' )
-        #self.rkConSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'contrastSlider')
-        #conValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        #self.rkConLETest.setValidator(conValidator)
-        #self.rkConLETest.setText(str(self.rkHDRContrast/10.0))
-        #self.rkConSlider.setValue(int(self.rkHDRContrast))
-        #self.rkConSlider.valueChanged.connect(self.setConText)
-        
-        #self.rkShaLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'shaText' )
-        #self.rkShaSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'sharpenSlider')
-        #shaValidator = QDoubleValidator(0.0, 2.0, 1, self.expOptFrame)
-        #self.rkShaLETest.setValidator(shaValidator)
-        #self.rkShaLETest.setText( str(self.rkHDRSharpenAmount/10.0))
-        #self.rkShaSlider.setValue(int(self.rkHDRSharpenAmount))
-        #self.rkShaSlider.valueChanged.connect(self.setShaText)
         
         self.rkConsolidateCheckbox = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkConsolidateCheckbox')
         self.rkConsolidateCheckbox.setChecked(self.rkConsolidate)
@@ -345,7 +297,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.colorOptions.setCurrentIndex(self.rkColorOpts)
 
 
-        
     def setProjectFolder(self):
         print("Set Project Folder")
         
@@ -387,12 +338,8 @@ class RKFOptsDialog(QtWidgets.QDialog):
         self.rkDefTexWidthLE         = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'textureWidth'           )
         self.rkDefTexHeightLE        = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'textureHeight'          )
 
-        #self.rkHDRBitRadio16           = self.expOptFrame.findChild(QtWidgets.QRadioButton, 'rkHDRbit16PNG'       )
         self.rkHDRCheckbox           = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkHDRCheckBox'          )
-        #self.rkExpSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'exposureSlider'         )
-        #self.rkSatSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'saturationSlider'       )
-        #self.rkConSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'contrastSlider'         )
-        #self.rkShaSlider             = self.expOptFrame.findChild(QtWidgets.QSlider,   'sharpenSlider'          )
+        self.rkEDRCheckbox           = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'extremeDynamicRange'    )
 
         self.rkConsolidateCheckbox   = self.expOptFrame.findChild(QtWidgets.QCheckBox, 'rkConsolidateCheckbox'  )
         self.procTextureComboBox     = self.expOptFrame.findChild(QtWidgets.QComboBox, 'procTextureComboBox'    )
@@ -449,7 +396,8 @@ class RKFOptsDialog(QtWidgets.QDialog):
         cmds.optionVar( iv=('rkTextureHeight', hwi))
 
         cmds.optionVar( iv=('rkConsolidate'  , self.rkConsolidateCheckbox.isChecked()))
-        cmds.optionVar( iv=('rkConvertHDRI'     , self.rkHDRCheckbox.isChecked()        ))
+        cmds.optionVar( iv=('rkConvertHDRI'     , self.rkHDRCheckbox.isChecked()     ))
+        cmds.optionVar( iv=('rkUseExtreme32BitCubeMap' , self.rkEDRCheckbox.isChecked()     ))
         cmds.optionVar( iv=('rkMaxCubeMapFaceSize', int(self.rkMaxFaceSize.text())))
         cmds.optionVar( iv=('rkProcTexType'  , self.procTextureComboBox.currentIndex()))
         cmds.optionVar( iv=('rkFileTexType'  , self.fileTextureComboBox.currentIndex()))
@@ -473,34 +421,6 @@ class RKFOptsDialog(QtWidgets.QDialog):
         cmds.optionVar( iv=('rkProcTexFormat', self.procTextureComboBox.currentIndex()))
         cmds.optionVar( iv=('rkFileTexFormat', self.consFormatComboBox.currentIndex())) #self.consFormatComboBox
 
-
-    def setExpText(self):
-        self.rkExpLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'expText' )
-        self.rkExpSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'exposureSlider')
-        expValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        self.rkExpLETest.setValidator(expValidator)
-        self.rkExpLETest.setText(str(self.rkExpSlider.value()/10.0))
-
-    def setSatText(self):
-        self.rkSatLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'satText' )
-        self.rkSatSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'saturationSlider')
-        satValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        self.rkSatLETest.setValidator(satValidator)
-        self.rkSatLETest.setText(str(self.rkSatSlider.value()/10.0))
-
-    def setConText(self):
-        self.rkConLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'conText' )
-        self.rkConSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'contrastSlider')
-        conValidator = QDoubleValidator(0.0, 3.0, 1, self.expOptFrame)
-        self.rkConLETest.setValidator(conValidator)
-        self.rkConLETest.setText(str(self.rkConSlider.value()/10.0))
-
-    def setShaText(self):
-        self.rkShaLETest = self.expOptFrame.findChild(QtWidgets.QLineEdit, 'shaText' )
-        self.rkShaSlider = self.expOptFrame.findChild(QtWidgets.QSlider, 'sharpenSlider')
-        shaValidator = QDoubleValidator(0.0, 2.0, 1, self.expOptFrame)
-        self.rkShaLETest.setValidator(shaValidator)
-        self.rkShaLETest.setText(str(self.rkShaSlider.value()/10.0))
 
     def exportX3D(self):
         if self.rkExportMode == 0:

--- a/rawkee4maya/maya/RKInterfaces.py
+++ b/rawkee4maya/maya/RKInterfaces.py
@@ -353,75 +353,20 @@ class RKInterfaces():
 #        iio.imwrite(outputPath, hdri16bit, extension='.png')
 
 
-    def _hdri_equirect_to_faces(self, eq_img, face_size):
-        """
-        Convert an equirectangular (panoramic) HDR image to 6 cubemap face images.
-        Returns a list of 6 float32 arrays, each (face_size, face_size, C).
-        Face order follows the Vulkan/KTX2 standard: +X, -X, +Y, -Y, +Z, -Z.
-        Bilinear interpolation via scipy.ndimage.map_coordinates.
-        Longitude wraps correctly (mode='wrap') for seamless east-west edges.
-        """
-        from scipy.ndimage import map_coordinates
-
-        h, w, C = eq_img.shape
-
-        # Normalised grid for one face: s = horizontal [-1,1], t = vertical [-1,1 downward]
-        s_vals = (np.arange(face_size, dtype=np.float32) + 0.5) / face_size * 2.0 - 1.0
-        t_vals = (np.arange(face_size, dtype=np.float32) + 0.5) / face_size * 2.0 - 1.0
-        s_grid, t_grid = np.meshgrid(s_vals, t_vals)   # (face_size, face_size)
-        one = np.ones_like(s_grid)
-
-        # Direction vectors per face (Vulkan cubemap convention, right-handed +Y up)
-        # s increases left→right, t increases top→bottom
-        face_vecs = [
-            np.stack([ one,    -t_grid, -s_grid], axis=-1),  # +X
-            np.stack([-one,    -t_grid,  s_grid], axis=-1),  # -X
-            np.stack([ s_grid,  one,     t_grid], axis=-1),  # +Y
-            np.stack([ s_grid, -one,    -t_grid], axis=-1),  # -Y
-            np.stack([ s_grid, -t_grid,  one],    axis=-1),  # +Z
-            np.stack([-s_grid, -t_grid, -one],    axis=-1),  # -Z
-        ]
-
-        faces = []
-        for vecs in face_vecs:
-            norms = np.sqrt((vecs ** 2).sum(axis=-1, keepdims=True))
-            vecs  = vecs / norms
-            x, y, z = vecs[..., 0], vecs[..., 1], vecs[..., 2]
-
-            # Equirectangular UV: longitude φ = atan2(x, -z) maps -Z→u=0.5 (front),
-            # +X→u=0.75 (right), matching the standard Maya/X3D -Z-forward convention.
-            lon = np.arctan2(x, -z)                  # [-π, π]
-            lat = np.arcsin(np.clip(y, -1.0, 1.0))   # [-π/2, π/2]
-            u   = (lon + np.pi) / (2.0 * np.pi)      # [0, 1]  left=0, right=1
-            v   = 0.5 - lat / np.pi                   # [0, 1]  top=0 (+Y), bottom=1 (-Y)
-
-            px = (u * w - 0.5).ravel()
-            py = (v * h - 0.5).ravel()
-
-            face = np.empty((face_size, face_size, C), dtype=np.float32)
-            for c in range(C):
-                face[..., c] = map_coordinates(
-                    eq_img[..., c], [py, px],
-                    order=1, mode='wrap', cval=0.0
-                ).reshape(face_size, face_size)
-
-            face = np.clip(np.nan_to_num(face, nan=0.0, posinf=65504.0, neginf=0.0),
-                           0.0, 65504.0)
-            faces.append(face)
-
-        return faces
-
-
-    def hdri2ktx2(self, hdr_path, ktx2_path, isEXR=False, maxFaceSize=2048):
+    def hdri2ktx2(self, hdr_path, ktx2_path, isEXR=False, maxFaceSize=4096, use32=False, autoExpose=True):
         """Converts an equirectangular HDRI to a KTX2 TEXTURE_CUBE_MAP (faceCount=6).
 
-        Output is VK_FORMAT_R16G16B16A16_SFLOAT, full mip chain, HDR preserved.
+        Output is VK_FORMAT_R16G16B16A16_SFLOAT (use32=False) or VK_FORMAT_R32G32B32A32_SFLOAT (use32=True).
+        autoExpose=True normalizes exposure via log-average luminance and clips at the 99.9th percentile.
+        autoExpose is ignored when use32=True (full range is preserved for renderer-side exposure).
         Face order follows Vulkan spec: +X(0) -X(1) +Y(2) -Y(3) +Z(4) -Z(5).
         Face size is auto-determined as input_width/4 rounded to nearest power of 2, capped at maxFaceSize.
         """
         import struct
         from scipy.ndimage import map_coordinates
 
+        # Static constants: face basis vectors, KTX2 magic identifier, and DFD block size.
+        # Each face entry is (label, forward, right, up) unit vectors in right-handed Y-up space.
         # Vulkan cubemap face order: +X(0) -X(1) +Y(2) -Y(3) +Z(4) -Z(5)
         _FACES = [
             ('+X', ( 1,  0,  0), ( 0,  0, -1), ( 0,  1,  0)),
@@ -431,8 +376,8 @@ class RKInterfaces():
             ('+Z', ( 0,  0,  1), ( 1,  0,  0), ( 0,  1,  0)),
             ('-Z', ( 0,  0, -1), (-1,  0,  0), ( 0,  1,  0)),
         ]
-        _KTX2_ID  = bytes([0xAB,0x4B,0x54,0x58,0x20,0x32,0x30,0xBB,0x0D,0x0A,0x1A,0x0A])
-        _DFD_SIZE = 92
+        _KTX2_ID  = bytes([0xAB,0x4B,0x54,0x58,0x20,0x32,0x30,0xBB,0x0D,0x0A,0x1A,0x0A])  # KTX2 file-identifier magic bytes
+        _DFD_SIZE = 92  # fixed size: 4-byte total + 88-byte descriptor block (4 channel samples × 16 bytes each)
 
         # 1. Load equirectangular HDR/EXR (RGB float32)
         if isEXR:
@@ -449,13 +394,20 @@ class RKInterfaces():
             hdr = np.stack([hdr, hdr, hdr], axis=-1)
         elif hdr.shape[2] != 3:  # strip alpha and any extra EXR AOV channels
             hdr = hdr[:, :, :3]
-        hdr = np.clip(np.nan_to_num(hdr, nan=0.0, posinf=65504.0, neginf=0.0), 0.0, 65504.0)
+        _clip_max = np.finfo(np.float32).max if use32 else 65504.0
+        hdr = np.clip(np.nan_to_num(hdr, nan=0.0, posinf=_clip_max, neginf=0.0), 0.0, _clip_max)
         H, W = hdr.shape[:2]
 
-        # Scale to mid-grey key (~0.18), then clip at 5.0 to prevent overexposure
-        lum    = 0.2126*hdr[:,:,0] + 0.7152*hdr[:,:,1] + 0.0722*hdr[:,:,2]
-        lw_bar = float(np.exp(np.mean(np.log(lum + 1e-6))))
-        hdr    = np.clip(hdr * (0.18 / max(lw_bar, 1e-6)), 0.0, 5.0)
+        # Auto-exposure: log-average key normalization + 99.9th-percentile white point
+        if autoExpose and not use32:
+            lum    = 0.2126*hdr[:,:,0] + 0.7152*hdr[:,:,1] + 0.0722*hdr[:,:,2]
+            lw_bar = float(np.exp(np.mean(np.log(np.maximum(lum, 1e-6)))))
+            scale  = 0.18 / max(lw_bar, 1e-6)
+            hdr    = hdr * scale
+            white_pt = float(np.percentile(hdr, 99.9))
+            hdr    = np.clip(hdr, 0.0, white_pt)
+            _clip_max = white_pt
+            print(f"  auto-expose: scale={scale:.4f}  white_pt={white_pt:.4f}")
 
         # Auto-determine face size: width/4 rounded to nearest power of 2, then cap at maxFaceSize
         ideal = W / 4
@@ -468,7 +420,9 @@ class RKInterfaces():
             TILE //= 2
         print(f"  source: {W}x{H}  →  face: {TILE}x{TILE}")
 
-        # 2. Build coordinate grids — computed once, shared across all faces
+        # 2. Build coordinate grids — computed once, shared across all faces.
+        # s and t are NDC coordinates in [-1, 1] with pixel-center sampling (texel offset of 0.5).
+        # s increases left-to-right (along the face's right axis), t increases bottom-to-top (along up).
         idx = np.arange(TILE, dtype=np.float32)
         px_grid, py_grid = np.meshgrid(idx, idx)
         s = (2.0 * px_grid + 1.0) / TILE - 1.0
@@ -481,12 +435,15 @@ class RKInterfaces():
             rgt = np.array(rgt_t, dtype=np.float32)
             upd = np.array(upd_t, dtype=np.float32)
 
+            # Reconstruct the world-space 3D direction for each texel by combining the face
+            # forward vector with scaled right and up offsets, then normalize to unit sphere.
             x = fwd[0] + s * rgt[0] + t * upd[0]
             y = fwd[1] + s * rgt[1] + t * upd[1]
             z = fwd[2] + s * rgt[2] + t * upd[2]
             r = np.sqrt(x*x + y*y + z*z)
             x /= r;  y /= r;  z /= r
 
+            # Project unit-sphere direction to equirectangular (lon/lat) UV coordinates.
             lon = np.arctan2(x, -z)
             lat = np.arcsin(np.clip(y, -1.0, 1.0))
             u_eq = (lon + np.pi) / (2.0 * np.pi)
@@ -503,11 +460,13 @@ class RKInterfaces():
                 ).reshape(TILE, TILE)
 
             face_arrays.append(np.clip(
-                np.nan_to_num(face, nan=0.0, posinf=5.0, neginf=0.0), 0.0, 5.0
+                np.nan_to_num(face, nan=0.0, posinf=_clip_max, neginf=0.0), 0.0, _clip_max
             ))
             print(f"  face {label:3s}  sampled")
 
-        # 4. Generate mip chain for each face (box filter in float32 linear space)
+        # 4. Generate mip chain for each face (box filter in float32 linear space).
+        # Each level halves both dimensions; the reshape groups 2×2 pixel blocks so mean(axis=(1,3))
+        # averages them in a single vectorized op. Filtering is done in linear light (no gamma).
         def make_mip_chain(f32):
             mips = [f32]
             while max(mips[-1].shape[:2]) > 1:
@@ -523,14 +482,18 @@ class RKInterfaces():
         mip_chains = [make_mip_chain(f) for f in face_arrays]
         num_levels = len(mip_chains[0])
 
-        # 5. Compute KTX2 file layout
+        # 5. Compute KTX2 file layout: header + level index + DFD + 8-byte-aligned padding + pixel data.
+        # KTX2 requires pixel data to start on an 8-byte boundary; pad_bytes bridges any gap.
         LEVEL_IDX_SIZE = num_levels * 24
         HEADER_END     = 80 + LEVEL_IDX_SIZE + _DFD_SIZE
         pad_bytes      = (8 - HEADER_END % 8) % 8
         PIXEL_OFFSET   = HEADER_END + pad_bytes
 
-        level_byte_sizes = [6 * max(1, TILE >> lvl)**2 * 8 for lvl in range(num_levels)]
+        # Each level stores all 6 faces; RGBA adds one extra channel beyond the source RGB.
+        _bytes_per_pixel = 16 if use32 else 8
+        level_byte_sizes = [6 * max(1, TILE >> lvl)**2 * _bytes_per_pixel for lvl in range(num_levels)]
 
+        # KTX2 stores mip levels from smallest (N-1) to largest (0) in the file; accumulate offsets in that order.
         level_file_offsets = {}
         cum = 0
         for lvl in range(num_levels - 1, -1, -1):
@@ -539,8 +502,8 @@ class RKInterfaces():
 
         # 6. KTX2 header (80 bytes)
         hdr_bytes = _KTX2_ID
-        hdr_bytes += struct.pack('<I', 97)                    # VK_FORMAT_R16G16B16A16_SFLOAT
-        hdr_bytes += struct.pack('<I', 2)                     # typeSize: 2 bytes/component
+        hdr_bytes += struct.pack('<I', 109 if use32 else 97)   # VK_FORMAT_R32G32B32A32_SFLOAT or R16G16B16A16_SFLOAT
+        hdr_bytes += struct.pack('<I', 4 if use32 else 2)        # typeSize: bytes/component
         hdr_bytes += struct.pack('<I', TILE)                  # pixelWidth
         hdr_bytes += struct.pack('<I', TILE)                  # pixelHeight
         hdr_bytes += struct.pack('<I', 0)                     # pixelDepth: 0 for 2D
@@ -562,29 +525,35 @@ class RKInterfaces():
             level_idx += struct.pack('<Q', level_byte_sizes[lvl])
             level_idx += struct.pack('<Q', level_byte_sizes[lvl])
 
-        # 8. DFD (92 bytes) — matches verified reference file
+        # 8. Data Format Descriptor (DFD): describes the per-texel channel layout so Vulkan/KTX
+        # loaders know the bit widths, signedness, and color model without inspecting pixel data.
         dfd = struct.pack('<I', _DFD_SIZE)                   # dfdTotalSize
         dfd += struct.pack('<I', 0)                           # vendorId=0, descriptorType=0
         dfd += struct.pack('<I', (88 << 16) | 2)             # descriptorBlockSize=88, versionNumber=2
         dfd += struct.pack('<I', (1 << 16) | (1 << 8) | 1)  # RGBSDA, BT709, LINEAR, flags=0
         dfd += struct.pack('<I', 0)                           # texelBlockDimensions
-        dfd += bytes([8, 0, 0, 0, 0, 0, 0, 0])              # bytesPlane: plane0=8
-        for bit_off, ch_id in [(0, 0), (16, 1), (32, 2), (48, 15)]:  # ch_id 15 = KHR alpha
+        dfd += bytes([16 if use32 else 8, 0, 0, 0, 0, 0, 0, 0])  # bytesPlane: plane0
+        _bit_len = 31 if use32 else 15                           # bitLength = bits-per-channel minus 1
+        _stride  = 2 if use32 else 1
+        for bit_off, ch_id in [(0*_stride, 0), (16*_stride, 1), (32*_stride, 2), (48*_stride, 15)]:
             dfd += struct.pack('<H', bit_off)
-            dfd += struct.pack('<B', 15)                      # bitLength = 16-1
+            dfd += struct.pack('<B', _bit_len)
             dfd += struct.pack('<B', ch_id | 0xC0)           # FLOAT|SIGNED, no extra flags
             dfd += bytes(4)                                   # samplePosition[4]
             dfd += struct.pack('<I', 0xBF800000)              # sampleLower: float32(-1.0)
             dfd += struct.pack('<I', 0x3F800000)              # sampleUpper: float32(+1.0)
 
-        # 9. Pixel data (level N-1 first → level 0 last, per KTX2 spec)
+        # 9. Pixel data (level N-1 first → level 0 last, per KTX2 spec).
+        # Within each level the 6 faces are interleaved in Vulkan order (+X … -Z).
+        # A constant alpha=1.0 channel is appended so the output format is RGBA (required by the VK_FORMAT).
+        _pix_dtype = np.float32 if use32 else np.float16
         pixel_data = bytearray()
         for lvl in range(num_levels - 1, -1, -1):
             for face_mips in mip_chains:
                 mip = face_mips[lvl]
-                rgb16 = mip.astype(np.float16)
-                alpha = np.full((*mip.shape[:2], 1), np.float16(1.0), dtype=np.float16)
-                pixel_data += np.concatenate([rgb16, alpha], axis=-1).tobytes()
+                rgb = mip.astype(_pix_dtype)
+                alpha = np.ones((*mip.shape[:2], 1), dtype=_pix_dtype)
+                pixel_data += np.concatenate([rgb, alpha], axis=-1).tobytes()
 
         # 10. Write file
         try:
@@ -595,8 +564,9 @@ class RKInterfaces():
                 f.write(dfd)
                 f.write(bytes(pad_bytes))
                 f.write(bytes(pixel_data))
+            fmt_label = 'R32G32B32A32_SFLOAT' if use32 else 'R16G16B16A16_SFLOAT'
             print(f"Saved {ktx2_path}  ({TILE}x{TILE} faces × 6, {num_levels} mip levels, "
-                  f"{total_mb:.1f} MB, R16G16B16A16_SFLOAT TEXTURE_CUBE_MAP)")
+                  f"{total_mb:.1f} MB, {fmt_label} TEXTURE_CUBE_MAP)")
         except Exception as e:
             print(f"Error: Could not write KTX2 file to {ktx2_path}: {e}")
 

--- a/rawkee4maya/maya/RKMaterialXEditor.py
+++ b/rawkee4maya/maya/RKMaterialXEditor.py
@@ -61,8 +61,8 @@ class RKMaterialXEditor(MayaQWidgetDockableMixin, QWidget):
 
         self.setObjectName(self.OBJECT_NAME)
         self.setWindowTitle("MaterialXSurfaceShader Export Type Editor")
-        self.setMinimumSize(400,300)
-        self.setMaximumSize(400,300)
+        _dpi = QtWidgets.QApplication.primaryScreen().logicalDotsPerInch() / 96.0
+        self.setMinimumSize(int(400 * _dpi), int(300 * _dpi))
 
         self.add_to_materialx_editor_workspace_control()
 

--- a/rawkee4maya/maya/RKOrganizer.py
+++ b/rawkee4maya/maya/RKOrganizer.py
@@ -1106,9 +1106,11 @@ class RKOrganizer():
                 
                 if self.rkHDRtoPNG > 0 and ("hdr" in fileExt or "exr" in fileExt):
                     rkMaxCubeMapFaceSize = cmds.optionVar( q='rkMaxCubeMapFaceSize')
+                    rkUseExtreme32BitCubeMap    = cmds.optionVar( q='rkUseExtreme32BitCubeMap'   )
+
                     fileName = fileName + ".ktx2"
                     localTexWrite   = localTexWrite + fileName
-                    self.rkint.hdri2ktx2(filePath, localTexWrite, 'exr' in fileExt, rkMaxCubeMapFaceSize)
+                    self.rkint.hdri2ktx2(filePath, localTexWrite, 'exr' in fileExt, rkMaxCubeMapFaceSize, rkUseExtreme32BitCubeMap)
                 elif self.rkConsolidate == True:
                     fileName = self.rkint.getFileName(filePath)
                     localTexWrite = localTexWrite + fileName
@@ -1157,10 +1159,12 @@ class RKOrganizer():
                     fileName = os.path.splitext(fileName)[0]
                     
                     if self.rkHDRtoPNG > 0 and ("hdr" in fileExt or "exr" in fileExt):
-                        rkMaxCubeMapFaceSize = cmds.optionVar( q='rkMaxCubeMapFaceSize')
+                        rkMaxCubeMapFaceSize     = cmds.optionVar( q='rkMaxCubeMapFaceSize'     )
+                        rkUseExtreme32BitCubeMap = cmds.optionVar( q='rkUseExtreme32BitCubeMap' )
+
                         fileName = fileName + ".ktx2"
                         localTexWrite   = localTexWrite   + fileName
-                        self.rkint.hdri2ktx2(filePath, localTexWrite, 'exr' in fileExt, rkMaxCubeMapFaceSize)
+                        self.rkint.hdri2ktx2(filePath, localTexWrite, 'exr' in fileExt, rkMaxCubeMapFaceSize, rkUseExtreme32BitCubeMap)
                     elif self.rkConsolidate == True:
                         fileName = self.rkint.getFileName(filePath)
                         localTexWrite = localTexWrite + "/" + fileName

--- a/rawkee4maya/maya/auxilary/RKAdvancedSkeletonEditor.ui
+++ b/rawkee4maya/maya/auxilary/RKAdvancedSkeletonEditor.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>400</width>
-    <height>600</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -59,7 +59,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>24</height>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -85,8 +85,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -104,8 +104,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -123,8 +123,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -165,8 +165,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -184,8 +184,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -226,8 +226,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -245,8 +245,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -287,8 +287,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -306,8 +306,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -348,8 +348,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -367,8 +367,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -566,8 +566,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -612,8 +612,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -678,8 +678,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -727,8 +727,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -752,8 +752,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>70</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -772,7 +772,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -813,8 +813,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -832,8 +832,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>70</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -851,8 +851,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -917,8 +917,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/auxilary/RKBasicHAnimSkeletonEditor.ui
+++ b/rawkee4maya/maya/auxilary/RKBasicHAnimSkeletonEditor.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>400</width>
-    <height>600</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -66,8 +66,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -85,8 +85,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -127,8 +127,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -146,8 +146,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -188,8 +188,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -207,8 +207,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -249,8 +249,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -268,8 +268,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -467,8 +467,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -513,8 +513,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -579,8 +579,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -628,8 +628,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -653,8 +653,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>70</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -673,7 +673,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -714,8 +714,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -733,8 +733,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>70</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -752,8 +752,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -818,8 +818,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/auxilary/RKBindPoseEditorPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKBindPoseEditorPanel.ui
@@ -53,8 +53,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>270</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="placeholderText">
@@ -92,8 +92,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>80</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -130,8 +130,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>80</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -166,8 +166,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>200</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -185,8 +185,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>60</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -221,8 +221,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>200</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -240,8 +240,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>60</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -276,8 +276,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>200</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -295,8 +295,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>60</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -334,8 +334,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>200</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -353,8 +353,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>60</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -392,8 +392,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>270</width>
-          <height>24</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="placeholderText">

--- a/rawkee4maya/maya/auxilary/RKCharacterAnimationClipEditorFrame.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterAnimationClipEditorFrame.ui
@@ -53,7 +53,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>24</height>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -86,7 +86,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>280</height>
+           <height>16777215</height>
           </size>
          </property>
          <column>
@@ -131,8 +131,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>80</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -151,7 +151,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>24</height>
+           <height>16777215</height>
           </size>
          </property>
         </widget>
@@ -171,7 +171,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>100</height>
+           <height>16777215</height>
           </size>
          </property>
          <property name="columnCount">
@@ -207,8 +207,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>110</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -227,7 +227,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
           </widget>
@@ -250,7 +250,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -285,8 +285,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -304,8 +304,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/auxilary/RKCharacterEditorAdvancedSkeletonPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterEditorAdvancedSkeletonPanel.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>800</width>
-    <height>600</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -58,8 +58,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>700</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="font">
@@ -111,8 +111,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -130,8 +130,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -149,8 +149,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -191,8 +191,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -210,8 +210,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -229,8 +229,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -273,7 +273,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>50</height>
+           <height>16777215</height>
           </size>
          </property>
          <property name="font">
@@ -331,8 +331,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -350,8 +350,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -369,8 +369,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -388,8 +388,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -413,8 +413,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>100</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -454,8 +454,8 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>600</width>
-         <height>24</height>
+         <width>16777215</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="font">
@@ -514,8 +514,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -564,8 +564,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -583,8 +583,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="currentIndex">
@@ -655,8 +655,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -708,8 +708,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>75</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -727,8 +727,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -769,8 +769,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -796,8 +796,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -849,8 +849,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>75</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -868,8 +868,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -910,8 +910,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -963,8 +963,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>75</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -982,8 +982,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1024,8 +1024,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="font">
@@ -1077,8 +1077,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>75</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1096,8 +1096,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/auxilary/RKCharacterEditorAnimationPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterEditorAnimationPanel.ui
@@ -93,7 +93,7 @@
              <property name="maximumSize">
               <size>
                <width>16777215</width>
-               <height>24</height>
+               <height>16777215</height>
               </size>
              </property>
              <property name="text">
@@ -117,8 +117,8 @@
              </property>
              <property name="maximumSize">
               <size>
-               <width>256</width>
-               <height>24</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
             </widget>
@@ -133,8 +133,8 @@
              </property>
              <property name="maximumSize">
               <size>
-               <width>81</width>
-               <height>24</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="text">
@@ -169,8 +169,8 @@
              </property>
              <property name="maximumSize">
               <size>
-               <width>106</width>
-               <height>24</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="text">
@@ -197,8 +197,8 @@
              </property>
              <property name="maximumSize">
               <size>
-               <width>260</width>
-               <height>24</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="text">
@@ -260,8 +260,8 @@
                </property>
                <property name="maximumSize">
                 <size>
-                 <width>100</width>
-                 <height>160</height>
+                 <width>16777215</width>
+                 <height>16777215</height>
                 </size>
                </property>
                <property name="text">
@@ -296,8 +296,8 @@
                </property>
                <property name="maximumSize">
                 <size>
-                 <width>256</width>
-                 <height>226</height>
+                 <width>16777215</width>
+                 <height>16777215</height>
                 </size>
                </property>
                <property name="indentation">
@@ -345,8 +345,8 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>100</width>
-                   <height>24</height>
+                   <width>16777215</width>
+                   <height>16777215</height>
                   </size>
                  </property>
                  <property name="text">
@@ -364,8 +364,8 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>156</width>
-                   <height>24</height>
+                   <width>16777215</width>
+                   <height>16777215</height>
                   </size>
                  </property>
                  <property name="text">
@@ -387,8 +387,8 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>130</width>
-                   <height>24</height>
+                   <width>16777215</width>
+                   <height>16777215</height>
                   </size>
                  </property>
                  <item>
@@ -423,8 +423,8 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>50</width>
-                   <height>24</height>
+                   <width>16777215</width>
+                   <height>16777215</height>
                   </size>
                  </property>
                  <property name="text">
@@ -442,8 +442,8 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>50</width>
-                   <height>24</height>
+                   <width>16777215</width>
+                   <height>16777215</height>
                   </size>
                  </property>
                  <property name="text">
@@ -480,8 +480,8 @@
                </property>
                <property name="maximumSize">
                 <size>
-                 <width>256</width>
-                 <height>290</height>
+                 <width>16777215</width>
+                 <height>16777215</height>
                 </size>
                </property>
                <property name="verticalScrollBarPolicy">

--- a/rawkee4maya/maya/auxilary/RKCharacterEditorGenericSkeletonPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterEditorGenericSkeletonPanel.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>800</width>
-    <height>600</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -58,8 +58,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>700</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="font">
@@ -111,8 +111,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>40</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -157,8 +157,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>40</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -176,8 +176,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>350</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -221,8 +221,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>40</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -240,8 +240,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>180</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">

--- a/rawkee4maya/maya/auxilary/RKCharacterEditorHAnimSkeletonPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKCharacterEditorHAnimSkeletonPanel.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>800</width>
-    <height>640</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -98,8 +98,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>160</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -120,8 +120,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>200</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -162,8 +162,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>160</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -184,8 +184,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>60</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="currentIndex">
@@ -256,8 +256,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>600</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -304,8 +304,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>140</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -329,8 +329,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>60</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -371,8 +371,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>140</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -393,8 +393,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>60</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <item>
@@ -460,8 +460,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>200</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">

--- a/rawkee4maya/maya/auxilary/RKGeneralAnimationClipEditorFrame.ui
+++ b/rawkee4maya/maya/auxilary/RKGeneralAnimationClipEditorFrame.ui
@@ -53,7 +53,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>280</height>
+           <height>16777215</height>
           </size>
          </property>
          <column>
@@ -91,8 +91,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>80</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -111,7 +111,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>24</height>
+           <height>16777215</height>
           </size>
          </property>
         </widget>
@@ -131,7 +131,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>100</height>
+           <height>16777215</height>
           </size>
          </property>
          <property name="columnCount">
@@ -167,8 +167,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>110</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -187,7 +187,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
           </widget>
@@ -210,7 +210,7 @@
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>24</height>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -240,8 +240,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -259,8 +259,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/auxilary/RKGeneralExportOptions.ui
+++ b/rawkee4maya/maya/auxilary/RKGeneralExportOptions.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>780</width>
-    <height>700</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -66,8 +66,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -111,8 +111,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -130,8 +130,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -175,8 +175,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -194,8 +194,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -248,8 +248,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -286,7 +286,14 @@
          <item>
           <widget class="QCheckBox" name="rkHDRCheckBox">
            <property name="text">
-            <string>Convert Panoramic HDR/EXR Images to Khronos KTX2 Images</string>
+            <string>Convert Equirectangular HDR/EXR Images to KTX2 Cube Map Images</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="extremeDynamicRange">
+           <property name="text">
+            <string>Enable Extreme Range for KTX2 Images</string>
            </property>
           </widget>
          </item>
@@ -326,8 +333,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>320</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -345,12 +352,12 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>40</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
-            <string>2048</string>
+            <string>4096</string>
            </property>
           </widget>
          </item>
@@ -395,8 +402,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -440,8 +447,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -492,8 +499,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -514,8 +521,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -545,8 +552,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -567,8 +574,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>80</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -616,8 +623,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="baseSize">
@@ -644,8 +651,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -675,8 +682,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -697,8 +704,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>80</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -751,8 +758,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -773,8 +780,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -822,8 +829,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -844,8 +851,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>140</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -896,8 +903,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>230</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -918,8 +925,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>40</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -940,8 +947,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -959,8 +966,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>46</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -981,8 +988,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1035,8 +1042,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>120</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1080,8 +1087,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>190</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1102,8 +1109,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>240</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -1148,8 +1155,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>75</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1167,8 +1174,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>60</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1212,8 +1219,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1234,8 +1241,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>240</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <item>
@@ -1320,8 +1327,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>130</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1345,8 +1352,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
           </widget>
@@ -1361,8 +1368,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1403,8 +1410,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>130</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1425,8 +1432,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>250</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
           </widget>
@@ -1464,8 +1471,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>130</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -1486,8 +1493,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>250</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
           </widget>

--- a/rawkee4maya/maya/auxilary/RKHAnimHumanoidSetupPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKHAnimHumanoidSetupPanel.ui
@@ -43,8 +43,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>30</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -62,8 +62,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>180</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="placeholderText">
@@ -101,8 +101,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>130</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">
@@ -120,8 +120,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>80</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <item>
@@ -196,8 +196,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>120</width>
-           <height>24</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="text">

--- a/rawkee4maya/maya/auxilary/RKMaterialXPanel.ui
+++ b/rawkee4maya/maya/auxilary/RKMaterialXPanel.ui
@@ -63,8 +63,8 @@
       </property>
       <property name="maximumSize">
        <size>
-        <width>390</width>
-        <height>290</height>
+        <width>16777215</width>
+        <height>16777215</height>
        </size>
       </property>
       <column>

--- a/rawkee4maya/maya/auxilary/RKmGearSetupEditor.ui
+++ b/rawkee4maya/maya/auxilary/RKmGearSetupEditor.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>400</width>
-    <height>600</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -69,8 +69,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -88,8 +88,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>160</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="readOnly">
@@ -110,8 +110,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>120</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -155,8 +155,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -209,8 +209,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -275,8 +275,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -294,8 +294,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>120</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -336,8 +336,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -355,8 +355,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>260</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -397,8 +397,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>50</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -416,8 +416,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>165</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -601,8 +601,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -620,8 +620,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -662,8 +662,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -681,8 +681,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -723,8 +723,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -742,8 +742,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -784,8 +784,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">
@@ -803,8 +803,8 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>24</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="text">

--- a/rawkee4maya/maya/mel/x3d.mel
+++ b/rawkee4maya/maya/mel/x3d.mel
@@ -270,7 +270,13 @@ global proc setDefRKOptVars()
     if(`optionVar -exists "rkMaxCubeMapFaceSize"`){
     }
     else{
-        optionVar -iv rkMaxCubeMapFaceSize 2048;
+        optionVar -iv rkMaxCubeMapFaceSize 4096;
+    }
+
+    if(`optionVar -exists "rkUseExtreme32BitCubeMap"`){
+    }
+    else{
+        optionVar -iv rkUseExtreme32BitCubeMap 0;
     }
     
     // Determines the format of Maya Proceedural Textures


### PR DESCRIPTION
This pull request introduces several improvements and new features to the `rawkee4maya/maya/RKFOptsDialog.py` and `rawkee4maya/maya/RKInterfaces.py` files, focusing on enhanced UI scaling, support for 32-bit float cube maps, and improved HDRI-to-cubemap conversion. It also cleans up unused code and simplifies the layout logic.

**UI scaling and layout improvements:**
- The dialog and widgets now scale according to the system DPI, ensuring consistent appearance on high-DPI displays. Fixed-size values for the window and buttons are now multiplied by a DPI factor. [[1]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L61-R63) [[2]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L97-R98)
- The layout for action buttons is simplified by replacing a fixed-width spacer label with `addStretch()`, improving flexibility and maintainability. [[1]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L107-L109) [[2]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L119-R117) [[3]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L131-L133) [[4]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L143-R138) [[5]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L157-L159) [[6]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L169-R161) [[7]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L181-L183) [[8]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L193-R182)

**New features for HDRI/cubemap export:**
- Added support for an "Extreme Dynamic Range" (32-bit float) cubemap export option, including a new checkbox in the UI and corresponding option variable (`rkUseExtreme32BitCubeMap`). [[1]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R199) [[2]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R259-L314) [[3]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L390-R342) [[4]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R400)
- Increased the maximum allowed cube map face size from 2048 to 4096 pixels and updated the validator accordingly.
- The HDRI-to-KTX2 conversion method now supports 32-bit float output, disables auto-exposure in this mode, and allows the maximum face size to be set up to 4096. [[1]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL356-R369) [[2]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL434-R380) [[3]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL452-R410)

**Code cleanup and refactoring:**
- Removed unused or commented-out code for legacy HDR controls and sliders, as well as the `_hdri_equirect_to_faces` method, reducing maintenance overhead. [[1]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60R259-L314) [[2]](diffhunk://#diff-c24683f119ab1e35af5a80b4cc761b0de368d8a509bf7fed4819636dd1324b60L477-L504) [[3]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL356-R369)
- Improved comments and documentation for key methods, clarifying cubemap conventions, pixel coordinate handling, and auto-exposure logic. [[1]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL434-R380) [[2]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL452-R410) [[3]](diffhunk://#diff-447ef5f4e36f08777eaf0a3a5219bbf3936e684d0308cf449ecb3f218575403eL471-R425)

These changes improve both the user experience and technical capabilities of the export dialog and HDRI processing pipeline.… aka - looking at the sun. Revised Pyside GUI scaling to fit most monitor display sizes.