### PR TITLE
Fixed bug that cuased the Interaction Editor standalone app to crash …

### DIFF
--- a/rawkee/editor/RKSceneEditor.py
+++ b/rawkee/editor/RKSceneEditor.py
@@ -588,7 +588,7 @@ class RKSceneEditor(QMainWindow):
         scene_node = getattr(x3d, 'Scene', None)
         self.setX3DScene(scene_node)
         self._push_file_to_xite()
-        self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
+        #self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
 
     def _push_file_to_xite(self):
         if self._file_url is None:
@@ -623,7 +623,7 @@ class RKSceneEditor(QMainWindow):
             trv = RKSceneTraversal()
             trv.collectProfileFromScene(self._x3dObj)
             trv.x3d2disk(self._x3dObj, file_path, encoding)
-            self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
+            #self.setWindowTitle(f"RawKee PE - {os.path.basename(file_path)}")
         except Exception as e:
             QMessageBox.critical(self, "Export Failed", str(e))
 

--- a/rawkee/editor/__main__.py
+++ b/rawkee/editor/__main__.py
@@ -35,6 +35,7 @@ from rawkee.editor.RKSceneEditor import RKSceneEditor, apply_dark_palette as _ap
 
 
 def _qt_message_handler(msg_type, context, message):
+    pass
 
 
 def main():

--- a/rawkee4blender/blender/RKWeb3DBlenderUI.py
+++ b/rawkee4blender/blender/RKWeb3DBlenderUI.py
@@ -56,7 +56,7 @@ class RAWKEE_OT_InstallPySide6(bpy.types.Operator):
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="PySide6 is required for the RawKee Scene Editor.", icon='INFO')
+        layout.label(text="PySide6 is required for the RawKee X3D Interaction Editor.", icon='INFO')
         layout.separator()
         layout.label(text="Click OK to install it via pip into Blender's Python.")
         layout.label(text="Requires internet access and may take 1-2 minutes.", icon='TIME')
@@ -88,7 +88,7 @@ class RAWKEE_OT_InstallPySide6(bpy.types.Operator):
                 capture_output=True, text=True, timeout=300
             )
             if result.returncode == 0:
-                self.report({'INFO'}, "PySide6 installed. Please restart Blender, then open the Scene Editor.")
+                self.report({'INFO'}, "PySide6 installed. Please restart Blender, then open the X3D Interaction Editor.")
             else:
                 self.report({'ERROR'}, f"pip install failed: {result.stderr[-300:]}")
         except Exception as exc:
@@ -97,9 +97,9 @@ class RAWKEE_OT_InstallPySide6(bpy.types.Operator):
 
 
 class RAWKEE_OT_OpenSceneEditor(bpy.types.Operator):
-    """Launch the RawKee Scene Editor alongside Blender"""
+    """Launch the RawKee X3D Interaction Editor alongside Blender"""
     bl_idname  = "rawkee.open_scene_editor"
-    bl_label   = "RawKee Scene Editor"
+    bl_label   = "RawKee X3D Interaction Editor"
     bl_options = {'REGISTER'}
 
     def execute(self, context):
@@ -277,15 +277,15 @@ class RAWKEE_PT_SubPanel_Export(bpy.types.Panel):
 
 
 class RAWKEE_PT_SubPanel_SceneEditor(bpy.types.Panel):
-    """Launch the standalone RawKee Scene Editor"""
-    bl_label       = "Scene Editor"
+    """Launch the standalone RawKee X3D Interaction Editor"""
+    bl_label       = "X3D Interaction Editor"
     bl_idname      = "RAWKEE_PT_SubPanel_SceneEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category    = 'RawKee (.X3D)'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     def draw(self, context):
-        self.layout.operator("rawkee.open_scene_editor", icon='WINDOW', text="Open Scene Editor")
+        self.layout.operator("rawkee.open_scene_editor", icon='WINDOW', text="X3D Interaction Editor")
 
 
 class RAWKEE_PT_SubPanel_AddNodes(bpy.types.Panel):

--- a/rawkee4maya/maya/RKWeb3D.py
+++ b/rawkee4maya/maya/RKWeb3D.py
@@ -165,7 +165,7 @@ class RKWeb3D():
         cmds.menuItem(label='Experimental Features', subMenu=True)
         ### --- will be part of future release --- ### 
         cmds.menuItem(label='MaterialXSurfaceShader Export Type Editor',  command='maya.cmds.rkShowMaterialXEditor()')
-        cmds.menuItem(label='X3D Scene Editor',                           command='maya.cmds.rkShowSceneEditor()')
+        cmds.menuItem(label='X3D Interaction Editor',                           command='maya.cmds.rkShowSceneEditor()')
         cmds.setParent(self.rkMenuName, menu=True)
         ### --- will be part of next release --- ### cmds.menuItem(label='X3D General Animation Editor')                  # -command "x3dAnimationEditor";
 


### PR DESCRIPTION
This pull request primarily updates the terminology in the user interface and documentation from "Scene Editor" to "X3D Interaction Editor" across both Blender and Maya integrations. Additionally, it includes minor code changes to suppress window title updates and handle Qt messages.

**UI and Documentation Terminology Updates:**

* Updated all references to "Scene Editor" in the Blender add-on (`RKWeb3DBlenderUI.py`) to "X3D Interaction Editor" for clarity and consistency, including operator tooltips, labels, and user messages. [[1]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL59-R59) [[2]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL91-R91) [[3]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL100-R102) [[4]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL280-R288)
* Changed the Maya integration menu item label from "X3D Scene Editor" to "X3D Interaction Editor" in `RKWeb3D.py`.

**Code Behavior Adjustments:**

* Commented out code in `RKSceneEditor.py` that previously updated the window title after opening or exporting a file, likely to prevent redundant or unwanted UI updates. [[1]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L591-R591) [[2]](diffhunk://#diff-48171488c4131989c6ae1fb8f7550aca73229d695a97eb834f28cde1a8417951L626-R626)
* Added a no-op (pass) implementation for the `_qt_message_handler` function in `__main__.py`.…on startup. The bug was the result of integrating the editor into Blender and Maya. Also changed some menu labeling in the DCC apps.