### PR TITLE
Integration of X_ITE browser with PySide6 Graph Editor, scene must ru…

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QGraphicsItem as rkgItem
 from PySide6.QtCore    import *
 from PySide6.QtWebEngineCore  import *
 
+import json
 import os
 import sys
 import http.server
@@ -262,15 +263,16 @@ class RKSceneEditor(QMainWindow):
 
         self.node_editor_name = ""
 
+        self.bkHost  = None
+        self.httpd   = None
+        self._x3dObj = None  # full rkx.X3D object kept in memory
+        self._file_url = None  # localhost URL of the open X3D file
+
         self.setURLPaths()
         self.create_actions()
         self.create_widgets()
         self.create_layout()
         self.create_connections()
-
-        self.bkHost  = None
-        self.httpd   = None
-        self._x3dObj = None  # full rkx.X3D object kept in memory
 
 
     def setX3DScene(self, x3dScene):
@@ -363,22 +365,32 @@ class RKSceneEditor(QMainWindow):
         self.cleanUpOnEditorClose()
         super().closeEvent(event)
 
+    _SERVER_PORT = 8765
+
+    def _local_url(self, abs_path):
+        """Convert an absolute local path to http://localhost URL."""
+        abs_path = os.path.abspath(abs_path)
+        if sys.platform == 'win32':
+            _, tail = os.path.splitdrive(abs_path)
+            url_path = tail.replace('\\', '/').lstrip('/')
+        else:
+            url_path = abs_path.lstrip('/')
+        return f'http://localhost:{self._SERVER_PORT}/{url_path}'
+
     def setURLPaths(self):
         module_name = self.__class__.__module__
         self.basePath = sys.modules[module_name].__file__.replace("\\", "/").rsplit("/", 1)[0]
-        
-        ############################################################
-        # Keep these for later use.
-        #self.serverPath = self.basePath + "/x_ite/x_ite-14.1.0"
-        #self.port = 8000
 
-        self.x_itePath = "https://und-dream-lab.github.io/rawkee/rawkee/examples/x_ite.html?v=20260803"
-        #self.x_itePath  = "https://create3000.github.io/x_ite/playground/?play=false&fullSize=true"
-        #http://localhost:{self.port}"
-        #self.x_itePath  = "https://vr.csgrid.org/x_ite/index.html"
+        # Serve the entire drive so any local X3D file and its textures are reachable
+        if sys.platform == 'win32':
+            drive_root = os.path.splitdrive(os.path.abspath(self.basePath))[0] + os.sep
+        else:
+            drive_root = '/'
+        self.bkHost = RKBackgroundHost(directory=drive_root, port=self._SERVER_PORT)
+        self.bkHost.start()
 
-        #self.bkHost = RKBackgroundHost(directory=self.serverPath, port=self.port)
-        #self.bkHost.start()
+        xite_abs = os.path.normpath(os.path.join(self.basePath, '..', 'examples', 'x_ite.html'))
+        self.x_itePath = self._local_url(xite_abs) + '?v=20260803'
         
         
     def create_actions(self):
@@ -447,7 +459,7 @@ class RKSceneEditor(QMainWindow):
         self.console_widget.setPlaceholderText("Output / Errors")
         self.custom_page.set_console(self.console_widget)
 
-        self.test_route_btn = QPushButton("Test SAI Routes")
+        self.test_route_btn = QPushButton("Test")
         self.test_route_btn.setMaximumHeight(24)
 
         self.console_container = QWidget()
@@ -502,28 +514,20 @@ class RKSceneEditor(QMainWindow):
 
 
     def _on_test_routes(self):
-        js = (
+        self.browser.page().runJavaScript(
             "(function(){"
             " var b=document.querySelector('x3d-canvas').browser;"
+            " if(!b){console.log('No browser');return;}"
             " var s=b.currentScene;"
-            " var mt=s.getNamedNode('myTransform');"
-            " var ot=s.getNamedNode('otherTransform');"
-            " if(!mt||!ot) return 'ERROR: nodes not found';"
-            " var before_mt=JSON.stringify(Array.from(mt.translation));"
-            " b.endUpdate();"
-            " mt.translation = new mt.translation.constructor(0,0,0);"
-            " b.beginUpdate();"
-            " b.firstViewpoint();"
-            " var after_mt=JSON.stringify(Array.from(mt.translation));"
-            " return 'before='+before_mt+' after='+after_mt;"
+            " try{"
+            "  var n=s.getNamedNode('myTransform');"
+            "  n.translation=new n.translation.constructor(0,0,0);"
+            "  console.log('myTransform translation reset to origin');"
+            " }catch(e){console.log('Error: '+e);}"
             "})()"
         )
-        self.browser.page().runJavaScript(
-            js, lambda r: (print(f"Route test: {r}"),
-                           self.console_widget.appendPlainText(f"Route test: {r}")))
-
     def _on_page_load_finished(self, ok):
-        if ok and self._x3dObj is not None:
+        if ok and self._file_url is not None:
             self._push_file_to_xite()
 
     def on_item_viewer_selection(self, index):
@@ -531,10 +535,14 @@ class RKSceneEditor(QMainWindow):
 
     def on_new_scene(self):
         self._x3dObj = None
+        self._file_url = None
         self.node_editor_widget.clearGraph()
         self.setX3DScene(None)
-        trv = RKSceneTraversal()
-        self.browser.page().runJavaScript(trv.scene2sai(None))
+        empty_url = self._local_url(os.path.normpath(
+            os.path.join(self.basePath, '..', 'examples', 'empty.x3d')))
+        self.browser.page().runJavaScript(
+            f'document.querySelector("x3d-canvas").src = {json.dumps(empty_url)};'
+        )
         self.setWindowTitle("RawKee PE - X3D Interaction Editor")
 
     def on_open_file(self):
@@ -549,6 +557,7 @@ class RKSceneEditor(QMainWindow):
             QMessageBox.warning(self, "Open Failed", f"Could not load:\n{file_path}")
             return
         self._x3dObj = x3d
+        self._file_url = self._local_url(os.path.abspath(file_path))
         self.node_editor_widget.clearGraph()
         scene_node = getattr(x3d, 'Scene', None)
         self.setX3DScene(scene_node)
@@ -556,10 +565,11 @@ class RKSceneEditor(QMainWindow):
         self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
 
     def _push_file_to_xite(self):
-        if self._x3dObj is None:
+        if self._file_url is None:
             return
-        trv = RKSceneTraversal()
-        self.browser.page().runJavaScript(trv.scene2sai(self._x3dObj))
+        self.browser.page().runJavaScript(
+            f'document.querySelector("x3d-canvas").src = {json.dumps(self._file_url)};'
+        )
 
     def on_export_as(self):
         if self._x3dObj is None:

--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -1280,7 +1280,7 @@ class RKSceneTraversal():
         return rNode        
 
 
-    def scene2sai(self, x3dDoc):
+    def scene2sai(self, x3dDoc, base_url=None):
         """Return a JS IIFE that rebuilds x3dDoc.Scene in X_ITE via SAI."""
         lines = [
             '(function () {',
@@ -1288,6 +1288,10 @@ class RKSceneTraversal():
             '  if (!c || !c.browser) return;',
             '  var b = c.browser;',
             '  var s = b.currentScene;',
+        ]
+        if base_url:
+            lines.append(f'  b.baseURL = {json.dumps(base_url)};')
+        lines += [
             '  var rn = []; for (var _i = 0; _i < s.rootNodes.length; _i++) rn.push(s.rootNodes[_i]);',
             '  b.endUpdate();',
             '  rn.forEach(function (n) { s.removeRootNode(n); });',
@@ -1300,9 +1304,9 @@ class RKSceneTraversal():
                 if type(child).__name__ == 'ROUTE':
                     routes.append(child)
                 else:
-                    var = self._node2sai(child, lines, counter)
+                    var = self._node2sai(child, lines, counter, base_url=base_url)
                     if var:
-                        lines.append(f'  s.addRootNode({var});')
+                        lines.append(f'  if ({var}) s.addRootNode({var});')
             for r in routes:
                 fd = getattr(r, 'fromNode',  '') or ''
                 ff = getattr(r, 'fromField', '') or ''
@@ -1316,13 +1320,27 @@ class RKSceneTraversal():
                     )
         lines.append('  b.beginUpdate();')
         lines.append('  b.viewAll();')
-        lines.append('  b.firstViewpoint();')
+        # Detect first Viewpoint DEF at Python time and bind it via set_bind
+        vp_def = None
+        _vp_names = {'Viewpoint', 'OrthoViewpoint', 'GeoViewpoint'}
+        if x3dDoc and x3dDoc.Scene:
+            for child in x3dDoc.Scene.children:
+                if hasattr(child, 'NAME') and child.NAME() in _vp_names:
+                    vp_def = getattr(child, 'DEF', None) or None
+                    if vp_def:
+                        break
+        if vp_def:
+            lines.append(
+                f'  setTimeout(function () {{'
+                f' try {{ s.getNamedNode({json.dumps(vp_def)}).set_bind = true; }}'
+                f' catch(_e) {{}} }}, 0);'
+            )
         lines.append('  console.log("RKI rootNodes=" + s.rootNodes.length);')
         lines.append('})();')
         return '\n'.join(lines)
 
 
-    def _node2sai(self, node, lines, counter):
+    def _node2sai(self, node, lines, counter, base_url=None):
         """Recursively emit SAI JS to create node; returns the JS variable name."""
         nType   = type(node).__name__
         use_val = getattr(node, 'USE', None) or ''
@@ -1337,12 +1355,16 @@ class RKSceneTraversal():
         x3d_type = node.NAME()  # canonical X3D name X_ITE recognises (vs Python subclass name)
         var = f'n{counter[0]}'
         counter[0] += 1
-        lines.append(f'  var {var} = s.createNode({json.dumps(x3d_type)});')
+
+        # Child nodes must be created before the parent's try block
+        # Collect field/child data first, then emit
+        block = []  # lines inside the try block for this node
+        block.append(f'    {var} = s.createNode({json.dumps(x3d_type)});')
 
         def_val = getattr(node, 'DEF', None) or ''
         if def_val:
-            lines.append(f'  s.updateNamedNode({json.dumps(def_val)}, {var});')
-            lines.append(f'  nodes[{json.dumps(def_val)}] = {var};')
+            block.append(f'    s.updateNamedNode({json.dumps(def_val)}, {var});')
+            block.append(f'    nodes[{json.dumps(def_val)}] = {var};')
 
         pastMeta = False
         for key, value in vars(node).items():
@@ -1371,29 +1393,50 @@ class RKSceneTraversal():
                     continue
                 if isinstance(value[0], (str, float, int, tuple, bool)):
                     if value[0] is not None:
-                        lines.append(f'  {var}.{js_fname} = {self._py2js(value)};')
+                        resolved = ([self._resolve_url(v, base_url) for v in value]
+                                    if js_fname == 'url' and base_url and isinstance(value[0], str)
+                                    else value)
+                        block.append(f'    {var}.{js_fname} = {self._py2js(resolved)};')
                 else:
-                    child_vars = [self._node2sai(c, lines, counter) for c in value]
+                    # MFNode children — recurse into outer lines before parent's try block
+                    child_vars = [self._node2sai(c, lines, counter, base_url=base_url) for c in value]
                     child_vars = [cv for cv in child_vars if cv]
                     if child_vars:
-                        children_js = ', '.join(child_vars)
-                        lines.append(f'  {var}.{js_fname} = [{children_js}];')
+                        children_js = ', '.join(cv for cv in child_vars)
+                        # Filter null children in case any failed to create
+                        block.append(f'    {var}.{js_fname} = [{children_js}].filter(Boolean);')
             else:
                 if value == default_val or value is None:
                     continue
                 if isinstance(value, tuple):
-                    # SFVec3f/SFColor/SFRotation etc. — must use typed constructor
                     args = ', '.join(repr(x) for x in value)
-                    lines.append(f'  {var}.{js_fname} = new {var}.{js_fname}.constructor({args});')
+                    block.append(f'    {var}.{js_fname} = new {var}.{js_fname}.constructor({args});')
                 elif isinstance(value, (str, float, int, bool)):
-                    lines.append(f'  {var}.{js_fname} = {self._py2js(value)};')
+                    resolved = (self._resolve_url(value, base_url)
+                                if js_fname == 'url' and isinstance(value, str) and base_url
+                                else value)
+                    block.append(f'    {var}.{js_fname} = {self._py2js(resolved)};')
                 elif hasattr(value, 'NAME'):
-                    cv = self._node2sai(value, lines, counter)
+                    # SFNode child — recurse into outer lines before parent's try block
+                    cv = self._node2sai(value, lines, counter, base_url=base_url)
                     if cv:
-                        lines.append(f'  {var}.{js_fname} = {cv};')
+                        block.append(f'    if ({cv}) {var}.{js_fname} = {cv};')
+
+        lines.append(f'  var {var} = null;')
+        lines.append(f'  try {{')
+        lines.extend(block)
+        lines.append(f'  }} catch (_e) {{ {var} = null; }}')
 
         return var
 
+
+    def _resolve_url(self, url_str, base_url):
+        """Resolve a relative URL against base_url; absolute URLs are returned unchanged."""
+        if not base_url or not url_str:
+            return url_str
+        if url_str.startswith(('http://', 'https://', 'file://', 'data:', '/')):
+            return url_str
+        return base_url + url_str
 
     def _py2js(self, value):
         """Convert a Python X3D field value to a JavaScript literal."""
@@ -1412,7 +1455,9 @@ class RKSceneTraversal():
                 return '[]'
             first = value[0]
             if isinstance(first, tuple):
-                return '[' + ', '.join('[' + ', '.join(repr(x) for x in t) + ']' for t in value) + ']'
+                # MF vector type — X_ITE expects a flat array, not nested arrays
+                flat = [repr(x) for tup in value for x in tup]
+                return '[' + ', '.join(flat) + ']'
             if isinstance(first, bool):
                 return '[' + ', '.join('true' if v else 'false' for v in value) + ']'
             if isinstance(first, str):


### PR DESCRIPTION
This pull request refactors and improves the X3D scene loading and SAI (Scene Access Interface) JavaScript generation logic in the RawKee editor. The main focus is on serving local X3D files and their assets via a local HTTP server, robustly reconstructing scenes in the X_ITE viewer, and ensuring correct resource URL resolution. It also improves error handling and code structure for scene and node creation.

**Improvements to local file serving and viewer integration:**
- The editor now starts a local HTTP server that serves the entire drive, allowing any local X3D file and its referenced assets (like textures) to be loaded in the X_ITE viewer. File URLs are converted to `http://localhost` paths and passed to the viewer, ensuring compatibility and asset loading. (`rawkee/editor/RKSceneEditor.py`) [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R368-R393) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R266-L274) [[3]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R560-R572)

**Enhancements to SAI JavaScript generation:**
- The `scene2sai` and `_node2sai` methods in `RKSceneTraversal` now accept a `base_url` parameter and resolve relative URLs for external resources, ensuring that all asset references are correct when loaded from the local server. This includes handling MFString/SFString fields named `'url'`. (`rawkee/io/RKSceneTraversal.py`) [[1]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14L1283-R1294) [[2]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14L1374-R1440)
- Node creation is now wrapped in `try` blocks, and child nodes are created before their parents, improving robustness and preventing partial scene construction if a node fails. (`rawkee/io/RKSceneTraversal.py`)

**Viewer and UI behavior improvements:**
- When a new scene is created or a file is opened, the X_ITE viewer is updated by setting its `src` attribute to the local file URL, rather than injecting a full SAI script. This simplifies synchronization between the Python editor and the JS viewer. (`rawkee/editor/RKSceneEditor.py`) [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L505-R545) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R560-R572)
- The "Test SAI Routes" button is now labeled simply as "Test" and its JavaScript has been simplified for clarity. (`rawkee/editor/RKSceneEditor.py`) [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L450-R462) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L505-R545)

**Scene initialization and viewpoint handling:**
- On scene loading, the first `Viewpoint` (or related node) is detected in Python and explicitly bound in the generated JS, ensuring the correct camera is active after a scene load. (`rawkee/io/RKSceneTraversal.py`)

**Other fixes and refactoring:**
- MF vector fields are now output as flat arrays in JS, matching X_ITE's expectations, instead of nested arrays. (`rawkee/io/RKSceneTraversal.py`)
- Minor code cleanup and reordering for clarity and maintainability. [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R266-L274) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R368-R393)

These changes collectively make scene loading, editing, and previewing more robust and accurate, especially when working with local files and assets.…n a webserver in the background in order to load files and resolve relative URLs. Use Ecmascript SAI to manipulate scene.