### PR TITLE
Adding the X_ITE Component to empty.x3d file.

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -513,7 +513,7 @@ class RKSceneEditor(QMainWindow):
             " b.endUpdate();"
             " mt.translation = new mt.translation.constructor(0,0,0);"
             " b.beginUpdate();"
-            " b.resetViewpoint();"
+            " b.firstViewpoint();"
             " var after_mt=JSON.stringify(Array.from(mt.translation));"
             " return 'before='+before_mt+' after='+after_mt;"
             "})()"
@@ -533,13 +533,8 @@ class RKSceneEditor(QMainWindow):
         self._x3dObj = None
         self.node_editor_widget.clearGraph()
         self.setX3DScene(None)
-        self.browser.page().runJavaScript(
-            "(function(){var c=document.querySelector('x3d-canvas');"
-            "if(!c||!c.browser)return;"
-            "var b=c.browser;var s=b.currentScene;"
-            "var rn=[];for(var i=0;i<s.rootNodes.length;i++)rn.push(s.rootNodes[i]);"
-            "b.endUpdate();rn.forEach(function(n){s.removeRootNode(n);});b.beginUpdate();})()"
-        )
+        trv = RKSceneTraversal()
+        self.browser.page().runJavaScript(trv.scene2sai(None))
         self.setWindowTitle("RawKee PE - X3D Interaction Editor")
 
     def on_open_file(self):

--- a/rawkee/examples/empty.bak
+++ b/rawkee/examples/empty.bak
@@ -5,6 +5,5 @@
 		<meta name='generator' content='RawKee X3D Exporter for Maya 2025+ [Python Edition], https://github.com/und-dream-lab/rawkee/'/>
 	</head>
 	<Scene>
-		<Group DEF='RKInteractionEditor'/>
 	</Scene>
 </X3D>

--- a/rawkee/examples/empty.x3d
+++ b/rawkee/examples/empty.x3d
@@ -2,6 +2,7 @@
 <!DOCTYPE X3D PUBLIC "ISO//Web3D//DTD X3D 4.1//EN" "https://www.web3d.org/specifications/x3d-4.1.dtd">
 <X3D profile='Full' version='4.1' xmlns:xsd='http://www.w3.org/2001/XMLSchema-instance' xsd:noNamespaceSchemaLocation='https://www.web3d.org/specifications/x3d-4.1.xsd'>
 	<head>
+		<component name='X_ITE' level='1'/>
 		<meta name='generator' content='RawKee X3D Exporter for Maya 2025+ [Python Edition], https://github.com/und-dream-lab/rawkee/'/>
 	</head>
 	<Scene>

--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -1334,13 +1334,14 @@ class RKSceneTraversal():
             return None
         compNode = nodeTuple[0]
 
+        x3d_type = node.NAME()  # canonical X3D name X_ITE recognises (vs Python subclass name)
         var = f'n{counter[0]}'
         counter[0] += 1
-        lines.append(f'  var {var} = s.createNode({json.dumps(nType)});')
+        lines.append(f'  var {var} = s.createNode({json.dumps(x3d_type)});')
 
         def_val = getattr(node, 'DEF', None) or ''
         if def_val:
-            lines.append(f'  s.addNamedNode({json.dumps(def_val)}, {var});')
+            lines.append(f'  s.updateNamedNode({json.dumps(def_val)}, {var});')
             lines.append(f'  nodes[{json.dumps(def_val)}] = {var};')
 
         pastMeta = False


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the scene editor and X3D export functionality. The main changes focus on better compatibility with X_ITE, improved scene clearing, and more accurate node creation in generated JavaScript.

**X3D and Scene Handling Improvements:**

* [`rawkee/examples/empty.x3d`](diffhunk://#diff-e1eec4a91203582cd46267e9ac4b6de0916a04dd5defa7265638a792da998788R5): Added the `<component name='X_ITE' level='1'/>` declaration to improve compatibility with the X_ITE X3D browser.
* [`rawkee/examples/empty.bak`](diffhunk://#diff-d80a9168670703397c6da9a56bf717b44dd04c7eac5612e041db6865bdf7e8bbL8): Removed the empty `Group` node from the default scene for a cleaner initial X3D file.

**Scene Editor and Traversal Logic Updates:**

* [`rawkee/editor/RKSceneEditor.py`](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L536-R537): Updated the scene clearing logic in `on_new_scene` to use the `scene2sai` method from `RKSceneTraversal`, ensuring more robust and consistent scene resets.
* [`rawkee/editor/RKSceneEditor.py`](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L516-R516): Changed the JavaScript method from `resetViewpoint()` to `firstViewpoint()` for improved viewpoint handling in test routes.
* [`rawkee/io/RKSceneTraversal.py`](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14R1337-R1344): Now uses the canonical X3D node name (via `node.NAME()`) when generating JavaScript for node creation, ensuring compatibility with X_ITE and correct node instantiation. Also replaced `addNamedNode` with `updateNamedNode` for better node management.