### PR TITLE
Added connection/route creation/deletion functionality. Updated popup…

### DIFF
--- a/rawkee/editor/RKGraphics.py
+++ b/rawkee/editor/RKGraphics.py
@@ -84,6 +84,9 @@ class RKGraphicsView(QGraphicsView):
         self.zoomStep = 1
         self.zoomRange = [0, 20]
 
+        self._drag_start_socket = None
+        self._drag_edge         = None
+
         
     def initUI(self):
         # At least in PySide6 - Tutorial's use of HighQualityAntialiasing is not supported
@@ -121,11 +124,285 @@ class RKGraphicsView(QGraphicsView):
             super().mouseReleaseEvent(event)
             
     def leftMouseButtonPress(self, event):
-        return super().mousePressEvent(event)
+        from rawkee.editor.RKXGraphicsSocket import RKXGraphicsSocket
+        item = self.itemAt(event.pos())
+        if isinstance(item, RKXGraphicsSocket):
+            self._begin_drag_edge(item)
+            return
+        super().mousePressEvent(event)
         
     def leftMouseButtonRelease(self, event):
-        return super().mouseReleaseEvent(event)
-        
+        if self._drag_start_socket is not None:
+            from rawkee.editor.RKXGraphicsSocket import RKXGraphicsSocket
+            item = self.itemAt(event.pos())
+            if isinstance(item, RKXGraphicsSocket) and item is not self._drag_start_socket:
+                self._complete_drag_edge(item)
+            else:
+                self._cancel_drag_edge()
+            return
+        super().mouseReleaseEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._drag_edge is not None:
+            self._drag_edge.setDestPos(self.mapToScene(event.pos()))
+            self._drag_edge.update()
+        super().mouseMoveEvent(event)
+
+    def _begin_drag_edge(self, gr_socket):
+        from rawkee.editor.RKXGraphicsEdge import RKXGraphicsEdge
+        self._drag_start_socket = gr_socket
+        self._drag_edge = RKXGraphicsEdge(None)
+        self.grScene.addItem(self._drag_edge)
+        src = gr_socket.scenePos()
+        self._drag_edge.setSourcePos(src)
+        self._drag_edge.setDestPos(src)
+        self._drag_edge.update()
+
+    def _complete_drag_edge(self, end_gr_socket):
+        from rawkee.editor.RKXEdge import RKXEdge
+        self.grScene.removeItem(self._drag_edge)
+        self._drag_edge = None
+        start, end = self._drag_start_socket, end_gr_socket
+        self._drag_start_socket = None
+        # Enforce output → input direction
+        if start.isOutput and not end.isOutput:
+            pass
+        elif end.isOutput and not start.isOutput:
+            start, end = end, start
+        else:
+            return  # both same direction — reject
+        start_sock = getattr(start, 'socket', None)
+        end_sock   = getattr(end,   'socket', None)
+        if start_sock and end_sock:
+            RKXEdge(self.grScene.scene, start_sock, end_sock)
+
+    def _cancel_drag_edge(self):
+        if self._drag_edge is not None:
+            self.grScene.removeItem(self._drag_edge)
+        self._drag_edge         = None
+        self._drag_start_socket = None
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Delete, Qt.Key_Backspace):
+            from rawkee.editor.RKXGraphicsEdge import RKXGraphicsEdge
+            for item in self.grScene.selectedItems():
+                if isinstance(item, RKXGraphicsEdge) and item.edge is not None:
+                    self._delete_edge(item.edge)
+            return
+        super().keyPressEvent(event)
+
+    def _delete_edge(self, edge):
+        edge.remove()
+
+    def contextMenuEvent(self, event):
+        from rawkee.editor.RKXGraphicsEdge import RKXGraphicsEdge
+        gr_node = self._find_graphics_node_at(event.pos())
+        gr_edge = self._find_graphics_edge_at(event.pos())
+        menu = QMenu(self)
+        menu.setStyleSheet("QMenu::separator { background: #39FF14; height: 2px; margin: 2px 4px; }")
+        if gr_edge is not None and gr_edge.edge is not None:
+            action = menu.addAction("Delete Connection")
+            if menu.exec(event.globalPos()) == action:
+                self._delete_edge(gr_edge.edge)
+        elif gr_node is not None:
+            action_fit   = menu.addAction("Fit Node to View")
+            menu.addSeparator()
+            action_graph = menu.addAction("Display All Nodes in Connected Graph")
+            menu.addSeparator()
+            action_both  = menu.addAction("Display Connected Adjacent Nodes")
+            action_up    = menu.addAction("Display Upstream Adjacent Nodes")
+            action_down  = menu.addAction("Display Downstream Adjacent Nodes")
+            menu.addSeparator()
+            action_clear = menu.addAction("Clear From Graph Editor")
+            chosen = menu.exec(event.globalPos())
+            if chosen == action_fit:
+                from PySide6.QtCore import Qt
+                self.fitInView(gr_node.sceneBoundingRect().adjusted(-40, -40, 40, 40), Qt.KeepAspectRatio)
+            elif chosen == action_clear:
+                self._remove_node(gr_node)
+            elif chosen == action_both:
+                self._add_adjacent_nodes(gr_node, 'both')
+            elif chosen == action_up:
+                self._add_adjacent_nodes(gr_node, 'upstream')
+            elif chosen == action_down:
+                self._add_adjacent_nodes(gr_node, 'downstream')
+            elif chosen == action_graph:
+                self._add_connected_graph_nodes(gr_node)
+        else:
+            action = menu.addAction("Clear Graph Editor")
+            if menu.exec(event.globalPos()) == action:
+                self.grScene.scene.clear_graph()
+
+    def _add_adjacent_nodes(self, gr_node, direction):
+        """Add graph editor nodes for X3D nodes connected via ROUTEs ('upstream'|'downstream'|'both')."""
+        from PySide6.QtCore import QPointF
+
+        x3d_scene = self.grScene.scene._x3d_scene
+        if x3d_scene is None:
+            return
+
+        def_val = getattr(getattr(gr_node.eNode, 'x3d_node', None), 'DEF', '')
+        if not def_val:
+            return
+
+        parent_editor = self.parent()
+        if not hasattr(parent_editor, 'addNodeFromX3D'):
+            return
+
+        # Build DEF→node map; prefer the tree registry (includes nested nodes)
+        def_map = {}
+        if hasattr(parent_editor, '_tree_widget') and parent_editor._tree_widget is not None:
+            for node in parent_editor._tree_widget._node_registry.values():
+                d = getattr(node, 'DEF', '')
+                if d:
+                    def_map[d] = node
+        else:
+            for child in x3d_scene.children:
+                d = getattr(child, 'DEF', '')
+                if d:
+                    def_map[d] = child
+
+        upstream_defs   = []
+        downstream_defs = []
+        for child in x3d_scene.children:
+            if not hasattr(child, 'fromNode'):
+                continue
+            if direction in ('upstream', 'both') and child.toNode == def_val:
+                if child.fromNode not in upstream_defs:
+                    upstream_defs.append(child.fromNode)
+            if direction in ('downstream', 'both') and child.fromNode == def_val:
+                if child.toNode not in downstream_defs:
+                    downstream_defs.append(child.toNode)
+
+        node_pos   = gr_node.pos()
+        spacing_x  = gr_node.width + 80
+        spacing_y  = 200
+
+        for i, adj_def in enumerate(upstream_defs):
+            if adj_def in def_map:
+                place = QPointF(node_pos.x() - spacing_x * 1.5, node_pos.y() + i * spacing_y)
+                parent_editor.addNodeFromX3D(def_map[adj_def], place)
+
+        for i, adj_def in enumerate(downstream_defs):
+            if adj_def in def_map:
+                place = QPointF(node_pos.x() + spacing_x * 1.5, node_pos.y() + i * spacing_y)
+                parent_editor.addNodeFromX3D(def_map[adj_def], place)
+
+        # Center the view on all nodes now visible in the graph
+        from PySide6.QtCore import Qt
+        self.fitInView(self.grScene.itemsBoundingRect(), Qt.KeepAspectRatio)
+
+    def _add_connected_graph_nodes(self, gr_node):
+        """BFS through all ROUTEs in both directions to add every reachable node."""
+        from PySide6.QtCore import QPointF, Qt
+
+        x3d_scene = self.grScene.scene._x3d_scene
+        if x3d_scene is None:
+            return
+
+        start_def = getattr(getattr(gr_node.eNode, 'x3d_node', None), 'DEF', '')
+        if not start_def:
+            return
+
+        parent_editor = self.parent()
+        if not hasattr(parent_editor, 'addNodeFromX3D'):
+            return
+
+        def_map = {}
+        if hasattr(parent_editor, '_tree_widget') and parent_editor._tree_widget is not None:
+            for node in parent_editor._tree_widget._node_registry.values():
+                d = getattr(node, 'DEF', '')
+                if d:
+                    def_map[d] = node
+        else:
+            for child in x3d_scene.children:
+                d = getattr(child, 'DEF', '')
+                if d:
+                    def_map[d] = child
+
+        # Build adjacency: for each DEF, collect all DEFs connected via any ROUTE
+        adjacency = {}
+        for child in x3d_scene.children:
+            if not hasattr(child, 'fromNode'):
+                continue
+            fn, tn = child.fromNode, child.toNode
+            adjacency.setdefault(fn, set()).add(tn)
+            adjacency.setdefault(tn, set()).add(fn)
+
+        # BFS from start_def
+        visited = set()
+        queue   = [start_def]
+        while queue:
+            current = queue.pop(0)
+            if current in visited:
+                continue
+            visited.add(current)
+            for neighbour in adjacency.get(current, []):
+                if neighbour not in visited:
+                    queue.append(neighbour)
+
+        # Layout: column per BFS depth layer
+        from collections import deque
+        layers   = {start_def: 0}
+        bfs_q    = deque([start_def])
+        while bfs_q:
+            cur = bfs_q.popleft()
+            for nb in adjacency.get(cur, []):
+                if nb not in layers:
+                    layers[nb] = layers[cur] + 1
+                    bfs_q.append(nb)
+
+        layer_nodes = {}
+        for d, l in layers.items():
+            if d in visited:
+                layer_nodes.setdefault(l, []).append(d)
+
+        node_pos  = gr_node.pos()
+        spacing_x = (gr_node.width if hasattr(gr_node, 'width') else 220) + 80
+        spacing_y = 200
+
+        for layer, defs in layer_nodes.items():
+            x = node_pos.x() + layer * spacing_x
+            for row, d in enumerate(defs):
+                if d == start_def:
+                    continue
+                if d in def_map:
+                    y = node_pos.y() + row * spacing_y
+                    parent_editor.addNodeFromX3D(def_map[d], QPointF(x, y))
+
+        self.fitInView(self.grScene.itemsBoundingRect(), Qt.KeepAspectRatio)
+
+    def _find_graphics_node_at(self, pos):
+        from rawkee.editor.RKXGraphicsNode import RKXGraphicsNode as GrNode
+        item = self.itemAt(pos)
+        while item is not None:
+            if isinstance(item, GrNode):
+                return item
+            item = item.parentItem()
+        return None
+
+    def _find_graphics_edge_at(self, pos):
+        from rawkee.editor.RKXGraphicsEdge import RKXGraphicsEdge
+        for item in self.items(pos):
+            if isinstance(item, RKXGraphicsEdge):
+                return item
+        return None
+
+    def _remove_node(self, gr_node):
+        eNode = gr_node.eNode
+        scene = self.grScene.scene
+        s_ids = set(id(s) for s in eNode.inputs + eNode.outputs)
+        for edge in [e for e in list(scene.eEdges)
+                     if id(e.start_socket) in s_ids or id(e.end_socket) in s_ids]:
+            # Remove visual edge only; preserve the ROUTE in the X3D scene
+            if edge.grEdge is not None:
+                scene.grScene.removeItem(edge.grEdge)
+            if edge in scene.eEdges:
+                scene.eEdges.remove(edge)
+        scene.grScene.removeItem(gr_node)
+        if eNode in scene.eNodes:
+            scene.eNodes.remove(eNode)
+
     def rightMouseButtonPress(self, event):
         return super().mousePressEvent(event)
         

--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -16,6 +16,146 @@ from functools import partial
 
 import rawkee.io.RKx3d as rkx
 from rawkee.io.RKLoadSceneFromFile import RKLoadSceneFromFile
+
+# Pure outputOnly/inputOnly event fields missing from FIELD_DECLARATIONS in RKx3d.py.
+# Format: {NodeTypeName: [(field_name, field_type, access)]}  access = 'inputOnly'|'outputOnly'
+_EXTRA_EVENT_FIELDS = {
+    'TimeSensor': [
+        ('cycleTime',        'SFTime',    'outputOnly'),
+        ('elapsedTime',      'SFTime',    'outputOnly'),
+        ('fraction_changed', 'SFFloat',   'outputOnly'),
+        ('isActive',         'SFBool',    'outputOnly'),
+        ('isPaused',         'SFBool',    'outputOnly'),
+        ('time',             'SFTime',    'outputOnly'),
+    ],
+    'PositionInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFVec3f',    'outputOnly'),
+    ],
+    'PositionInterpolator2D': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFVec2f',    'outputOnly'),
+    ],
+    'OrientationInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFRotation', 'outputOnly'),
+    ],
+    'ColorInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFColor',    'outputOnly'),
+    ],
+    'ScalarInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFFloat',    'outputOnly'),
+    ],
+    'NormalInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'MFVec3f',    'outputOnly'),
+    ],
+    'CoordinateInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'MFVec3f',    'outputOnly'),
+    ],
+    'CoordinateInterpolator2D': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'MFVec2f',    'outputOnly'),
+    ],
+    'SquadOrientationInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFRotation', 'outputOnly'),
+    ],
+    'SplinePositionInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFVec3f',    'outputOnly'),
+    ],
+    'SplinePositionInterpolator2D': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFVec2f',    'outputOnly'),
+    ],
+    'SplineScalarInterpolator': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('value_changed', 'SFFloat',    'outputOnly'),
+    ],
+    'EaseInEaseOut': [
+        ('set_fraction',  'SFFloat',    'inputOnly'),
+        ('modifiedFraction_changed', 'SFFloat', 'outputOnly'),
+    ],
+    'TouchSensor': [
+        ('hitNormal_changed',   'SFVec3f',  'outputOnly'),
+        ('hitPoint_changed',    'SFVec3f',  'outputOnly'),
+        ('hitTexCoord_changed', 'SFVec2f',  'outputOnly'),
+        ('isActive',            'SFBool',   'outputOnly'),
+        ('isOver',              'SFBool',   'outputOnly'),
+        ('touchTime',           'SFTime',   'outputOnly'),
+    ],
+    'ProximitySensor': [
+        ('centerOfRotation_changed', 'SFVec3f',    'outputOnly'),
+        ('isActive',                 'SFBool',     'outputOnly'),
+        ('orientation_changed',      'SFRotation', 'outputOnly'),
+        ('position_changed',         'SFVec3f',    'outputOnly'),
+        ('enterTime',                'SFTime',     'outputOnly'),
+        ('exitTime',                 'SFTime',     'outputOnly'),
+    ],
+    'VisibilitySensor': [
+        ('isActive',   'SFBool', 'outputOnly'),
+        ('enterTime',  'SFTime', 'outputOnly'),
+        ('exitTime',   'SFTime', 'outputOnly'),
+    ],
+    'PlaneSensor': [
+        ('isActive',           'SFBool',   'outputOnly'),
+        ('isOver',             'SFBool',   'outputOnly'),
+        ('translation_changed','SFVec3f',  'outputOnly'),
+        ('trackPoint_changed', 'SFVec3f',  'outputOnly'),
+    ],
+    'CylinderSensor': [
+        ('isActive',           'SFBool',    'outputOnly'),
+        ('isOver',             'SFBool',    'outputOnly'),
+        ('rotation_changed',   'SFRotation','outputOnly'),
+        ('trackPoint_changed', 'SFVec3f',   'outputOnly'),
+    ],
+    'SphereSensor': [
+        ('isActive',           'SFBool',    'outputOnly'),
+        ('isOver',             'SFBool',    'outputOnly'),
+        ('rotation_changed',   'SFRotation','outputOnly'),
+        ('trackPoint_changed', 'SFVec3f',   'outputOnly'),
+    ],
+    'KeySensor': [
+        ('actionKeyPress',   'SFInt32', 'outputOnly'),
+        ('actionKeyRelease', 'SFInt32', 'outputOnly'),
+        ('altKey',           'SFBool',  'outputOnly'),
+        ('controlKey',       'SFBool',  'outputOnly'),
+        ('isActive',         'SFBool',  'outputOnly'),
+        ('keyPress',         'SFString','outputOnly'),
+        ('keyRelease',       'SFString','outputOnly'),
+        ('shiftKey',         'SFBool',  'outputOnly'),
+    ],
+    'StringSensor': [
+        ('enteredText',  'SFString', 'outputOnly'),
+        ('finalText',    'SFString', 'outputOnly'),
+        ('isActive',     'SFBool',   'outputOnly'),
+    ],
+    'BooleanFilter': [
+        ('set_boolean',    'SFBool', 'inputOnly'),
+        ('inputFalse',     'SFBool', 'outputOnly'),
+        ('inputNegate',    'SFBool', 'outputOnly'),
+        ('inputTrue',      'SFBool', 'outputOnly'),
+    ],
+    'BooleanToggle': [
+        ('set_boolean', 'SFBool', 'inputOnly'),
+    ],
+    'BooleanTrigger': [
+        ('set_triggerTime', 'SFTime', 'inputOnly'),
+        ('triggerTrue',     'SFBool', 'outputOnly'),
+    ],
+    'IntegerTrigger': [
+        ('set_boolean',       'SFBool',  'inputOnly'),
+        ('triggerValue',      'SFInt32', 'outputOnly'),
+    ],
+    'TimeTrigger': [
+        ('set_boolean',  'SFBool', 'inputOnly'),
+        ('triggerTime',  'SFTime', 'outputOnly'),
+    ],
+}
 from rawkee.editor.RKXScene   import RKXScene
 from rawkee.editor.RKXNodes   import RKXNode
 from rawkee.editor.RKXSocket  import RKXSocket
@@ -127,14 +267,16 @@ class RKSceneEditor(QMainWindow):
         self.create_layout()
         self.create_connections()
 
-        self.bkHost = None
-        self.httpd  = None
+        self.bkHost  = None
+        self.httpd   = None
+        self._x3dObj = None  # full rkx.X3D object kept in memory
 
 
     def setX3DScene(self, x3dScene):
         """Populate the tree widget from an rkx.Scene object produced by maya2x3d()."""
         self._x3dScene = x3dScene
         self._build_scene_tree(x3dScene)
+        self.node_editor_widget.set_x3d_scene(x3dScene)
 
     def _build_scene_tree(self, scene):
         self.tree_widget.clearRegistry()
@@ -151,11 +293,13 @@ class RKSceneEditor(QMainWindow):
         if isinstance(node, rkx.ROUTE):
             return None
 
-        # USE reference — shown read-only, not draggable
+        # USE reference — register for drag so addNodeFromX3D can resolve it to the DEF node
         use_val = getattr(node, 'USE', '')
         if use_val:
             node_type = type(node).NAME()
-            return QTreeWidgetItem(["USE '{}' ({})".format(use_val, node_type)])
+            item = QTreeWidgetItem(["USE '{}' ({})".format(use_val, node_type)])
+            item.setData(0, Qt.UserRole, self.tree_widget.registerNode(node))
+            return item
 
         # Regular node — register it so it can be dragged into the node editor
         node_type = type(node).NAME()
@@ -242,6 +386,7 @@ class RKSceneEditor(QMainWindow):
         self.exportX3DAs    = QAction("   Export X3D As...")
         #self.openX3DFile.setShortcut(QtGui.QKeySequence("Ctrl+S"))
 
+        self.clearGraphAction = QAction("   Clear Graph Editor")
         self.copySceneMaya  = QAction("   Copy Entire Maya Scene")
         self.copySelectMaya = QAction("   Copy Selected Maya Nodes")
         self.pasteSGToMaya  = QAction("   Paste Entire X3D Scenegraph")
@@ -259,8 +404,9 @@ class RKSceneEditor(QMainWindow):
         
     def create_widgets(self):
         file_menu   = self.menuBar().addMenu("File")
-        node_menu   = self.menuBar().addMenu("X3D Nodes")    # noqa: F841
+        node_menu   = self.menuBar().addMenu("X3D Nodes")
         about_menu  = self.menuBar().addMenu("About RawKee") # noqa: F841
+        node_menu.addAction(self.clearGraphAction)
 
         file_menu.addAction(self.newX3DScene)
         file_menu.addAction(self.openX3DFile)
@@ -379,6 +525,7 @@ class RKSceneEditor(QMainWindow):
         self.newX3DScene.triggered.connect(self.on_new_scene)
         self.openX3DFile.triggered.connect(self.on_open_file)
         self.exportX3DAs.triggered.connect(self.on_export_as)
+        self.clearGraphAction.triggered.connect(self.on_clear_graph)
         self.closeEditor.triggered.connect(self.close)
         self.combo_box.activated.connect(self.on_item_viewer_selection)
 
@@ -402,6 +549,8 @@ class RKSceneEditor(QMainWindow):
         self.browser.load(self.playerURL)
 
     def on_new_scene(self):
+        self._x3dObj = None
+        self.node_editor_widget.clearGraph()
         self.setX3DScene(None)
         self.setWindowTitle("RawKee PE - X3D Interaction Editor")
 
@@ -416,12 +565,17 @@ class RKSceneEditor(QMainWindow):
         if x3d is None:
             QMessageBox.warning(self, "Open Failed", f"Could not load:\n{file_path}")
             return
+        self._x3dObj = x3d
+        self.node_editor_widget.clearGraph()
         scene_node = getattr(x3d, 'Scene', None)
         self.setX3DScene(scene_node)
         self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
 
     def on_export_as(self):
         QMessageBox.information(self, "Export X3D", "Export not yet implemented.")
+
+    def on_clear_graph(self):
+        self.node_editor_widget.clearGraph()
 
     def stopWebserver(self):
         if self.httpd:
@@ -499,37 +653,129 @@ class RKCustomNodeEditor(QWidget):
         else:
             self.view = RKGraphicsView(self.scene.grScene, self)
         self.layout.addWidget(self.view)
-        
-        # Adding an RKXNode for Development / Testing purposes.
-        self.node1 = RKXNode(self.scene, "RawKeeNode 1", inputs=[1, 2, 3], outputs=[1])
-        self.node1.setPos(0,0)
-        node2 = RKXNode(self.scene, "RawKeeNode 2", inputs=[1, 2, 3], outputs=[1])
-        node2.setPos(300,0)
-        node3 = RKXNode(self.scene, "RawKeeNode 3", inputs=[1, 2, 3], outputs=[1])
-        node3.setPos(600,0)
+
+    def set_x3d_scene(self, x3d_scene):
+        self.scene.set_x3d_scene(x3d_scene)
+
+    def clearGraph(self):
+        self.scene.clear_graph()
 
     def addNodeFromX3D(self, x3d_node, scene_pos):
         """Create an RKXNode in the editor canvas from a dropped rkx node object."""
+        # USE nodes are just references — resolve to the actual DEF node
+        use_val = getattr(x3d_node, 'USE', '')
+        if use_val:
+            node_type = type(x3d_node)
+            for candidate in self._tree_widget._node_registry.values():
+                if type(candidate) == node_type and getattr(candidate, 'DEF', '') == use_val:
+                    x3d_node = candidate
+                    break
+
+        # Prevent duplicate: same DEF already in graph
+        def_val = getattr(x3d_node, 'DEF', '')
+        if def_val:
+            for existing in self.scene.eNodes:
+                if getattr(getattr(existing, 'x3d_node', None), 'DEF', '') == def_val:
+                    return
+
         node_type = type(x3d_node).NAME()
         def_name  = getattr(x3d_node, 'DEF', '')
-        title = "{} DEF='{}'".format(node_type, def_name) if def_name else node_type
+        use_name  = getattr(x3d_node, 'USE', '')
+        title = use_name if use_name else def_name
 
+        _NO_ROUTE_NAMES = frozenset({'DEF', 'USE', 'IS', 'class_', 'id_', 'style_'})
         inputs  = []
         outputs = []
         if hasattr(type(x3d_node), 'FIELD_DECLARATIONS'):
             for decl in type(x3d_node).FIELD_DECLARATIONS():
                 field_name = decl[0]
-                try:
-                    access_str = decl[3]()
-                except Exception:
-                    access_str = ''
+                try:    field_type = decl[2]()
+                except Exception: field_type = ''
+                try:    access_str = decl[3]()
+                except Exception: access_str = ''
+                if field_name in _NO_ROUTE_NAMES:
+                    continue
                 if access_str in ('inputOnly', 'inputOutput'):
-                    inputs.append(field_name)
+                    inputs.append((field_name, field_type))
                 if access_str in ('outputOnly', 'inputOutput'):
-                    outputs.append(field_name)
+                    outputs.append((field_name, field_type))
 
-        new_node = RKXNode(self.scene, title, inputs=inputs, outputs=outputs)
+        # Merge spec event fields absent from FIELD_DECLARATIONS
+        existing_in  = {fn for fn, _ in inputs}
+        existing_out = {fn for fn, _ in outputs}
+        for (fname, ftype, access) in _EXTRA_EVENT_FIELDS.get(node_type, []):
+            if access == 'inputOnly' and fname not in existing_in:
+                inputs.append((fname, ftype))
+            elif access == 'outputOnly' and fname not in existing_out:
+                outputs.append((fname, ftype))
+
+        new_node = RKXNode(self.scene, title, inputs=inputs, outputs=outputs, x3d_node=x3d_node, node_type=node_type)
         new_node.setPos(scene_pos.x(), scene_pos.y())
+        self._sync_routes_to_edges()
+
+    def _sync_routes_to_edges(self):
+        if self.scene._x3d_scene is None:
+            return
+
+        def base(name):
+            if name.endswith('_changed'): return name[:-8]
+            if name.startswith('set_'):   return name[4:]
+            return name
+
+        def_map = {getattr(n.x3d_node, 'DEF', ''): n
+                   for n in self.scene.eNodes
+                   if getattr(n, 'x3d_node', None) and getattr(n.x3d_node, 'DEF', '')}
+        existing_pairs = {(id(e.start_socket), id(e.end_socket))
+                          for e in self.scene.eEdges if e.start_socket and e.end_socket}
+        for child in self.scene._x3d_scene.children:
+            if not hasattr(child, 'fromNode'):
+                continue
+            from_enode = def_map.get(child.fromNode)
+            to_enode   = def_map.get(child.toNode)
+            if from_enode is None or to_enode is None:
+                continue
+            rf = base(child.fromField)
+            rt = base(child.toField)
+            start_sock = next((from_enode.outputs[i]
+                               for i, (fn, _) in enumerate(from_enode.output_fields)
+                               if base(fn) == rf and i < len(from_enode.outputs)), None)
+            end_sock   = next((to_enode.inputs[i]
+                               for i, (fn, _) in enumerate(to_enode.input_fields)
+                               if base(fn) == rt and i < len(to_enode.inputs)), None)
+
+            # Field not in FIELD_DECLARATIONS (pure event field) — create a socket on the fly
+            if start_sock is None:
+                start_sock = self._add_dynamic_socket(from_enode, child.fromField, is_output=True)
+            if end_sock is None:
+                end_sock = self._add_dynamic_socket(to_enode, child.toField, is_output=False)
+
+            if start_sock is None or end_sock is None:
+                continue
+            pair = (id(start_sock), id(end_sock))
+            if pair in existing_pairs:
+                continue
+            from rawkee.editor.RKXEdge import RKXEdge
+            RKXEdge(self.scene, start_sock, end_sock)
+            existing_pairs.add(pair)
+
+    def _add_dynamic_socket(self, enode, field_name, is_output):
+        """Create a socket for a field not present in FIELD_DECLARATIONS (pure event field)."""
+        from rawkee.editor.RKXSocket import RKXSocket, LEFT_BOTTOM, RIGHT_TOP
+        if is_output:
+            idx = len(enode.outputs)
+            enode.output_fields.append((field_name, ''))
+            enode._resize_for_sockets()
+            sock = RKXSocket(eNode=enode, index=idx, position=RIGHT_TOP,
+                             isOutput=True, field_name=field_name)
+            enode.outputs.append(sock)
+        else:
+            idx = len(enode.inputs)
+            enode.input_fields.append((field_name, ''))
+            enode._resize_for_sockets()
+            sock = RKXSocket(eNode=enode, index=idx, position=LEFT_BOTTOM,
+                             isOutput=False, field_name=field_name)
+            enode.inputs.append(sock)
+        return sock
 
     def centerViewOn(self, qpoint=QPointF(0,0)):
         self.view.centerOn(qpoint)

--- a/rawkee/editor/RKXContentWidget.py
+++ b/rawkee/editor/RKXContentWidget.py
@@ -11,10 +11,20 @@ class RKXContentWidget(QWidget):
     def initUI(self):
         self.layout = QVBoxLayout()
         self.layout.setContentsMargins(0,0,0,0)
+        self.layout.setSpacing(0)
         self.setLayout(self.layout)
         
-        self.widget_label = QLabel("BoundaryEnhancementVolumeStyle")
+        self.widget_label = QLabel()
         self.widget_label.setObjectName("X3DNodeType")
+        self.widget_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.widget_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.widget_label.setStyleSheet(
+            "background-color: #2a2a2a; color: #39FF14;"
+            "font-weight: bold; padding: 3px 4px 6px 4px;"
+        )
         
         self.layout.addWidget(self.widget_label)
-        self.layout.addWidget(QTextEdit("Javascript:"))
+        self.layout.addStretch()
+
+    def setNodeType(self, type_name):
+        self.widget_label.setText(type_name)

--- a/rawkee/editor/RKXGraphicsEdge.py
+++ b/rawkee/editor/RKXGraphicsEdge.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QGraphicsPathItem, QGraphicsItem
-from PySide6.QtGui     import QPen, QColor, QPainterPath
+from PySide6.QtGui     import QPen, QColor, QPainterPath, QPainterPathStroker
 from PySide6.QtCore    import Qt, QPointF
 
 
@@ -14,9 +14,9 @@ class RKXGraphicsEdge(QGraphicsPathItem):
         super().__init__(parent)
         self.edge = edge
 
-        self._color          = QColor("#FF009A44")
-        self._color_selected = QColor("#FFFF671F")
-        self._color_dragging = QColor("#FF009A44")
+        self._color          = QColor("#FF009A44")   # UND green — connected
+        self._color_selected = QColor("#FFFF671F")   # orange — selected
+        self._color_dragging = QColor("#39FF14")     # neon green — in-progress drag
 
         self._pen = QPen(self._color)
         self._pen.setWidthF(2.0)
@@ -56,13 +56,16 @@ class RKXGraphicsEdge(QGraphicsPathItem):
         return self.shape().boundingRect()
 
     def shape(self):
-        return self._calcPath()
+        # Widen the hit area to ~10px so right-click detection works reliably
+        stroker = QPainterPathStroker()
+        stroker.setWidth(10.0)
+        return stroker.createStroke(self._calcPath())
 
     def paint(self, painter, option, widget=None):
         self.setPath(self._calcPath())
         pen = self._pen_selected if self.isSelected() else self._pen
         # Use dashed style when destination is not yet connected
-        if self.edge.end_socket is None:
+        if self.edge is None or self.edge.end_socket is None:
             pen = self._pen_dragging
         painter.setPen(pen)
         painter.setBrush(Qt.NoBrush)

--- a/rawkee/editor/RKXGraphicsNode.py
+++ b/rawkee/editor/RKXGraphicsNode.py
@@ -28,7 +28,7 @@ class RKXGraphicsNode(QGraphicsItem):
         self.height = 280
         
         self.title_height = 24.0
-        self._padding = 2.0
+        self._padding = 3.0
         
         self.edge_size = 10.0
         
@@ -72,6 +72,13 @@ class RKXGraphicsNode(QGraphicsItem):
     def initUI(self):
         self.setFlag(RKXGraphicsNode.ItemIsSelectable)
         self.setFlag(RKXGraphicsNode.ItemIsMovable)
+        self.setFlag(RKXGraphicsNode.ItemSendsGeometryChanges)
+
+    def itemChange(self, change, value):
+        if change == RKXGraphicsNode.GraphicsItemChange.ItemPositionHasChanged:
+            for edge in self.eNode.scene.eEdges:
+                edge.updatePositions()
+        return super().itemChange(change, value)
 
 
     @property
@@ -79,8 +86,7 @@ class RKXGraphicsNode(QGraphicsItem):
     @title.setter
     def title(self, value):
         self._title = value
-        nodeDEFChop = self._title[:28]
-        self.title_item.setPlainText(nodeDEFChop)
+        self.title_item.setPlainText(value[:28])
         
     
         

--- a/rawkee/editor/RKXGraphicsSocket.py
+++ b/rawkee/editor/RKXGraphicsSocket.py
@@ -2,11 +2,37 @@ from PySide6.QtWidgets import *
 from PySide6.QtCore    import *
 from PySide6.QtGui     import *
 
+# Socket fill color keyed by X3D field type; falls back to input/output default
+_TYPE_COLORS = {
+    'SFBool':      '#999999', 'MFBool':      '#999999',
+    'SFInt32':     '#00BFFF', 'MFInt32':     '#00BFFF',
+    'SFFloat':     '#7FFF00', 'MFFloat':     '#7FFF00',
+    'SFDouble':    '#7FFF00', 'MFDouble':    '#7FFF00',
+    'SFTime':      '#7FFF00', 'MFTime':      '#7FFF00',
+    'SFVec2f':     '#FFD700', 'MFVec2f':     '#FFD700',
+    'SFVec3f':     '#FFD700', 'MFVec3f':     '#FFD700',
+    'SFVec4f':     '#FFD700', 'MFVec4f':     '#FFD700',
+    'SFVec2d':     '#FFD700', 'MFVec2d':     '#FFD700',
+    'SFVec3d':     '#FFD700', 'MFVec3d':     '#FFD700',
+    'SFVec4d':     '#FFD700', 'MFVec4d':     '#FFD700',
+    'SFColor':     '#FF8C00', 'MFColor':     '#FF8C00',
+    'SFColorRGBA': '#FF8C00', 'MFColorRGBA': '#FF8C00',
+    'SFRotation':  '#9B59B6', 'MFRotation':  '#9B59B6',
+    'SFString':    '#FF69B4', 'MFString':    '#FF69B4',
+    'SFMatrix3f':  '#E74C3C', 'MFMatrix3f':  '#E74C3C',
+    'SFMatrix4f':  '#E74C3C', 'MFMatrix4f':  '#E74C3C',
+    'SFMatrix3d':  '#E74C3C', 'MFMatrix3d':  '#E74C3C',
+    'SFMatrix4d':  '#E74C3C', 'MFMatrix4d':  '#E74C3C',
+    'SFImage':     '#8B6914', 'MFImage':     '#8B6914',
+}
+
 class RKXGraphicsSocket(QGraphicsItem):
-    def __init__(self, parent=None, isOutput=False):
+    def __init__(self, parent=None, isOutput=False, field_type='', field_name=''):
         super().__init__(parent)
 
-        self.isOutput = isOutput
+        self.isOutput   = isOutput
+        self.field_type = field_type
+        self.socket     = None  # set by RKXSocket after creation
         
         self._und_green         = QColor("#FF009A44")
         self._und_green_trans   = QColor("#55009A44")
@@ -23,7 +49,10 @@ class RKXGraphicsSocket(QGraphicsItem):
         self._und_black         = QColor(Qt.black)
         
         self.radius = 6.0
-        if self.isOutput:
+        type_color = _TYPE_COLORS.get(field_type)
+        if type_color:
+            self._color_background = QColor(type_color)
+        elif self.isOutput:
             self._color_background = self._und_green
         else:
             self._color_background = self._und_orange
@@ -31,8 +60,21 @@ class RKXGraphicsSocket(QGraphicsItem):
         
         self._pen   = QPen(self._color_outline)
         self._brush = QBrush(self._color_background)
-        
         self._pen.setWidthF(self.outline_width)
+        self.setZValue(1)  # render above splines (edges are at Z=-1)
+
+        # Field name label positioned inside the node
+        self._label = QGraphicsSimpleTextItem(field_name, self)
+        lbl_font = QFont('Arial')
+        lbl_font.setPixelSize(9)
+        lbl_font.setBold(True)
+        self._label.setFont(lbl_font)
+        self._label.setBrush(QBrush(QColor('#FFFFFF')))
+        lbl_w = self._label.boundingRect().width()
+        if isOutput:
+            self._label.setPos(-self.radius - lbl_w - 4, -7)  # left of dot, inside node
+        else:
+            self._label.setPos(self.radius + 4, -7)            # right of dot, inside node
 
         
     def boundingRect(self):

--- a/rawkee/editor/RKXNodes.py
+++ b/rawkee/editor/RKXNodes.py
@@ -3,34 +3,56 @@ from rawkee.editor.RKXContentWidget import RKXContentWidget
 from rawkee.editor.RKXSocket        import *
 
 class RKXNode():
-    def __init__(self, scene, title="Undefined Node", inputs=[], outputs=[]):
+    @staticmethod
+    def _norm(fields):
+        """Accept [(name, type)] or [name] and always return [(name, type)]."""
+        result = []
+        for f in fields:
+            if isinstance(f, (list, tuple)) and len(f) >= 2:
+                result.append((str(f[0]), str(f[1])))
+            else:
+                result.append((str(f), ''))
+        return result
+
+    def __init__(self, scene, title="Undefined Node", inputs=[], outputs=[], x3d_node=None, node_type=''):
         self.scene = scene
         
-        self.title = title
+        self.title    = title
+        self.x3d_node = x3d_node
+        self.input_fields  = self._norm(inputs)
+        self.output_fields = self._norm(outputs)
         
         self.content = RKXContentWidget()
+        self.content.setNodeType(node_type)
         self.grNode = RKXGraphicsNode(self)
-        
+
+        self.socket_spacing = 22
+
+        # Compute height before placing sockets so positions are correct
+        n_out = len(self.output_fields)
+        n_in  = len(self.input_fields)
+        top_start = int(self.grNode.title_height * self.grNode._padding) + self.grNode.edge_size
+        bot_start = self.grNode.edge_size + int(self.grNode._padding)
+        # Height spans max(n_in, n_out) rows so inputs and outputs share the same Y range
+        n = max(n_in, n_out, 1)
+        needed = top_start + (n - 1) * self.socket_spacing + bot_start
+        self.grNode.height = max(needed, 100)
+        self.grNode.initContent()
+
         self.scene.add_eNode(self)
         self.scene.grScene.addItem(self.grNode)
-        
-        self.socket_spacing = 22
-        
+
         # create sockets for inputs and outputs
         self.inputs  = []
         self.outputs = []
-        
-        counter = 0
-        for item in inputs:
-            socket = RKXSocket(eNode=self, index=counter, position=LEFT_BOTTOM )
+
+        for counter, (field_name, field_type) in enumerate(self.input_fields):
+            socket = RKXSocket(eNode=self, index=counter, position=LEFT_BOTTOM, field_type=field_type, field_name=field_name)
             self.inputs.append(socket)
-            counter += 1
-        
-        counter = 0
-        for item in outputs:
-            socket = RKXSocket(eNode=self, index=counter, position=RIGHT_TOP, isOutput=True)
+
+        for counter, (field_name, field_type) in enumerate(self.output_fields):
+            socket = RKXSocket(eNode=self, index=counter, position=RIGHT_TOP, isOutput=True, field_type=field_type, field_name=field_name)
             self.outputs.append(socket)
-            counter += 1
 
     @property
     def pos(self):
@@ -50,5 +72,23 @@ class RKXNode():
             y = (self.grNode.title_height * self.grNode._padding) + self.grNode.edge_size + (index * self.socket_spacing)
 
         return x, y
+
+    def _resize_for_sockets(self):
+        """Recompute node height from current socket counts; reposition input sockets."""
+        n_out = len(self.output_fields)
+        n_in  = len(self.input_fields)
+        top_start = int(self.grNode.title_height * self.grNode._padding) + self.grNode.edge_size
+        bot_start = self.grNode.edge_size + int(self.grNode._padding)
+        n = max(n_in, n_out, 1)
+        needed = top_start + (n - 1) * self.socket_spacing + bot_start
+        new_height = max(needed, 100)
+        if new_height == self.grNode.height:
+            return
+        self.grNode.prepareGeometryChange()
+        self.grNode.height = new_height
+        self.grNode.initContent()
+        for sock in self.inputs:
+            sock.grSocket.setPos(*self.getSocketPosition(sock.index, LEFT_BOTTOM))
+        self.grNode.update()
 
 

--- a/rawkee/editor/RKXScene.py
+++ b/rawkee/editor/RKXScene.py
@@ -1,15 +1,59 @@
 import rawkee.io.RKx3d as rkx
 from rawkee.editor.RKGraphics import RKGraphicsScene
 
+def _is_inputoutput_field(field_name, x3d_node):
+    """Return True only if field_name is declared inputOutput on x3d_node's type."""
+    if not hasattr(type(x3d_node), 'FIELD_DECLARATIONS'):
+        return False
+    for decl in type(x3d_node).FIELD_DECLARATIONS():
+        try:
+            access_str = decl[3]()
+        except Exception:
+            continue
+        if decl[0] == field_name and access_str == 'inputOutput':
+            return True
+    return False
+
+
+def _fields_match(name_a, name_b, x3d_node):
+    """True if name_a and name_b name the same routable event on x3d_node.
+    set_foo / foo_changed are treated as aliases only when foo is inputOutput."""
+    if name_a == name_b:
+        return True
+    for raw, aliased in ((name_a, name_b), (name_b, name_a)):
+        if aliased.endswith('_changed') and aliased[:-8] == raw:
+            if _is_inputoutput_field(raw, x3d_node):
+                return True
+        elif aliased.startswith('set_') and aliased[4:] == raw:
+            if _is_inputoutput_field(raw, x3d_node):
+                return True
+    return False
+
+# Field types that are implicitly compatible for ROUTE purposes
+_COMPAT_GROUPS = [
+    {'SFFloat', 'SFDouble', 'SFTime'},
+    {'MFFloat', 'MFDouble', 'MFTime'},
+]
+
+def _types_compatible(t1, t2):
+    if t1 == t2:
+        return True
+    for group in _COMPAT_GROUPS:
+        if t1 in group and t2 in group:
+            return True
+    # SFNode and MFNode fields are routable when both sides match
+    if t1 in ('SFNode', 'MFNode') and t2 in ('SFNode', 'MFNode'):
+        return True
+    return False
+
 class RKXScene(rkx.Scene):# class X3D_Transform (aom.MPxNode, x3d.Transform):
     
     def __init__(self):
         super().__init__()
-        #super(RKScene, self).__init__()
-		#x3d.Transform.__init__(self)
         
         self.eNodes = []
         self.eEdges = []
+        self._x3d_scene = None  # reference to rkx.Scene; used for ROUTE insertion
         
         self.scene_width  = 64000
         self.scene_height = 64000
@@ -26,18 +70,104 @@ class RKXScene(rkx.Scene):# class X3D_Transform (aom.MPxNode, x3d.Transform):
         
     def add_eEdge(self, eEdge):
         self.eEdges.append(eEdge)
+        self._add_route_for_edge(eEdge)
         
     def remove_eNode(self, eNode):
         self.eNodes.remove(eNode)
         
     def remove_eEdge(self, eEdge):
+        self._remove_route_for_edge(eEdge)
         self.eEdges.remove(eEdge)
-        
+
+    def _remove_route_for_edge(self, edge):
+        """When an edge is removed, delete the corresponding ROUTE from the X3D scene."""
+        if self._x3d_scene is None:
+            return
+        ss = edge.start_socket
+        es = edge.end_socket
+        if ss is None or es is None:
+            return
+        from_x3d = getattr(ss.eNode, 'x3d_node', None)
+        to_x3d   = getattr(es.eNode, 'x3d_node', None)
+        if from_x3d is None or to_x3d is None:
+            return
+        from_def = getattr(from_x3d, 'DEF', '')
+        to_def   = getattr(to_x3d,   'DEF', '')
+        if not from_def or not to_def:
+            return
+        out_fields = ss.eNode.output_fields
+        in_fields  = es.eNode.input_fields
+        if ss.index >= len(out_fields) or es.index >= len(in_fields):
+            return
+        from_field = out_fields[ss.index][0]
+        to_field   = in_fields[es.index][0]
+        if not from_field or not to_field:
+            return
+        self._x3d_scene.children = [
+            c for c in self._x3d_scene.children
+            if not (hasattr(c, 'fromNode') and
+                    c.fromNode == from_def and
+                    _fields_match(c.fromField, from_field, from_x3d) and
+                    c.toNode   == to_def   and
+                    _fields_match(c.toField, to_field, to_x3d))
+        ]
+
+    def set_x3d_scene(self, x3d_scene):
+        self._x3d_scene = x3d_scene
+
+    def clear_graph(self):
+        """Remove all nodes and edges from the canvas without touching the scenegraph tree."""
+        for edge in list(self.eEdges):
+            if edge.grEdge is not None:
+                self.grScene.removeItem(edge.grEdge)
+        for node in list(self.eNodes):
+            if node.grNode is not None:
+                self.grScene.removeItem(node.grNode)
+        self.eNodes.clear()
+        self.eEdges.clear()
+
+    def _add_route_for_edge(self, edge):
+        """When a fully-connected edge is added, append a ROUTE to the X3D scene."""
+        if self._x3d_scene is None:
+            return
+        if edge.start_socket is None or edge.end_socket is None:
+            return
+        from_x3d = getattr(edge.start_socket.eNode, 'x3d_node', None)
+        to_x3d   = getattr(edge.end_socket.eNode,   'x3d_node', None)
+        if from_x3d is None or to_x3d is None:
+            return
+        from_def = getattr(from_x3d, 'DEF', '')
+        to_def   = getattr(to_x3d,   'DEF', '')
+        if not from_def or not to_def:
+            return
+        out_fields = edge.start_socket.eNode.output_fields
+        in_fields  = edge.end_socket.eNode.input_fields
+        si = edge.start_socket.index
+        ei = edge.end_socket.index
+        if si >= len(out_fields) or ei >= len(in_fields):
+            return
+        from_field, from_type = out_fields[si]
+        to_field,   to_type   = in_fields[ei]
+        if not from_field or not to_field:
+            return
+        # Skip if an equivalent ROUTE already exists (legacy set_/_changed aliases for inputOutput only)
+        for existing in self._x3d_scene.children:
+            if (hasattr(existing, 'fromNode') and
+                    existing.fromNode == from_def and
+                    _fields_match(existing.fromField, from_field, from_x3d) and
+                    existing.toNode   == to_def   and
+                    _fields_match(existing.toField, to_field, to_x3d)):
+                return
+        route = rkx.ROUTE()
+        route.fromNode  = from_def
+        route.fromField = from_field
+        route.toNode    = to_def
+        route.toField   = to_field
+        self._x3d_scene.children.append(route)
+
     def initUI(self):
         self.grScene = RKGraphicsScene(self)
         self.grScene.setGrScene(self.scene_width, self.scene_height)
-
-        
 
     @classmethod
     def creator(cls):

--- a/rawkee/editor/RKXSocket.py
+++ b/rawkee/editor/RKXSocket.py
@@ -7,13 +7,16 @@ RIGHT_BOTTOM = 4
 
 
 class RKXSocket():
-    def __init__(self, eNode, index=0, position=LEFT_TOP, isOutput=False):
+    def __init__(self, eNode, index=0, position=LEFT_TOP, isOutput=False, field_type='', field_name=''):
         
-        self.eNode = eNode
-        self.index = index
-        self.position = position
-        self.isOutput = isOutput
+        self.eNode      = eNode
+        self.index      = index
+        self.position   = position
+        self.isOutput   = isOutput
+        self.field_type = field_type
+        self.field_name = field_name
         
-        self.grSocket = RKXGraphicsSocket(self.eNode.grNode, isOutput)
+        self.grSocket = RKXGraphicsSocket(self.eNode.grNode, isOutput, field_type, field_name)
+        self.grSocket.socket = self  # back-reference for drag-to-connect
 
         self.grSocket.setPos(*self.eNode.getSocketPosition(index, position))

--- a/rawkee/editor/__main__.py
+++ b/rawkee/editor/__main__.py
@@ -31,9 +31,23 @@ else:
                           '--ignore-gpu-blacklist --ignore-gpu-blocklist')
 
 from PySide6.QtWidgets import QApplication
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QtMsgType, qInstallMessageHandler
 from PySide6.QtGui import QPalette, QColor
 from rawkee.editor.RKSceneEditor import RKSceneEditor
+
+
+def _qt_message_handler(msg_type, context, message):
+    # Suppress noisy Qt painter/rendering warnings that don't affect functionality
+    _suppressed = (
+        'QPainter::',
+        'QBackingStore::',
+        'QOpenGLContext::',
+        'updateRequestSent',
+    )
+    if any(message.startswith(s) for s in _suppressed):
+        return
+    if msg_type in (QtMsgType.QtDebugMsg, QtMsgType.QtInfoMsg):
+        return
 
 
 def _apply_dark_palette(app):
@@ -63,6 +77,7 @@ def _apply_dark_palette(app):
 
 
 def main():
+    qInstallMessageHandler(_qt_message_handler)
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     app = QApplication.instance() or QApplication(sys.argv)
     _apply_dark_palette(app)

--- a/rawkee/io/RKLoadSceneFromFile.py
+++ b/rawkee/io/RKLoadSceneFromFile.py
@@ -578,12 +578,22 @@ class RKLoadSceneFromFile:
 
             elif tok == 'COMPONENT':
                 self._classicConsume()
-                compTok  = self._classicConsume()   # Name:level
-                parts    = compTok.split(':')
+                compTok = self._classicConsume()    # "Name:level" or just "Name"
+                # Handle both "Name:level" (no spaces) and "Name : level" (spaces)
+                if ':' in compTok:
+                    parts = compTok.split(':')
+                    compName  = parts[0].strip()
+                    compLevel = int(parts[1].strip()) if len(parts) > 1 else 1
+                else:
+                    compName = compTok
+                    if self._classicPeek() == ':':
+                        self._classicConsume()      # consume ':'
+                    try:    compLevel = int(self._classicConsume())
+                    except Exception: compLevel = 1
                 compNode = component()
-                try:    compNode.name  = parts[0].strip()
+                try:    compNode.name  = compName
                 except Exception: pass
-                try:    compNode.level = int(parts[1].strip()) if len(parts) > 1 else 1
+                try:    compNode.level = compLevel
                 except Exception: pass
                 if x3dDoc.head is None:
                     x3dDoc.head = head()

--- a/rawkee/io/RKx3d.py
+++ b/rawkee/io/RKx3d.py
@@ -60170,8 +60170,9 @@ print("x3d.py package 4.0.64.5 loaded, have fun with X3D Graphics!", flush=True)
 ###############################################
 
 
-def instantiateNodeFromString(x3dType):
-    x3dNodeMapping = {
+def instantiateNodeFromString(x3dType, _cache={}):
+    if not _cache:
+        _cache.update({
         ####################################### A
         'AcousticProperties':(AcousticProperties(), {'Core':1, 'Lighting':4, 'Grouping':1, 'Rendering':1, 'Shape':4}),
         'Analyser':(Analyser(), {'Core':1, 'Sound':2, 'Time':1}),
@@ -60473,8 +60474,14 @@ def instantiateNodeFromString(x3dType):
         'WaveShaper':(WaveShaper(), {'Core':1, 'Sound':2, 'Time':1}),
         'WindPhysicsModel':(WindPhysicsModel(), {'Core':1, 'Grouping':1, 'ParticleSystems':1, 'Rendering':1, 'Shape':1}),
         'WorldInfo':(WorldInfo(), {'Core':1})
-    }
+        })
 
-    return x3dNodeMapping.get(x3dType, (None, {'NotFound':0}))
-    
+    result = _cache.get(x3dType)
+    if result is None:
+        return (None, {'NotFound': 0})
+    node_or_class, profile_dict = result
+    if isinstance(node_or_class, type):
+        return (node_or_class, profile_dict)
+    return (type(node_or_class)(), profile_dict)
+
     #return x3dNodeMapping[x3dType]()


### PR DESCRIPTION
This pull request introduces several enhancements to the X3D node editor, focusing on improved graph editing, more complete support for X3D event fields, and better integration between the scene tree and the graphical editor. The most significant changes add interactive edge (connection) creation and deletion in the node graph, extend the set of recognized event fields for X3D nodes, and ensure better synchronization and clearing of the graph editor in response to UI actions.

**Graph Editor Interactivity and Integration:**

* Added interactive edge (connection) creation, dragging, completion, and cancellation to the node editor (`RKGraphics.py`). This allows users to visually connect node sockets, with enforcement of input/output direction and the ability to delete edges via keyboard or context menu. Also added context menu options for fitting nodes to view, displaying adjacent/connected nodes, and clearing nodes from the editor.
* The graph editor now synchronizes with the X3D scene: when a new scene is loaded or created, or when "Clear Graph Editor" is triggered, the visual graph is cleared to match the current scene. (Fb9a63f5L549, Fb9a63f5L565)

**X3D Event Field Support:**

* Added `_EXTRA_EVENT_FIELDS` to `RKSceneEditor.py`, defining missing `inputOnly` and `outputOnly` event fields for a wide range of X3D node types. This improves the accuracy and completeness of the node editor's representation of X3D event interfaces.

**Scene Tree and Node Editor Integration:**

* Updated the scene tree to register `USE` references, allowing them to be resolved and dragged into the node editor, improving the workflow for reusing nodes. (Fb9a63f5L293)
* When a new scene is set, the node editor widget is updated to reflect the new X3D scene, ensuring visual and data consistency. (Fb9a63f5L269)

**UI and Action Wiring:**

* Added a "Clear Graph Editor" action to the X3D Nodes menu, wired it to the editor, and ensured it clears the visual graph when triggered. (Fb9a63f5L386, Fb9a63f5L404, Fb9a63f5L525, Fb9a63f5L549, Fb9a63f5L565)

These changes collectively make the node editor more interactive, robust, and better synchronized with the underlying X3D data model.… menues to better control Graph Node placement and node display features based on node connections. Minor tweaks to loader and RKx3d.py