### PR TITLE
Quick Test Reset

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -514,31 +514,14 @@ class RKSceneEditor(QMainWindow):
         self.node_editor_widget.clearGraph()
         scene_node = getattr(x3d, 'Scene', None)
         self.setX3DScene(scene_node)
-        self._push_file_to_xite(file_path)
+        self._push_file_to_xite()
         self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
 
-    def _push_file_to_xite(self, file_path):
-        import json, re
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-        except Exception as e:
-            self.console_widget.appendPlainText(f"File read error: {e}")
+    def _push_file_to_xite(self):
+        if self._x3dObj is None:
             return
-        # Strip XML declaration and DOCTYPE — createX3DFromString expects bare <X3D>
-        content = re.sub(r'<\?xml[^?]*\?>', '', content)
-        content = re.sub(r'<!DOCTYPE[^>]*>', '', content)
-        # Upgrade Core profile to Immersive so X_ITE enables the full render pipeline
-        content = re.sub(r"profile=['\"]Core['\"]", "profile='Immersive'", content)
-        content = content.strip()
-        js = (
-            "(function(){"
-            " var c=document.querySelector('x3d-canvas');"
-            " c.removeAttribute('src');"
-            " c.browser.replaceWorld(c.browser.createX3DFromString(" + json.dumps(content) + "));"
-            "})()"
-        )
-        self.browser.page().runJavaScript(js)
+        trv = RKSceneTraversal()
+        self.browser.page().runJavaScript(trv.scene2sai(self._x3dObj))
 
     def on_export_as(self):
         if self._x3dObj is None:

--- a/rawkee/editor/RKXScene.py
+++ b/rawkee/editor/RKXScene.py
@@ -124,7 +124,9 @@ class RKXScene(rkx.Scene):# class X3D_Transform (aom.MPxNode, x3d.Transform):
             f"var s=b.currentScene;"
             f"var fn=s.getNamedNode({from_def!r});"
             f"var tn=s.getNamedNode({to_def!r});"
-            f"if(fn&&tn)b.deleteRoute(fn,{from_field!r},tn,{to_field!r});}})()"
+            f"b.endUpdate();"
+            f"if(fn&&tn)b.deleteRoute(fn,{from_field!r},tn,{to_field!r});"
+            f"b.beginUpdate();}})()"
         )
 
     def set_x3d_scene(self, x3d_scene):
@@ -184,7 +186,9 @@ class RKXScene(rkx.Scene):# class X3D_Transform (aom.MPxNode, x3d.Transform):
             f"var s=b.currentScene;"
             f"var fn=s.getNamedNode({from_def!r});"
             f"var tn=s.getNamedNode({to_def!r});"
-            f"if(fn&&tn)b.addRoute(fn,{from_field!r},tn,{to_field!r});}})()"
+            f"b.endUpdate();"
+            f"if(fn&&tn)b.addRoute(fn,{from_field!r},tn,{to_field!r});"
+            f"b.beginUpdate();}})()"
         )
 
     def initUI(self):

--- a/rawkee/examples/x_ite.bak
+++ b/rawkee/examples/x_ite.bak
@@ -18,6 +18,6 @@ x3d-canvas {
     </style>
   </head>
   <body>
-    <x3d-canvas src="empty.x3d"></x3d-canvas>
+    <x3d-canvas src="example.x3d"></x3d-canvas>
   </body>
 </html>

--- a/rawkee/examples/x_ite.html
+++ b/rawkee/examples/x_ite.html
@@ -18,6 +18,6 @@ x3d-canvas {
     </style>
   </head>
   <body>
-    <x3d-canvas src="example.x3d"></x3d-canvas>
+    <x3d-canvas src="empty.x3d"></x3d-canvas>
   </body>
 </html>

--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -1286,6 +1286,7 @@ class RKSceneTraversal():
             '(function () {',
             '  var b = document.querySelector(\'x3d-canvas\').browser;',
             '  var s = b.currentScene;',
+            '  b.endUpdate();',
             '  var rn = []; for (var _i = 0; _i < s.rootNodes.length; _i++) rn.push(s.rootNodes[_i]);',
             '  rn.forEach(function (n) { s.removeRootNode(n); });',
             '  var nodes = {};',
@@ -1311,8 +1312,8 @@ class RKSceneTraversal():
                         f' b.addRoute(nodes[{json.dumps(fd)}], {json.dumps(ff)},'
                         f' nodes[{json.dumps(td)}], {json.dumps(tf)});'
                     )
+        lines.append('  b.beginUpdate();')
         lines.append('  b.viewAll();')
-        lines.append('  window.dispatchEvent(new Event("resize"));')
         lines.append('})();')
         return '\n'.join(lines)
 


### PR DESCRIPTION
This pull request refactors how X3D scene updates are pushed to the X_ITE browser and improves the atomicity of route modifications in the scene graph. The changes move away from string-based X3D serialization in favor of programmatically traversing and updating the scene, and ensure that batch updates are properly bracketed to avoid rendering artifacts. Additionally, there are minor adjustments to example files.

**Scene update and traversal refactoring:**

* The `_push_file_to_xite` method in `RKSceneEditor.py` now uses the `RKSceneTraversal.scene2sai` method to generate JavaScript for updating the X_ITE scene, rather than reading and manipulating the file as a string. This makes the update process more robust and less error-prone.
* The `scene2sai` method in `RKSceneTraversal.py` now calls `b.endUpdate()` before removing root nodes and adds a `b.beginUpdate()` after adding all routes, ensuring that scene updates are performed atomically. [[1]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14R1289) [[2]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14R1315-L1315)

**Atomic route modifications:**

* Both `_add_route_for_edge` and `_remove_route_for_edge` in `RKXScene.py` now bracket route changes with `b.endUpdate()` and `b.beginUpdate()`, ensuring that batch changes are applied cleanly and efficiently. [[1]](diffhunk://#diff-9021e0877d6bb5ca84adaefa5ad5651abb25075b89a04ee679f4514fd26089efL127-R129) [[2]](diffhunk://#diff-9021e0877d6bb5ca84adaefa5ad5651abb25075b89a04ee679f4514fd26089efL187-R191)

**Example file adjustments:**

* The `src` attribute in `x_ite.bak` and `x_ite.html` example files was swapped: `x_ite.bak` now loads `example.x3d`, while `x_ite.html` loads `empty.x3d`. [[1]](diffhunk://#diff-dd3bca5a0c0b60ef5f2de8cb4146fdbde1b21f72133cf88b3240e09677e24c35L21-R21) [[2]](diffhunk://#diff-f18fc4762a53ad29b18740201369dd81715d576e7d26cc9cd71c35e717b4af32L21-R21)