### PR TITLE
Found the reason why the render failed, claude incorrectly set fields…

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -509,10 +509,13 @@ class RKSceneEditor(QMainWindow):
             " var mt=s.getNamedNode('myTransform');"
             " var ot=s.getNamedNode('otherTransform');"
             " if(!mt||!ot) return 'ERROR: nodes not found';"
-            " b.addRoute(mt,'translation_changed',ot,'set_translation');"
-            " mt.translation=[10,0,0];"
-            " return 'Route added; myTransform=[10,0,0]; otherTransform.translation='"
-            "        +JSON.stringify(Array.from(ot.translation));"
+            " var before_mt=JSON.stringify(Array.from(mt.translation));"
+            " b.endUpdate();"
+            " mt.translation = new mt.translation.constructor(0,0,0);"
+            " b.beginUpdate();"
+            " b.resetViewpoint();"
+            " var after_mt=JSON.stringify(Array.from(mt.translation));"
+            " return 'before='+before_mt+' after='+after_mt;"
             "})()"
         )
         self.browser.page().runJavaScript(
@@ -531,9 +534,11 @@ class RKSceneEditor(QMainWindow):
         self.node_editor_widget.clearGraph()
         self.setX3DScene(None)
         self.browser.page().runJavaScript(
-            "(function(){var b=document.querySelector('x3d-canvas').browser;"
-            "var g=b.currentScene.getNamedNode('RKInteractionEditor');"
-            "b.endUpdate();g.children=[];b.beginUpdate();})()"
+            "(function(){var c=document.querySelector('x3d-canvas');"
+            "if(!c||!c.browser)return;"
+            "var b=c.browser;var s=b.currentScene;"
+            "var rn=[];for(var i=0;i<s.rootNodes.length;i++)rn.push(s.rootNodes[i]);"
+            "b.endUpdate();rn.forEach(function(n){s.removeRootNode(n);});b.beginUpdate();})()"
         )
         self.setWindowTitle("RawKee PE - X3D Interaction Editor")
 
@@ -558,14 +563,6 @@ class RKSceneEditor(QMainWindow):
     def _push_file_to_xite(self):
         if self._x3dObj is None:
             return
-        # Confirm x3d-canvas and X_ITE browser are ready
-        self.browser.page().runJavaScript(
-            "(function(){var c=document.querySelector('x3d-canvas');"
-            "var g=c&&c.browser?c.browser.currentScene.getNamedNode('RKInteractionEditor'):null;"
-            "return g?'RKIENode: found':'RKIENode: NOT FOUND (canvas='+(c?'ok':'null')+')';})()",
-            lambda r: (print(f"SAI check: {r}"),
-                       self.console_widget.appendPlainText(f"SAI check: {r}"))
-        )
         trv = RKSceneTraversal()
         self.browser.page().runJavaScript(trv.scene2sai(self._x3dObj))
 

--- a/rawkee/examples/empty.bak
+++ b/rawkee/examples/empty.bak
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE X3D PUBLIC "ISO//Web3D//DTD X3D 4.1//EN" "https://www.web3d.org/specifications/x3d-4.0.dtd">
+<!DOCTYPE X3D PUBLIC "ISO//Web3D//DTD X3D 4.1//EN" "https://www.web3d.org/specifications/x3d-4.1.dtd">
 <X3D profile='Full' version='4.1' xmlns:xsd='http://www.w3.org/2001/XMLSchema-instance' xsd:noNamespaceSchemaLocation='https://www.web3d.org/specifications/x3d-4.1.xsd'>
 	<head>
 		<meta name='generator' content='RawKee X3D Exporter for Maya 2025+ [Python Edition], https://github.com/und-dream-lab/rawkee/'/>
 	</head>
 	<Scene>
+		<Group DEF='RKInteractionEditor'/>
 	</Scene>
 </X3D>

--- a/rawkee/examples/empty.x3d
+++ b/rawkee/examples/empty.x3d
@@ -5,6 +5,5 @@
 		<meta name='generator' content='RawKee X3D Exporter for Maya 2025+ [Python Edition], https://github.com/und-dream-lab/rawkee/'/>
 	</head>
 	<Scene>
-		<Group DEF='RKInteractionEditor'/>
 	</Scene>
 </X3D>

--- a/rawkee/examples/x_ite.html
+++ b/rawkee/examples/x_ite.html
@@ -18,6 +18,6 @@ x3d-canvas {
     </style>
   </head>
   <body>
-    <x3d-canvas src="example.x3d"></x3d-canvas>
+    <x3d-canvas src="empty.x3d"></x3d-canvas>
   </body>
 </html>

--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -1281,21 +1281,20 @@ class RKSceneTraversal():
 
 
     def scene2sai(self, x3dDoc):
-        """Return a JS IIFE that populates the permanent RKInteractionEditor Group via SAI."""
+        """Return a JS IIFE that rebuilds x3dDoc.Scene in X_ITE via SAI."""
         lines = [
             '(function () {',
             '  var c = document.querySelector(\'x3d-canvas\');',
             '  if (!c || !c.browser) return;',
             '  var b = c.browser;',
             '  var s = b.currentScene;',
-            '  var g = s.getNamedNode(\'RKInteractionEditor\');',
-            '  if (!g) return;',
-            '  var nodes = {};',
+            '  var rn = []; for (var _i = 0; _i < s.rootNodes.length; _i++) rn.push(s.rootNodes[_i]);',
             '  b.endUpdate();',
+            '  rn.forEach(function (n) { s.removeRootNode(n); });',
+            '  var nodes = {};',
         ]
         counter = [0]
         routes  = []
-        root_vars = []
         if x3dDoc and x3dDoc.Scene:
             for child in x3dDoc.Scene.children:
                 if type(child).__name__ == 'ROUTE':
@@ -1303,10 +1302,7 @@ class RKSceneTraversal():
                 else:
                     var = self._node2sai(child, lines, counter)
                     if var:
-                        root_vars.append(var)
-            if root_vars:
-                root_js = ', '.join(root_vars)
-                lines.append(f'  g.children = [{root_js}];')
+                        lines.append(f'  s.addRootNode({var});')
             for r in routes:
                 fd = getattr(r, 'fromNode',  '') or ''
                 ff = getattr(r, 'fromField', '') or ''
@@ -1315,13 +1311,13 @@ class RKSceneTraversal():
                 if fd and ff and td and tf:
                     lines.append(
                         f'  if (nodes[{json.dumps(fd)}] && nodes[{json.dumps(td)}])'
-                        f' b.addRoute(nodes[{json.dumps(fd)}], {json.dumps(ff)},'
+                        f' s.addRoute(nodes[{json.dumps(fd)}], {json.dumps(ff)},'
                         f' nodes[{json.dumps(td)}], {json.dumps(tf)});'
                     )
         lines.append('  b.beginUpdate();')
         lines.append('  b.viewAll();')
         lines.append('  b.firstViewpoint();')
-        lines.append('  console.log("RKI children=" + g.children.length + " rootNodes=" + s.rootNodes.length);')
+        lines.append('  console.log("RKI rootNodes=" + s.rootNodes.length);')
         lines.append('})();')
         return '\n'.join(lines)
 
@@ -1384,7 +1380,11 @@ class RKSceneTraversal():
             else:
                 if value == default_val or value is None:
                     continue
-                if isinstance(value, (str, float, int, tuple, bool)):
+                if isinstance(value, tuple):
+                    # SFVec3f/SFColor/SFRotation etc. — must use typed constructor
+                    args = ', '.join(repr(x) for x in value)
+                    lines.append(f'  {var}.{js_fname} = new {var}.{js_fname}.constructor({args});')
+                elif isinstance(value, (str, float, int, bool)):
                     lines.append(f'  {var}.{js_fname} = {self._py2js(value)};')
                 elif hasattr(value, 'NAME'):
                     cv = self._node2sai(value, lines, counter)


### PR DESCRIPTION
This pull request introduces several updates to the handling of X3D scene management and SAI (Scene Access Interface) integration, with a focus on how scenes are reset, loaded, and rebuilt in the X_ITE browser. The changes improve scene clearing, route handling, and ensure that node attributes are set with the correct JavaScript constructors. There are also updates to example files to match the new logic.

**Scene management and SAI integration:**

* Updated the JavaScript logic in `RKSceneTraversal.scene2sai` to clear all root nodes from the scene before rebuilding it, rather than just modifying the `RKInteractionEditor` group. Rebuilt nodes are now added directly to `rootNodes`, and routes are attached at the scene level, not the browser level. [[1]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14L1284-R1305) [[2]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14L1318-R1320)
* Modified the attribute assignment in `_node2sai` to use the correct typed constructor for tuple values (e.g., SFVec3f, SFColor), ensuring proper type handling in the generated JavaScript.

**Editor behavior improvements:**

* Changed `on_new_scene` in `RKSceneEditor.py` to clear all root nodes from the scene in the browser when creating a new scene, instead of only clearing the children of the `RKInteractionEditor` group.
* Simplified the `_push_file_to_xite` method by removing a redundant SAI readiness check and directly invoking the scene traversal logic.
* Updated the `_on_test_routes` method to reset the translation of a node and viewpoint, and to report the translation before and after, improving test clarity.

**Example and documentation updates:**

* Changed the example file `x_ite.html` to load `empty.x3d` instead of `example.x3d`, aligning with the updated workflow.
* Updated the DOCTYPE in `empty.bak` to point to the X3D 4.1 DTD, and added an empty `RKInteractionEditor` group.
* Removed the `RKInteractionEditor` group from `empty.x3d` to avoid conflicts with the new scene clearing logic.… and cause the render to crash.