### PR TITLE
Added feature that allows the Interaction Editor window to be launche…

### DIFF
--- a/Maya_RawKee_Python_X3D.py
+++ b/Maya_RawKee_Python_X3D.py
@@ -113,7 +113,8 @@ def initialize_mtlx_paths():
 # Global RawKee menu systems Object used to add Menus to Maya Main Window
 # Cosntructing the RawKee menu system using "maya.cmds" is a more pleasant 
 # experience than using MEL 
-global rkWeb3D
+rkWeb3D = None
+_rkSceneEditorWin = None
 
 
 class RKServer(aom.MPxCommand):
@@ -682,7 +683,7 @@ class RKAssignLabelAsName(aom.MPxCommand):
         
         return jointName
 
-'''
+
 class RKShowSceneEditor(aom.MPxCommand):
     kPluginCmdName = "rkShowSceneEditor"
     
@@ -694,25 +695,13 @@ class RKShowSceneEditor(aom.MPxCommand):
         return RKShowSceneEditor()
         
     def doIt(self, args):
-        print("RawKee Scene Editor - Removed")
-        #cmds.rkPrimeX3DScene()
-        
-        #global rkWeb3D
-        #if rkWeb3D is not None:
-        #    sceneEditorControlName = RKSceneEditor.scene_editor_control_name()
-        #
-        #    if cmds.workspaceControl(sceneEditorControlName, exists=True):
-        #        #Must Close before Delete
-        #        cmds.workspaceControl(sceneEditorControlName, e=True, close=True, closeCommand=RKSceneEditor.workplace_close_command())
-        #        cmds.deleteUI(sceneEditorControlName)
-            
-        #    rkSEditor = RKSceneEditor()
-        #    rkSEditor.setRKWeb3D(rkWeb3D)
-        #    rkSEditor.show(dockable=True, uiScript=RKSceneEditor.workspace_ui_script())
-        #    rkSEditor.centerNodeEditor()
-        #else:
-        #    print("RKWeb3D is not set!")
-'''
+        global _rkSceneEditorWin
+        if _rkSceneEditorWin is not None and _rkSceneEditorWin.isVisible():
+            _rkSceneEditorWin.raise_()
+            _rkSceneEditorWin.activateWindow()
+        else:
+            _rkSceneEditorWin = RKSceneEditor()
+            _rkSceneEditorWin.show()
 
 
 class RKShowCharacterEditor(aom.MPxCommand):

--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -13,6 +13,32 @@ import os
 import sys
 import http.server
 import threading
+
+
+def apply_dark_palette(app):
+    app.setStyle('Fusion')
+    p = QPalette()
+    p.setColor(QPalette.ColorRole.Window,               QColor(45,  45,  45))
+    p.setColor(QPalette.ColorRole.WindowText,           QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Base,                 QColor(30,  30,  30))
+    p.setColor(QPalette.ColorRole.AlternateBase,        QColor(45,  45,  45))
+    p.setColor(QPalette.ColorRole.ToolTipBase,          QColor(30,  30,  30))
+    p.setColor(QPalette.ColorRole.ToolTipText,          QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Text,                 QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Button,               QColor(55,  55,  55))
+    p.setColor(QPalette.ColorRole.ButtonText,           QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.BrightText,           QColor(255, 255, 255))
+    p.setColor(QPalette.ColorRole.Link,                 QColor(0,   154,  68))
+    p.setColor(QPalette.ColorRole.Highlight,            QColor(0,   154,  68))
+    p.setColor(QPalette.ColorRole.HighlightedText,      QColor(255, 255, 255))
+    p.setColor(QPalette.ColorRole.PlaceholderText,      QColor(120, 120, 120))
+    disabled = QPalette.ColorGroup.Disabled
+    p.setColor(disabled, QPalette.ColorRole.WindowText, QColor(120, 120, 120))
+    p.setColor(disabled, QPalette.ColorRole.Text,       QColor(120, 120, 120))
+    p.setColor(disabled, QPalette.ColorRole.ButtonText, QColor(120, 120, 120))
+    p.setColor(disabled, QPalette.ColorRole.Highlight,  QColor(60,  100,  60))
+    app.setPalette(p)
+
 from functools import partial
 
 import rawkee.io.RKx3d as rkx
@@ -612,6 +638,22 @@ class RKSceneEditor(QMainWindow):
             # .server_close() closes the socket properly
             self.httpd.server_close()
 
+    def getDataFromMaya(self, mayaData, selected_only=False):
+        # Placeholder for future DCC-host integration.
+        return None
+
+    def sendDataToMaya(self, x3dData, selected_only=False):
+        # Placeholder for future DCC-host integration.
+        return None
+
+    def getDataFromBlender(self, blenderData, selected_only=False):
+        # Placeholder for future DCC-host integration.
+        return None
+
+    def sendDataToBlender(self, x3dData, selected_only=False):
+        # Placeholder for future DCC-host integration.
+        return None
+
 
 class RKCustomWebEnginePage(QWebEnginePage):
     def __init__(self, parent=None):
@@ -649,11 +691,15 @@ class RKBackgroundHost:
         print(f"Server started at http://localhost:{self.port} (Root: {self.directory})")
 
     def stop(self):
-        print("Shutting down server...")
-        self.httpd.shutdown() # Stops the serve_forever loop
-        self.httpd.server_close() # Releases the port
-        self.thread.join() # Ensures the thread has finished
-        print("Server stopped.")    
+        # Shutdown blocks until serve_forever exits; run it off the main thread
+        def _do_stop():
+            try:
+                self.httpd.shutdown()
+                self.httpd.server_close()
+            except Exception:
+                pass
+        threading.Thread(target=_do_stop, daemon=True).start()
+        print("Server shutting down.")    
 
 
 #####################################################################

--- a/rawkee/editor/__main__.py
+++ b/rawkee/editor/__main__.py
@@ -31,48 +31,10 @@ else:
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt, QtMsgType, qInstallMessageHandler
-from PySide6.QtGui import QPalette, QColor
-from rawkee.editor.RKSceneEditor import RKSceneEditor
+from rawkee.editor.RKSceneEditor import RKSceneEditor, apply_dark_palette as _apply_dark_palette
 
 
 def _qt_message_handler(msg_type, context, message):
-    # Suppress noisy Qt painter/rendering warnings that don't affect functionality
-    _suppressed = (
-        'QPainter::',
-        'QBackingStore::',
-        'QOpenGLContext::',
-        'updateRequestSent',
-    )
-    if any(message.startswith(s) for s in _suppressed):
-        return
-    if msg_type in (QtMsgType.QtDebugMsg, QtMsgType.QtInfoMsg):
-        return
-
-
-def _apply_dark_palette(app):
-    app.setStyle('Fusion')
-    p = QPalette()
-    p.setColor(QPalette.ColorRole.Window,               QColor(45,  45,  45))
-    p.setColor(QPalette.ColorRole.WindowText,           QColor(220, 220, 220))
-    p.setColor(QPalette.ColorRole.Base,                 QColor(30,  30,  30))
-    p.setColor(QPalette.ColorRole.AlternateBase,        QColor(45,  45,  45))
-    p.setColor(QPalette.ColorRole.ToolTipBase,          QColor(30,  30,  30))
-    p.setColor(QPalette.ColorRole.ToolTipText,          QColor(220, 220, 220))
-    p.setColor(QPalette.ColorRole.Text,                 QColor(220, 220, 220))
-    p.setColor(QPalette.ColorRole.Button,               QColor(55,  55,  55))
-    p.setColor(QPalette.ColorRole.ButtonText,           QColor(220, 220, 220))
-    p.setColor(QPalette.ColorRole.BrightText,           QColor(255, 255, 255))
-    p.setColor(QPalette.ColorRole.Link,                 QColor(0,   154,  68))   # UND green
-    p.setColor(QPalette.ColorRole.Highlight,            QColor(0,   154,  68))   # UND green
-    p.setColor(QPalette.ColorRole.HighlightedText,      QColor(255, 255, 255))
-    p.setColor(QPalette.ColorRole.PlaceholderText,      QColor(120, 120, 120))
-    # Disabled state
-    disabled = QPalette.ColorGroup.Disabled
-    p.setColor(disabled, QPalette.ColorRole.WindowText, QColor(120, 120, 120))
-    p.setColor(disabled, QPalette.ColorRole.Text,       QColor(120, 120, 120))
-    p.setColor(disabled, QPalette.ColorRole.ButtonText, QColor(120, 120, 120))
-    p.setColor(disabled, QPalette.ColorRole.Highlight,  QColor(60,  100,  60))
-    app.setPalette(p)
 
 
 def main():

--- a/rawkee4blender/blender/RKWeb3DBlenderUI.py
+++ b/rawkee4blender/blender/RKWeb3DBlenderUI.py
@@ -24,6 +24,113 @@ from rawkee4blender.blender.nodes import rkBX3DSound, rkBAnimPack
 
 
 # ---------------------------------------------------------------------------
+# Qt co-pump state — one QApplication and one editor window shared across calls.
+_qt_app      = None
+_editor_win  = None
+_timer_live  = False
+
+
+def _pump_qt_events():
+    """Blender timer callback: keep Qt responsive. Returns next interval or None to stop."""
+    global _editor_win, _timer_live
+    if _editor_win is None or not _editor_win.isVisible():
+        _editor_win  = None
+        _timer_live  = False
+        return None  # unregisters the timer
+    try:
+        from PySide6.QtWidgets import QApplication
+        QApplication.processEvents()
+    except Exception:
+        pass
+    return 0.016  # ~60 fps
+
+
+class RAWKEE_OT_InstallPySide6(bpy.types.Operator):
+    """Install PySide6 into Blender's bundled Python via pip"""
+    bl_idname  = "rawkee.install_pyside6"
+    bl_label   = "Install PySide6"
+    bl_options = {'REGISTER'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self, width=420)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="PySide6 is required for the RawKee Scene Editor.", icon='INFO')
+        layout.separator()
+        layout.label(text="Click OK to install it via pip into Blender's Python.")
+        layout.label(text="Requires internet access and may take 1-2 minutes.", icon='TIME')
+        layout.label(text="Blender must be restarted after installation.", icon='ERROR')
+
+    def execute(self, context):
+        import subprocess
+        import glob
+
+        # sys.executable is blender.exe; find the real Python binary via sys.prefix
+        if sys.platform == 'win32':
+            candidates = glob.glob(os.path.join(sys.prefix, 'bin', 'python*.exe'))
+        else:
+            candidates = [p for p in glob.glob(os.path.join(sys.prefix, 'bin', 'python3*'))
+                          if not p.endswith('-config')]
+        if not candidates:
+            self.report({'ERROR'}, f"Could not locate Python binary under {sys.prefix}")
+            return {'CANCELLED'}
+        python_exe = candidates[0]
+
+        # Install into Blender's user modules dir, which is already on sys.path
+        target_dir = bpy.utils.user_resource('SCRIPTS', path='modules')
+        os.makedirs(target_dir, exist_ok=True)
+
+        self.report({'INFO'}, f"Installing PySide6 to {target_dir} …")
+        try:
+            result = subprocess.run(
+                [python_exe, '-m', 'pip', 'install', 'PySide6', '--target', target_dir],
+                capture_output=True, text=True, timeout=300
+            )
+            if result.returncode == 0:
+                self.report({'INFO'}, "PySide6 installed. Please restart Blender, then open the Scene Editor.")
+            else:
+                self.report({'ERROR'}, f"pip install failed: {result.stderr[-300:]}")
+        except Exception as exc:
+            self.report({'ERROR'}, f"Installation failed: {exc}")
+        return {'FINISHED'}
+
+
+class RAWKEE_OT_OpenSceneEditor(bpy.types.Operator):
+    """Launch the RawKee Scene Editor alongside Blender"""
+    bl_idname  = "rawkee.open_scene_editor"
+    bl_label   = "RawKee Scene Editor"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        global _qt_app, _editor_win, _timer_live
+        try:
+            from PySide6.QtWidgets import QApplication
+            from rawkee.editor.RKSceneEditor import RKSceneEditor
+        except ImportError:
+            bpy.ops.rawkee.install_pyside6('INVOKE_DEFAULT')
+            return {'CANCELLED'}
+
+        if _qt_app is None:
+            _qt_app = QApplication.instance() or QApplication([])
+            from rawkee.editor.RKSceneEditor import apply_dark_palette
+            apply_dark_palette(_qt_app)
+            from rawkee.editor.RKSceneEditor import apply_dark_palette
+            apply_dark_palette(_qt_app)
+
+        if _editor_win is not None and _editor_win.isVisible():
+            _editor_win.raise_()
+            _editor_win.activateWindow()
+        else:
+            _editor_win = RKSceneEditor()
+            _editor_win.show()
+
+        if not _timer_live:
+            bpy.app.timers.register(_pump_qt_events, first_interval=0.016)
+            _timer_live = True
+
+        return {'FINISHED'}
+
 ENCODING_ITEMS = [
     ('x3d',  "X3D XML (.x3d)",      "X3D 4.1 XML encoding"),
     ('x3dv', "X3D Classic (.x3dv)", "X3D 4.1 Classic VRML-style encoding"),
@@ -169,6 +276,18 @@ class RAWKEE_PT_SubPanel_Export(bpy.types.Panel):
         col.operator("rawkee.set_project", icon='FILE_FOLDER', text="Set RawKee Project")
 
 
+class RAWKEE_PT_SubPanel_SceneEditor(bpy.types.Panel):
+    """Launch the standalone RawKee Scene Editor"""
+    bl_label       = "Scene Editor"
+    bl_idname      = "RAWKEE_PT_SubPanel_SceneEditor"
+    bl_space_type  = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category    = 'RawKee (.X3D)'
+    bl_parent_id   = 'RAWKEE_PT_MainPanel'
+    def draw(self, context):
+        self.layout.operator("rawkee.open_scene_editor", icon='WINDOW', text="Open Scene Editor")
+
+
 class RAWKEE_PT_SubPanel_AddNodes(bpy.types.Panel):
     """Add RawKee custom nodes"""
     bl_label       = "Add Custom Nodes"
@@ -221,6 +340,8 @@ def _menu_export(self, context):
 
 
 _own_classes = [
+    RAWKEE_OT_InstallPySide6,
+    RAWKEE_OT_OpenSceneEditor,
     RAWKEE_OT_ExportX3DAll,
     RAWKEE_OT_ExportX3DSelected,
     RAWKEE_OT_SetProject,
@@ -233,6 +354,7 @@ _own_classes = [
     RAWKEE_OT_ShowWeb3D,
     RAWKEE_OT_ShowMSF,
     RKMainPanel,
+    RAWKEE_PT_SubPanel_SceneEditor,
     RAWKEE_PT_SubPanel_Export,
     RAWKEE_PT_SubPanel_AddNodes,
     RAWKEE_PT_SubPanel_Links,
@@ -271,6 +393,19 @@ def register():
 
 
 def unregister():
+    global _editor_win, _timer_live
+    if _editor_win is not None:
+        try:
+            _editor_win.close()
+        except Exception:
+            pass
+        _editor_win = None
+    if _timer_live:
+        try:
+            bpy.app.timers.unregister(_pump_qt_events)
+        except Exception:
+            pass
+        _timer_live = False
     bpy.types.TOPBAR_MT_file_export.remove(_menu_export)
 
     for mod in reversed(_sub_modules):

--- a/rawkee4maya/maya/RKWeb3D.py
+++ b/rawkee4maya/maya/RKWeb3D.py
@@ -165,7 +165,7 @@ class RKWeb3D():
         cmds.menuItem(label='Experimental Features', subMenu=True)
         ### --- will be part of future release --- ### 
         cmds.menuItem(label='MaterialXSurfaceShader Export Type Editor',  command='maya.cmds.rkShowMaterialXEditor()')
-        #cmds.menuItem(label='X3D Graph Editor (Scene and Interactions) - Under Development', command='maya.cmds.rkShowSceneEditor()')
+        cmds.menuItem(label='X3D Scene Editor',                           command='maya.cmds.rkShowSceneEditor()')
         cmds.setParent(self.rkMenuName, menu=True)
         ### --- will be part of next release --- ### cmds.menuItem(label='X3D General Animation Editor')                  # -command "x3dAnimationEditor";
 


### PR DESCRIPTION
This pull request introduces major integration improvements for the RawKee Scene Editor with both Maya and Blender, along with code organization and UI enhancements. The most significant changes are the addition of a Qt-based Scene Editor launcher for Blender (with auto-installation of PySide6 if needed), improved Scene Editor window management in Maya, and refactoring of the dark palette code. Additionally, the Scene Editor now includes placeholder methods for future DCC integration and safer webserver shutdown. Below are the key changes grouped by theme:

**Blender Integration:**

* Added a new operator (`RAWKEE_OT_OpenSceneEditor`) and UI panel to launch the RawKee Scene Editor from within Blender, with event pumping to keep the Qt UI responsive alongside Blender's event loop. If PySide6 is missing, a one-click installer (`RAWKEE_OT_InstallPySide6`) is provided. The Scene Editor window is managed as a singleton, and cleanup occurs on addon unload. [[1]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aR27-R133) [[2]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aR279-R290) [[3]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aR343-R344) [[4]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aR357) [[5]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aR396-R408)

**Maya Integration:**

* Updated the Maya menu to provide direct access to the X3D Scene Editor, and refactored the command logic to manage the Scene Editor window as a singleton, ensuring only one instance is open and properly focused. [[1]](diffhunk://#diff-e44b35976655f7382d09b650933fbd526b8f79dd96cc6ae4131dec157d220cefL168-R168) [[2]](diffhunk://#diff-2a1a6d3b38ecf62d7e774c6562ddb5b4bde783254c18cd7d1db26aeb457d4bb6L116-R117) [[3]](diffhunk://#diff-2a1a6d3b38ecf62d7e774c6562ddb5b4bde783254c18cd7d1db26aeb457d4bb6L697-R704)

**Scene Editor Core and UI:**

* Moved the `apply_dark_palette` function to `rawkee/editor/RKSceneEditor.py` for reuse, and applied it in both Maya and Blender entry points. [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951R16-R41) [[2]](diffhunk://#diff-0b112b9004d3bffef8ced4ca406be30cdf98b96ab71b12cba26d424cd5a89933L34-L75)
* Added placeholder methods in `RKSceneEditor` for future integration with Maya and Blender data transfer, preparing for deeper DCC host interoperability.

**Webserver Improvements:**

* Made the Scene Editor’s embedded webserver shutdown process safer and non-blocking by moving shutdown calls to a background thread.

These changes significantly improve the user experience and maintainability of the RawKee Scene Editor integration with both Blender and Maya, and lay groundwork for future cross-application features.…d from Maya and Blender, with functions that allow Maya and Blender to communicate with the Interaction Editor window. However, the Interaction Editor can still be launched as an independent QApplication as well. Blender users will be receive a GUI prompt to install PySide6 into the Blender python interpreter the first time they launch the Interaction Editor from Blender.