### PR TITLE
Added a group node to the empty.x3d file with a known DEF.

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -496,7 +496,11 @@ class RKSceneEditor(QMainWindow):
         self._x3dObj = None
         self.node_editor_widget.clearGraph()
         self.setX3DScene(None)
-        self.browser.reload()
+        self.browser.page().runJavaScript(
+            "(function(){var b=document.querySelector('x3d-canvas').browser;"
+            "var g=b.currentScene.getNamedNode('RKInteractionEditor');"
+            "b.endUpdate();g.children=[];b.beginUpdate();})()"
+        )
         self.setWindowTitle("RawKee PE - X3D Interaction Editor")
 
     def on_open_file(self):

--- a/rawkee/examples/empty.x3d
+++ b/rawkee/examples/empty.x3d
@@ -5,5 +5,6 @@
 		<meta name='generator' content='RawKee X3D Exporter for Maya 2025+ [Python Edition], https://github.com/und-dream-lab/rawkee/'/>
 	</head>
 	<Scene>
+		<Group DEF='RKInteractionEditor'/>
 	</Scene>
 </X3D>

--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -1281,18 +1281,18 @@ class RKSceneTraversal():
 
 
     def scene2sai(self, x3dDoc):
-        """Return a JS IIFE that rebuilds x3dDoc.Scene in X_ITE via SAI."""
+        """Return a JS IIFE that populates the permanent RKInteractionEditor Group via SAI."""
         lines = [
             '(function () {',
             '  var b = document.querySelector(\'x3d-canvas\').browser;',
             '  var s = b.currentScene;',
-            '  b.endUpdate();',
-            '  var rn = []; for (var _i = 0; _i < s.rootNodes.length; _i++) rn.push(s.rootNodes[_i]);',
-            '  rn.forEach(function (n) { s.removeRootNode(n); });',
+            '  var g = s.getNamedNode(\'RKInteractionEditor\');',
             '  var nodes = {};',
+            '  b.endUpdate();',
         ]
         counter = [0]
         routes  = []
+        root_vars = []
         if x3dDoc and x3dDoc.Scene:
             for child in x3dDoc.Scene.children:
                 if type(child).__name__ == 'ROUTE':
@@ -1300,7 +1300,10 @@ class RKSceneTraversal():
                 else:
                     var = self._node2sai(child, lines, counter)
                     if var:
-                        lines.append(f'  s.addRootNode({var});')
+                        root_vars.append(var)
+            if root_vars:
+                root_js = ', '.join(root_vars)
+                lines.append(f'  g.children = [{root_js}];')
             for r in routes:
                 fd = getattr(r, 'fromNode',  '') or ''
                 ff = getattr(r, 'fromField', '') or ''


### PR DESCRIPTION
This pull request refactors how the editor manages and updates the X3D scene, specifically focusing on the use of a permanent `RKInteractionEditor` group node. The changes ensure that scene updates are performed by manipulating the children of this group, rather than replacing root nodes directly, and that the group is always present in new scenes and example files.

**Scene management and updates:**

* In `RKSceneEditor.py`, replaced a full browser reload with JavaScript that clears the children of the `RKInteractionEditor` group, ensuring a smoother and more targeted scene reset.
* In `RKSceneTraversal.py`, changed the `scene2sai` method to populate the `RKInteractionEditor` group with new nodes instead of replacing all root nodes, making scene updates more modular and less disruptive.

**Scene structure:**

* Updated the `empty.x3d` example to always include a `Group` node with `DEF='RKInteractionEditor'`, ensuring the necessary group is present for scene manipulation.