### PR TITLE
Blender 4.2+ and Blender 5+, support of PBR materials, EnvironmentLight, IndexedFaceSet, and more nodes. HDRI conversion to KTX2, and X3D Interaction Editor.

### DIFF
--- a/Blender_RawKee_Python_X3D.py
+++ b/Blender_RawKee_Python_X3D.py
@@ -13,7 +13,7 @@ bl_info = {
     "name"        : "BlenderRawKeeX3DExport",
     "author"      : "UND Dream Lab",
     "version"     : (0, 1, 0),
-    "blender"     : (5, 0, 1),
+    "blender"     : (4, 2, 0),
     "location"    : "File > Export / Sidebar N-panel 'RawKee (.X3D)'",
     "description" : "RawKee PE X3D export plugin for Blender 5",
     "doc_url"     : "https://github.com/und-dream-lab/rawkee/",
@@ -25,6 +25,17 @@ bl_info = {
 _addon_dir = os.path.dirname(__file__)
 if _addon_dir not in sys.path:
     sys.path.insert(0, _addon_dir)
+
+# Add pip-installed package locations to sys.path before any rawkee imports
+# so that RKTools.py picks up numpy/imageio at module load time.
+try:
+    import site as _site, importlib as _il, os as _os
+    _user_site = _os.path.normpath(_site.getusersitepackages())
+    if _user_site not in [_os.path.normpath(p) for p in sys.path]:
+        sys.path.insert(0, _user_site)
+        _il.invalidate_caches()
+except Exception:
+    pass
 
 
 class RawKeeAddonPreferences(bpy.types.AddonPreferences):

--- a/blender_rawkee_install.py
+++ b/blender_rawkee_install.py
@@ -145,6 +145,72 @@ def _show_result(title, lines):
     bpy.context.window_manager.popup_menu(draw, title=title, icon="INFO")
 
 
+def _check_pip_dependencies():
+    """Check all required pip packages and install any that are missing.
+    Uses actual import attempts. After install, queries pip show for the exact
+    install location and adds it to sys.path so packages are usable immediately
+    in the current session — works across all Blender versions."""
+    import subprocess, importlib
+
+    # pip install-name → Python import-name
+    PACKAGES = {
+        "numpy":         "numpy",
+        "imageio":       "imageio",
+        "opencv-python": "cv2",
+        "scipy":         "scipy",
+        "PySide6":       "PySide6",
+        "MaterialX":     "MaterialX",
+    }
+
+    def _importable(import_name):
+        try:
+            __import__(import_name)
+            return True
+        except Exception as e:
+            print(f"[RawKee] Cannot import '{import_name}': {type(e).__name__}: {e}")
+            return False
+
+    def _add_pip_location(pip_name):
+        """Query pip show to find install location and add it to sys.path."""
+        show = subprocess.run(
+            [sys.executable, "-m", "pip", "show", pip_name],
+            capture_output=True, text=True,
+        )
+        for line in show.stdout.splitlines():
+            if line.startswith("Location: "):
+                loc = os.path.normpath(line[10:].strip())
+                if loc not in [os.path.normpath(p) for p in sys.path]:
+                    sys.path.insert(0, loc)
+                break
+
+    missing = [pip for pip, imp in PACKAGES.items() if not _importable(imp)]
+    if not missing:
+        return [f"Python dependencies OK: {', '.join(PACKAGES)}"]
+
+    lines = [f"Missing: {', '.join(missing)}", "Installing via pip …"]
+
+    import site as _site
+    user_site = _site.getusersitepackages()
+    os.makedirs(user_site, exist_ok=True)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--target", user_site] + missing,
+        capture_output=True, text=True,
+    )
+
+    # Find and register every installed package's location immediately
+    for pip_name in missing:
+        _add_pip_location(pip_name)
+    importlib.invalidate_caches()
+
+    if result.returncode == 0:
+        lines.append(f"Installed: {', '.join(missing)}")
+    else:
+        lines.append("pip install FAILED — see system console for details.")
+        print(result.stderr)
+    return lines
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -199,6 +265,7 @@ def install():
     rawkee4blender_dst  = _copy_package(repo_root, modules_dir, "rawkee4blender")
     addon_dst           = _copy_addon_entry_point(repo_root, addons_dir)
     status_msg          = _enable_addon(modules_dir)
+    dep_lines           = _check_pip_dependencies()
 
     _show_result(
         "RawKee Blender Installer — Done",
@@ -209,6 +276,8 @@ def install():
             f"Addon file       : {addon_dst}",
             "",
             status_msg,
+            "",
+        ] + dep_lines + [
             "",
             "Please restart Blender to confirm the installation.",
         ],

--- a/rawkee4blender/blender/RKBBindPoseEditor.py
+++ b/rawkee4blender/blender/RKBBindPoseEditor.py
@@ -212,7 +212,7 @@ class RAWKEE_PT_BindPoseEditor(Panel):
     bl_idname      = "RAWKEE_PT_BindPoseEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKBCharacterAnimationClipEditor.py
+++ b/rawkee4blender/blender/RKBCharacterAnimationClipEditor.py
@@ -205,7 +205,7 @@ class RAWKEE_PT_CharacterAnimationClipEditor(Panel):
     bl_idname      = "RAWKEE_PT_CharacterAnimationClipEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKBCharacterEditor.py
+++ b/rawkee4blender/blender/RKBCharacterEditor.py
@@ -209,7 +209,7 @@ class RAWKEE_PT_CharacterEditor(Panel):
     bl_idname      = "RAWKEE_PT_CharacterEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKBExportOptions.py
+++ b/rawkee4blender/blender/RKBExportOptions.py
@@ -14,9 +14,67 @@ Blender approach : A bpy.types.PropertyGroup (RKExportOptionsProperties) is
 """
 
 import bpy
+import json
 import os
 from bpy.props import (StringProperty, BoolProperty, IntProperty, FloatProperty, EnumProperty)
 from bpy.types import PropertyGroup
+
+
+# ---------------------------------------------------------------------------
+#  Persistent defaults — JSON config (mirrors Maya optionVar behaviour)
+# ---------------------------------------------------------------------------
+
+# Keys that are saved/restored across sessions
+_PERSISTENT_KEYS = [
+    'prj_dir',
+    'image_path', 'audio_path', 'inline_path', 'matx_path',
+    'use_hanim_sites', 'skin_influence',
+    'adj_tex_size', 'tex_width', 'tex_height',
+    'consolidate', 'convert_hdr_to_ktx2', 'max_cube_map_face_size',
+    'proc_tex_type', 'proc_tex_format', 'file_tex_type', 'file_tex_format',
+    'movie_tex_type', 'audio_clip_type',
+    'normal_opts', 'crease_angle', 'color_opts', 'is_triangles',
+    'decimal_limit', 'export_tangents', 'export_empties',
+    'export_metadata', 'export_animations', 'launch_ext',
+]
+
+
+def _config_path():
+    return os.path.join(bpy.utils.user_resource('CONFIG'), "rawkee_export_opts.json")
+
+
+def _save_opts(props):
+    data = {k: getattr(props, k) for k in _PERSISTENT_KEYS}
+    path = _config_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def _load_opts(props):
+    path = _config_path()
+    if not os.path.isfile(path):
+        return
+    try:
+        with open(path, 'r') as f:
+            data = json.load(f)
+        for k, v in data.items():
+            if k in _PERSISTENT_KEYS:
+                try:
+                    setattr(props, k, v)
+                except Exception:
+                    pass
+    except Exception as e:
+        print(f"[RawKee] Could not load export defaults: {e}")
+
+
+@bpy.app.handlers.persistent
+def _restore_opts_on_load(dummy):
+    """Restore saved export defaults whenever a file is loaded."""
+    try:
+        _load_opts(bpy.context.scene.rk_export_opts)
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -83,22 +141,22 @@ class RKExportOptionsProperties(PropertyGroup):
     image_path: StringProperty(
         name="Image Sub-path",
         description="Sub-directory (relative to project dir) for exported textures",
-        default="/images",
+        default="images/",
     )
     audio_path: StringProperty(
         name="Audio Sub-path",
         description="Sub-directory (relative to project dir) for exported audio",
-        default="/audio",
+        default="audio/",
     )
     inline_path: StringProperty(
         name="Inline Sub-path",
         description="Sub-directory (relative to project dir) for X3D Inline files",
-        default="/inline",
+        default="inline/",
     )
     matx_path: StringProperty(
         name="MaterialX Sub-path",
         description="Sub-directory (relative to project dir) for MaterialX documents",
-        default="/mtlx",
+        default="mtlx/",
     )
 
     # HAnim
@@ -134,6 +192,16 @@ class RKExportOptionsProperties(PropertyGroup):
         name="Consolidate Media",
         description="Copy textures/audio into the project sub-directories",
         default=True,
+    )
+    convert_hdr_to_ktx2: BoolProperty(
+        name="Convert HDR/EXR to KTX2",
+        description="Convert HDR and EXR environment images to KTX2 cube map files on export",
+        default=True,
+    )
+    max_cube_map_face_size: IntProperty(
+        name="Max Cube Map Face Size",
+        description="Maximum face resolution (pixels) for KTX2 cube map conversion",
+        default=4096, min=64, max=16384,
     )
     proc_tex_type: EnumProperty(
         name="Procedural Texture",
@@ -220,6 +288,130 @@ class RKExportOptionsProperties(PropertyGroup):
 
 
 # ---------------------------------------------------------------------------
+#  Shared draw helper — used by the popup dialog
+# ---------------------------------------------------------------------------
+
+def _draw_export_options_layout(layout, opts):
+    box = layout.box()
+    box.label(text="Paths", icon='FILE_FOLDER')
+    col = box.column(align=True)
+    col.prop(opts, "prj_dir")
+    col.prop(opts, "image_path")
+    col.prop(opts, "audio_path")
+    col.prop(opts, "inline_path")
+    col.prop(opts, "matx_path")
+
+    box = layout.box()
+    box.label(text="HAnim / Skinning", icon='ARMATURE_DATA')
+    col = box.column(align=True)
+    col.prop(opts, "use_hanim_sites")
+    col.prop(opts, "skin_influence")
+
+    box = layout.box()
+    box.label(text="Textures", icon='IMAGE_DATA')
+    col = box.column(align=True)
+    col.prop(opts, "adj_tex_size")
+    if opts.adj_tex_size:
+        row = col.row(align=True)
+        row.prop(opts, "tex_width")
+        row.prop(opts, "tex_height")
+    col.prop(opts, "consolidate")
+    col.prop(opts, "convert_hdr_to_ktx2")
+    if opts.convert_hdr_to_ktx2:
+        col.prop(opts, "max_cube_map_face_size")
+    col.prop(opts, "proc_tex_type")
+    if opts.proc_tex_type != '0':
+        col.prop(opts, "proc_tex_format")
+    col.prop(opts, "file_tex_type")
+    if opts.file_tex_type not in ('0',):
+        col.prop(opts, "file_tex_format")
+    col.prop(opts, "movie_tex_type")
+    col.prop(opts, "audio_clip_type")
+
+    box = layout.box()
+    box.label(text="Geometry & Output", icon='MESH_DATA')
+    col = box.column(align=True)
+    col.prop(opts, "normal_opts")
+    col.prop(opts, "crease_angle")
+    col.prop(opts, "color_opts")
+    col.prop(opts, "is_triangles")
+    col.prop(opts, "export_tangents")
+    col.prop(opts, "decimal_limit")
+
+    box = layout.box()
+    box.label(text="Misc", icon='SETTINGS')
+    col = box.column(align=True)
+    col.prop(opts, "export_empties")
+    col.prop(opts, "export_metadata")
+    col.prop(opts, "export_animations")
+    col.prop(opts, "launch_ext")
+
+
+# ---------------------------------------------------------------------------
+#  Operator — export options popup dialog
+# ---------------------------------------------------------------------------
+
+class RAWKEE_OT_ExportOptionsDialog(bpy.types.Operator):
+    """Open the RawKee X3D export options dialog"""
+    bl_idname  = "rawkee.export_options_dialog"
+    bl_label   = "Save Options & Close"
+    bl_options = {'REGISTER'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=520, title="RawKee X3D Export Options"
+        )
+
+    def draw(self, context):
+        layout = self.layout
+        opts   = context.scene.rk_export_opts
+        _draw_export_options_layout(layout, opts)
+        layout.separator()
+        row = layout.row(align=True)
+        row.scale_y = 1.3
+        row.operator("rawkee.export_save_and_export_all",      text="Save Options & Export All",      icon='EXPORT')
+        row.operator("rawkee.export_save_and_export_selected", text="Save Options & Export Selected", icon='EXPORT')
+        layout.separator()
+        layout.operator("rawkee.reset_export_options", text="Reset to Defaults", icon='LOOP_BACK')
+
+    def execute(self, context):
+        _save_opts(context.scene.rk_export_opts)
+        return {'FINISHED'}
+
+
+class RAWKEE_OT_ExportSaveAndExportAll(bpy.types.Operator):
+    """Save export options then open the file browser to export all objects"""
+    bl_idname  = "rawkee.export_save_and_export_all"
+    bl_label   = "Save Options & Export All"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        _save_opts(context.scene.rk_export_opts)
+        # Defer so this operator finishes (closing the dialog) before the file browser opens
+        bpy.app.timers.register(
+            lambda: bpy.ops.rawkee.export_x3d_all('INVOKE_DEFAULT') and None,
+            first_interval=0.01,
+        )
+        return {'FINISHED'}
+
+
+class RAWKEE_OT_ExportSaveAndExportSelected(bpy.types.Operator):
+    """Save export options then open the file browser to export selected objects"""
+    bl_idname  = "rawkee.export_save_and_export_selected"
+    bl_label   = "Save Options & Export Selected"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        _save_opts(context.scene.rk_export_opts)
+        # Defer so this operator finishes (closing the dialog) before the file browser opens
+        bpy.app.timers.register(
+            lambda: bpy.ops.rawkee.export_x3d_selected('INVOKE_DEFAULT') and None,
+            first_interval=0.01,
+        )
+        return {'FINISHED'}
+
+
+# ---------------------------------------------------------------------------
 #  Operator — reset to defaults
 # ---------------------------------------------------------------------------
 
@@ -231,119 +423,37 @@ class RAWKEE_OT_ResetExportOptions(bpy.types.Operator):
 
     def execute(self, context):
         props = context.scene.rk_export_opts
-        # Trigger defaults by re-assigning a fresh PropertyGroup snapshot
-        for attr in RKExportOptionsProperties.__annotations__:
-            prop_def = RKExportOptionsProperties.__annotations__[attr]
-            # Skip complex enums/strings — just tell Blender to reset
-        # Simplest approach: explicitly re-set each
-        props.prj_dir        = ""
-        props.image_path     = "/images"
-        props.audio_path     = "/audio"
-        props.inline_path    = "/inline"
-        props.matx_path      = "/mtlx"
-        props.use_hanim_sites = False
-        props.skin_influence  = '0'
-        props.adj_tex_size    = False
-        props.tex_width       = 256
-        props.tex_height      = 256
-        props.consolidate     = True
-        props.proc_tex_type   = '0'
-        props.proc_tex_format = '0'
-        props.file_tex_type   = '0'
-        props.file_tex_format = '0'
-        props.movie_tex_type  = '0'
-        props.audio_clip_type = '0'
-        props.normal_opts     = '0'
-        props.crease_angle    = 0.0
-        props.color_opts      = '0'
-        props.is_triangles    = False
-        props.decimal_limit   = 6
-        props.export_tangents = False
-        props.export_empties  = True
-        props.export_metadata = True
-        props.export_animations = True
-        props.launch_ext      = False
+        props.prj_dir             = ""
+        props.image_path          = "images/"
+        props.audio_path          = "audio/"
+        props.inline_path         = "inline/"
+        props.matx_path           = "mtlx/"
+        props.use_hanim_sites     = False
+        props.skin_influence      = '0'
+        props.adj_tex_size        = False
+        props.tex_width           = 256
+        props.tex_height          = 256
+        props.consolidate         = True
+        props.convert_hdr_to_ktx2    = True
+        props.max_cube_map_face_size = 4096
+        props.proc_tex_type       = '0'
+        props.proc_tex_format     = '0'
+        props.file_tex_type       = '0'
+        props.file_tex_format     = '0'
+        props.movie_tex_type      = '0'
+        props.audio_clip_type     = '0'
+        props.normal_opts         = '0'
+        props.crease_angle        = 0.0
+        props.color_opts          = '0'
+        props.is_triangles        = False
+        props.decimal_limit       = 6
+        props.export_tangents     = False
+        props.export_empties      = True
+        props.export_metadata     = True
+        props.export_animations   = True
+        props.launch_ext          = False
         self.report({'INFO'}, "Export options reset to defaults")
         return {'FINISHED'}
-
-
-# ---------------------------------------------------------------------------
-#  Sidebar Panel — shown in the RawKee N-panel tab
-# ---------------------------------------------------------------------------
-
-class RAWKEE_PT_ExportOptions(bpy.types.Panel):
-    """RawKee X3D Export Options sidebar panel"""
-    bl_label       = "Export Options"
-    bl_idname      = "RAWKEE_PT_ExportOptions"
-    bl_space_type  = 'VIEW_3D'
-    bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
-    bl_parent_id   = 'RAWKEE_PT_MainPanel'
-    bl_options     = {'DEFAULT_CLOSED'}
-
-    def draw(self, context):
-        layout = self.layout
-        opts   = context.scene.rk_export_opts
-
-        # -- Paths
-        box = layout.box()
-        box.label(text="Paths", icon='FILE_FOLDER')
-        col = box.column(align=True)
-        col.prop(opts, "prj_dir")
-        col.prop(opts, "image_path")
-        col.prop(opts, "audio_path")
-        col.prop(opts, "inline_path")
-        col.prop(opts, "matx_path")
-
-        # -- HAnim
-        box = layout.box()
-        box.label(text="HAnim / Skinning", icon='ARMATURE_DATA')
-        col = box.column(align=True)
-        col.prop(opts, "use_hanim_sites")
-        col.prop(opts, "skin_influence")
-
-        # -- Textures
-        box = layout.box()
-        box.label(text="Textures", icon='IMAGE_DATA')
-        col = box.column(align=True)
-        row = col.row(align=True)
-        row.prop(opts, "adj_tex_size")
-        if opts.adj_tex_size:
-            row2 = col.row(align=True)
-            row2.prop(opts, "tex_width")
-            row2.prop(opts, "tex_height")
-        col.prop(opts, "consolidate")
-        col.prop(opts, "proc_tex_type")
-        if opts.proc_tex_type != '0':
-            col.prop(opts, "proc_tex_format")
-        col.prop(opts, "file_tex_type")
-        if opts.file_tex_type not in ('0',):
-            col.prop(opts, "file_tex_format")
-        col.prop(opts, "movie_tex_type")
-        col.prop(opts, "audio_clip_type")
-
-        # -- Geometry
-        box = layout.box()
-        box.label(text="Geometry & Output", icon='MESH_DATA')
-        col = box.column(align=True)
-        col.prop(opts, "normal_opts")
-        col.prop(opts, "crease_angle")
-        col.prop(opts, "color_opts")
-        col.prop(opts, "is_triangles")
-        col.prop(opts, "export_tangents")
-        col.prop(opts, "decimal_limit")
-
-        # -- Misc
-        box = layout.box()
-        box.label(text="Misc", icon='SETTINGS')
-        col = box.column(align=True)
-        col.prop(opts, "export_empties")
-        col.prop(opts, "export_metadata")
-        col.prop(opts, "export_animations")
-        col.prop(opts, "launch_ext")
-
-        layout.separator()
-        layout.operator("rawkee.reset_export_options", icon='LOOP_BACK')
 
 
 # ---------------------------------------------------------------------------
@@ -352,8 +462,10 @@ class RAWKEE_PT_ExportOptions(bpy.types.Panel):
 
 classes = [
     RKExportOptionsProperties,
+    RAWKEE_OT_ExportOptionsDialog,
+    RAWKEE_OT_ExportSaveAndExportAll,
+    RAWKEE_OT_ExportSaveAndExportSelected,
     RAWKEE_OT_ResetExportOptions,
-    RAWKEE_PT_ExportOptions,
 ]
 
 
@@ -363,9 +475,16 @@ def register():
     bpy.types.Scene.rk_export_opts = bpy.props.PointerProperty(
         type=RKExportOptionsProperties
     )
+    bpy.app.handlers.load_post.append(_restore_opts_on_load)
+    try:
+        _load_opts(bpy.context.scene.rk_export_opts)
+    except Exception:
+        pass
 
 
 def unregister():
+    if _restore_opts_on_load in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(_restore_opts_on_load)
     del bpy.types.Scene.rk_export_opts
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/rawkee4blender/blender/RKBHAnimHumanoidSetupEditor.py
+++ b/rawkee4blender/blender/RKBHAnimHumanoidSetupEditor.py
@@ -148,7 +148,7 @@ class RAWKEE_PT_HAnimHumanoidSetupEditor(Panel):
     bl_idname      = "RAWKEE_PT_HAnimHumanoidSetupEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKBMaterialXEditor.py
+++ b/rawkee4blender/blender/RKBMaterialXEditor.py
@@ -116,7 +116,7 @@ class RAWKEE_PT_MaterialXEditor(Panel):
     bl_idname      = "RAWKEE_PT_MaterialXEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKBRigifySetupEditor.py
+++ b/rawkee4blender/blender/RKBRigifySetupEditor.py
@@ -266,7 +266,7 @@ class RAWKEE_PT_RigifySetupEditor(Panel):
     bl_idname      = "RAWKEE_PT_RigifySetupEditor"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
 

--- a/rawkee4blender/blender/RKOrganizerBlender.py
+++ b/rawkee4blender/blender/RKOrganizerBlender.py
@@ -30,10 +30,12 @@ import bpy
 import math
 import mathutils
 import os
+import sys
 import shutil
 
 from rawkee.io.RKSceneTraversal import RKSceneTraversal
 from rawkee.io.RKx3d import *
+from rawkee.tools.RKTools         import RKTools
 
 # ---------------------------------------------------------------------------
 #  Axis-conversion matrix  Blender Z-up → X3D Y-up
@@ -87,6 +89,20 @@ def _safe_name(name):
     return name.replace(' ', '_').replace('.', '_').replace(':', '_')
 
 
+_RK_LOG_NAME = "RawKee Export Log"
+
+
+def _rk_log(msg):
+    """Write to system console AND the 'RawKee Export Log' text block in the Text Editor."""
+    print(msg)
+    try:
+        if _RK_LOG_NAME not in bpy.data.texts:
+            bpy.data.texts.new(_RK_LOG_NAME)
+        bpy.data.texts[_RK_LOG_NAME].write(msg + "\n")
+    except Exception:
+        pass
+
+
 # ---------------------------------------------------------------------------
 #  Main class
 # ---------------------------------------------------------------------------
@@ -102,17 +118,19 @@ class RKOrganizerBlender:
 
         # Export option mirrors (loaded from scene.rk_export_opts in prepForSceneTraversal)
         self.rkPrjDir        = ""
-        self.rkImagePath     = "/images"
-        self.rkAudioPath     = "/audio"
-        self.rkInlinePath    = "/inline"
-        self.rkMatXPath      = "/mtlx"
+        self.rkImagePath     = "images/"
+        self.rkAudioPath     = "audio/"
+        self.rkInlinePath    = "inline/"
+        self.rkMatXPath      = "mtlx/"
         self.rkUseHAnimSites = False
         self.rkSkinInfluence = 0
         self.rkAdjTexSize    = False
         self.rkDefTexWidth   = 256
         self.rkDefTexHeight  = 256
-        self.rkConsolidate   = True
-        self.rkProcTexType   = 0
+        self.rkConsolidate         = True
+        self.rkConvertHDRToKTX2   = True
+        self.rkMaxCubeMapFaceSize  = 4096
+        self.rkProcTexType         = 0
         self.rkProcTexFormat = 0
         self.rkFileTexType   = 0
         self.rkFileTexFormat = 0
@@ -127,7 +145,6 @@ class RKOrganizerBlender:
         self.rkExportEmpties = True
         self.rkExportMetadata = True
         self.rkExportAnimations = True
-        self.exEncoding      = "x3d"
         self.exEncoding      = "x3d"
 
         # Internal state
@@ -150,16 +167,20 @@ class RKOrganizerBlender:
         opts = context.scene.rk_export_opts
 
         self.rkPrjDir        = opts.prj_dir
-        self.rkImagePath     = opts.image_path
-        self.rkAudioPath     = opts.audio_path
-        self.rkMatXPath      = opts.matx_path
+        # Normalize sub-paths: replace backslashes with forward slashes
+        self.rkImagePath  = opts.image_path.replace('\\', '/')
+        self.rkAudioPath  = opts.audio_path.replace('\\', '/')
+        self.rkInlinePath = opts.inline_path.replace('\\', '/')
+        self.rkMatXPath   = opts.matx_path.replace('\\', '/')
         self.rkUseHAnimSites = opts.use_hanim_sites
         self.rkSkinInfluence = int(opts.skin_influence)
         self.rkAdjTexSize    = opts.adj_tex_size
         self.rkDefTexWidth   = opts.tex_width
         self.rkDefTexHeight  = opts.tex_height
-        self.rkConsolidate   = opts.consolidate
-        self.rkProcTexType   = int(opts.proc_tex_type)
+        self.rkConsolidate        = opts.consolidate
+        self.rkConvertHDRToKTX2  = opts.convert_hdr_to_ktx2
+        self.rkMaxCubeMapFaceSize = opts.max_cube_map_face_size
+        self.rkProcTexType        = int(opts.proc_tex_type)
         self.rkProcTexFormat = int(opts.proc_tex_format)
         self.rkFileTexType   = int(opts.file_tex_type)
         self.rkFileTexFormat = int(opts.file_tex_format)
@@ -185,8 +206,8 @@ class RKOrganizerBlender:
     def checkSubDirs(self, fullPath):
         """Create sub-directories for consolidated media next to the output file."""
         base = os.path.dirname(fullPath)
-        self.imageMoveDir = base + self.rkImagePath
-        self.audioMoveDir = base + self.rkAudioPath
+        self.imageMoveDir = os.path.normpath(os.path.join(base, self.rkImagePath))
+        self.audioMoveDir = os.path.normpath(os.path.join(base, self.rkAudioPath))
         if self.rkConsolidate:
             os.makedirs(self.imageMoveDir, exist_ok=True)
             os.makedirs(self.audioMoveDir, exist_ok=True)
@@ -200,11 +221,12 @@ class RKOrganizerBlender:
             return src_abs
         fname   = os.path.basename(src_abs)
         dst_abs = os.path.join(self.imageMoveDir, fname)
-        try:
-            shutil.copy2(src_abs, dst_abs)
-        except Exception as e:
-            print(f"RKOrganizerBlender: texture copy failed: {e}")
-        rel_url = self.rkImagePath.lstrip('/') + '/' + fname
+        if src_abs != dst_abs:
+            try:
+                shutil.copy2(src_abs, dst_abs)
+            except Exception as e:
+                print(f"RKOrganizerBlender: texture copy failed: {e}")
+        rel_url = self.rkImagePath + fname  # rkImagePath is already normalised, e.g. "images/"
         self.exportedTextures[src_abs] = rel_url
         return rel_url
 
@@ -226,17 +248,17 @@ class RKOrganizerBlender:
         self.animation_data.clear()
         self.exportedTextures.clear()
 
+        # Reset the in-Blender log for this export run
+        try:
+            if _RK_LOG_NAME in bpy.data.texts:
+                bpy.data.texts[_RK_LOG_NAME].clear()
+            else:
+                bpy.data.texts.new(_RK_LOG_NAME)
+        except Exception:
+            pass
+
         # Mark pseudo-root
         self.trv.setAsHasBeen("BlenderScene", x3dScene)
-
-        # Background from world colour
-        world = context.scene.world
-        bkNode = self.trv.processBasicNodeAddition(
-            x3dScene, "children", "Background", "DefaultBackground"
-        )
-        if bkNode and world:
-            c = world.color
-            bkNode.skyColor[0] = (c.r, c.g, c.b)
 
         # World environment texture → EnvironmentLight
         self._process_world_environment(x3dScene, context)
@@ -278,15 +300,16 @@ class RKOrganizerBlender:
         self.haveBeenObjects.clear()
         self.animation_data.clear()
         self.exportedTextures.clear()
-        self.trv.setAsHasBeen("BlenderScene", x3dScene)
 
-        world = context.scene.world
-        bkNode = self.trv.processBasicNodeAddition(
-            x3dScene, "children", "Background", "DefaultBackground"
-        )
-        if bkNode and world:
-            c = world.color
-            bkNode.skyColor[0] = (c.r, c.g, c.b)
+        # Reset the in-Blender log for this export run
+        try:
+            if _RK_LOG_NAME in bpy.data.texts:
+                bpy.data.texts[_RK_LOG_NAME].clear()
+            else:
+                bpy.data.texts.new(_RK_LOG_NAME)
+        except Exception:
+            pass
+        self.trv.setAsHasBeen("BlenderScene", x3dScene)
 
         for obj in context.selected_objects:
             if obj.parent is None or obj.parent not in context.selected_objects:
@@ -329,9 +352,9 @@ class RKOrganizerBlender:
             x3dTarget = x3dParent
 
         # Objects directly inside this collection (only those without parents
-        # in the same collection so we don't double-export)
-        for obj in collection.objects:
-            if obj.parent is None or obj.parent.name not in collection.objects:
+        # reversed() matches the outliner top-to-bottom display order
+        for obj in reversed(list(collection.objects)):
+            if obj.parent is None or obj.parent not in collection.objects:
                 self._process_object(x3dTarget, obj, context, is_root=is_root)
 
         # Recurse into child collections
@@ -609,10 +632,15 @@ class RKOrganizerBlender:
                     gltf_mr = node
 
         # Prefer Principled BSDF; fall back to glTF MR; then legacy Material.
-        shader_node = pbsdf or gltf_mr
+        shader_node   = pbsdf or gltf_mr
+        as_x3d_shader = bool(mat.get("rk_as_x3d_shader", False))
         if shader_node is not None:
-            self._build_physical_material(app, mat, shader_node, app_name,
-                                          is_gltf_mr=(pbsdf is None))
+            if as_x3d_shader:
+                self._build_packaged_composed_shader(app, mat, shader_node, app_name,
+                                                     is_gltf_mr=(pbsdf is None))
+            else:
+                self._build_physical_material_ext(app, mat, shader_node, app_name,
+                                                  is_gltf_mr=(pbsdf is None))
         else:
             # Fallback: use diffuse colour directly
             pm = self.trv.processBasicNodeAddition(
@@ -649,69 +677,76 @@ class RKOrganizerBlender:
         return None
 
 
-    def _build_physical_material(self, x3dApp, mat, pbsdf, base_name,
-                                   is_gltf_mr=False):
-        """Map Principled BSDF or glTF Metallic Roughness inputs to X3D PhysicalMaterial."""
+    def _build_physical_material_ext(self, x3dApp, mat, pbsdf, base_name,
+                                      is_gltf_mr=False):
+        """Map Principled BSDF or glTF MR inputs to X3D PhysicalMaterialExt + glTF extensions."""
         pm = self.trv.processBasicNodeAddition(
-            x3dApp, "material", "PhysicalMaterial", base_name + "_PhysMat"
+            x3dApp, "material", "PhysicalMaterialExt", base_name + "_PhysMatExt"
         )
         if pm is None:
             return
 
+        # glTF MR group uses different socket names from Principled BSDF
+        base_col_sock = "BaseColorFactor"  if is_gltf_mr else "Base Color"
+        metal_sock    = "MetallicFactor"   if is_gltf_mr else "Metallic"
+        rough_sock    = "RoughnessFactor"  if is_gltf_mr else "Roughness"
+
         # Base color
-        base_col = self._get_pbsdf_input_value(pbsdf, "Base Color")
+        base_col = self._get_pbsdf_input_value(pbsdf, base_col_sock)
         if base_col:
             pm.baseColor = (base_col[0], base_col[1], base_col[2])
 
-        # Metallic / roughness
-        metal = self._get_pbsdf_input_value(pbsdf, "Metallic")
+        # Metallic / roughness scalars
+        metal = self._get_pbsdf_input_value(pbsdf, metal_sock)
         if metal is not None:
             pm.metallic = float(metal)
 
-        rough = self._get_pbsdf_input_value(pbsdf, "Roughness")
+        rough = self._get_pbsdf_input_value(pbsdf, rough_sock)
         if rough is not None:
             pm.roughness = float(rough)
 
-        # Emissive — socket name differs between the two shader types:
-        #   Principled BSDF : "Emission" (color) + "Emission Strength" (float)
-        #   glTF MR group   : "Emissive" (color, strength already baked in)
+        # Emissive color — do NOT pre-multiply by strength; extension handles that
         if is_gltf_mr:
             em_col = self._get_pbsdf_input_value(pbsdf, "Emissive")
             if em_col:
                 pm.emissiveColor = (float(em_col[0]), float(em_col[1]), float(em_col[2]))
         else:
-            em_sock = pbsdf.inputs.get("Emission")
-            em_str  = pbsdf.inputs.get("Emission Strength")
-            if em_sock and em_str:
+            # 4.x renamed "Emission" → "Emission Color"
+            em_sock = pbsdf.inputs.get("Emission Color") or pbsdf.inputs.get("Emission")
+            if em_sock:
                 ec = em_sock.default_value
-                es = float(em_str.default_value)
-                pm.emissiveColor = (ec[0] * es, ec[1] * es, ec[2] * es)
+                em_c = (float(ec[0]), float(ec[1]), float(ec[2]))
+                if any(v > 0.001 for v in em_c):
+                    pm.emissiveColor = em_c
 
-        # Transparency (alpha)
+        # Transparency
         alpha = self._get_pbsdf_input_value(pbsdf, "Alpha")
         if alpha is not None and float(alpha) < 0.999:
             pm.transparency = 1.0 - float(alpha)
 
         # ---- Textures ------------------------------------------------
-        # Diagnostics: print shader node inputs to Blender console
-        print(f"[RawKee] _build_physical_material: shader='{pbsdf.name}' "
+        print(f"[RawKee] _build_physical_material_ext: shader='{pbsdf.name}' "
               f"type={pbsdf.type} is_gltf_mr={is_gltf_mr}")
         for s in pbsdf.inputs:
             linked = len(s.links) > 0
             from_t = s.links[0].from_node.type if linked else 'none'
-            print(f"[RawKee]   socket '{s.name}': linked={linked} from_type={from_t}")
+            _rk_log(f"[RawKee]   socket '{s.name}': linked={linked} from_type={from_t}")
 
-        # Base color
-        img = self._find_image_texture(mat.node_tree, "Base Color", pbsdf)
-        print(f"[RawKee]   _find_image_texture('Base Color') -> {img}")
+        # Base color texture (glTF MR: "BaseColor"; Principled BSDF: "Base Color")
+        base_tex_sock = "BaseColor" if is_gltf_mr else "Base Color"
+        img = self._find_image_texture(mat.node_tree, base_tex_sock, pbsdf)
+        _rk_log(f"[RawKee]   _find_image_texture({base_tex_sock!r}) -> {img}")
         if img and img.image:
-            print(f"[RawKee]   image.name={img.image.name!r}  filepath={img.image.filepath!r}  packed={img.image.packed_file is not None}")
-            self._make_image_texture(pm, "baseTexture", img.image,
-                                     base_name + "_BaseTex")
+            _rk_log(f"[RawKee]   image.name={img.image.name!r}  filepath={img.image.filepath!r}"
+                  f"  packed={img.image.packed_file is not None}")
+            self._make_image_texture(pm, "baseTexture", img.image, base_name + "_BaseTex")
 
-        # Metallic-roughness (try Metallic socket first, fall back to Roughness)
-        mr = (self._find_image_texture(mat.node_tree, "Metallic", pbsdf) or
-              self._find_image_texture(mat.node_tree, "Roughness", pbsdf))
+        # Metallic-roughness texture
+        if is_gltf_mr:
+            mr = self._find_image_texture(mat.node_tree, "MetallicRoughness", pbsdf)
+        else:
+            mr = (self._find_image_texture(mat.node_tree, "Metallic", pbsdf) or
+                  self._find_image_texture(mat.node_tree, "Roughness", pbsdf))
         if mr and mr.image:
             self._make_image_texture(pm, "metallicRoughnessTexture", mr.image,
                                      base_name + "_MRTex")
@@ -719,21 +754,368 @@ class RKOrganizerBlender:
         # Normal map
         nm = self._find_image_texture(mat.node_tree, "Normal", pbsdf)
         if nm and nm.image:
-            self._make_image_texture(pm, "normalTexture", nm.image,
-                                     base_name + "_NormTex")
+            self._make_image_texture(pm, "normalTexture", nm.image, base_name + "_NormTex")
 
-        # Emissive texture
-        em_sock = "Emissive" if is_gltf_mr else "Emission"
-        em = self._find_image_texture(mat.node_tree, em_sock, pbsdf)
-        if em and em.image:
-            self._make_image_texture(pm, "emissiveTexture", em.image,
-                                     base_name + "_EmissTex")
+        # Emissive texture — override emissiveColor to white when a texture is present
+        em_tex_sock = ("Emissive" if is_gltf_mr
+                       else ("Emission Color" if pbsdf.inputs.get("Emission Color") else "Emission"))
+        em_tex = self._find_image_texture(mat.node_tree, em_tex_sock, pbsdf)
+        if em_tex and em_tex.image:
+            pm.emissiveColor = (1.0, 1.0, 1.0)
+            self._make_image_texture(pm, "emissiveTexture", em_tex.image, base_name + "_EmissTex")
 
         # Occlusion texture
         occ = self._find_image_texture(mat.node_tree, "Occlusion", pbsdf)
         if occ and occ.image:
-            self._make_image_texture(pm, "occlusionTexture", occ.image,
-                                     base_name + "_OccTex")
+            self._make_image_texture(pm, "occlusionTexture", occ.image, base_name + "_OccTex")
+
+        # ---- glTF material extensions (Principled BSDF only) ---------
+        if is_gltf_mr:
+            return
+
+        # IOR (KHR_materials_ior) — only when not the default 1.5
+        ior_val = self._get_pbsdf_input_value(pbsdf, "IOR")
+        if ior_val is not None and abs(float(ior_val) - 1.5) > 0.001:
+            ior_ext = self.trv.processBasicNodeAddition(
+                pm, "extensions", "IORMaterialExtension", base_name + "_IORME")
+            if ior_ext:
+                ior_ext.indexOfRefraction = float(ior_val)
+
+        # Emissive strength (KHR_materials_emissive_strength) — only when != 1.0
+        em_str_sock = pbsdf.inputs.get("Emission Strength")
+        if em_str_sock:
+            es = float(em_str_sock.default_value)
+            if abs(es - 1.0) > 0.001:
+                es_ext = self.trv.processBasicNodeAddition(
+                    pm, "extensions", "EmissiveStrengthMaterialExtension", base_name + "_ESME")
+                if es_ext:
+                    es_ext.emissiveStrength = es
+
+        # Transmission (KHR_materials_transmission)
+        trans_sock = (pbsdf.inputs.get("Transmission Weight") or  # 4.x
+                      pbsdf.inputs.get("Transmission"))           # 3.x
+        if trans_sock:
+            tv = float(trans_sock.default_value)
+            if tv > 0.001:
+                tr_ext = self.trv.processBasicNodeAddition(
+                    pm, "extensions", "TransmissionMaterialExtension", base_name + "_TRME")
+                if tr_ext:
+                    tr_ext.transmission = tv
+                    tr_tex = (self._find_image_texture(mat.node_tree, "Transmission Weight", pbsdf) or
+                              self._find_image_texture(mat.node_tree, "Transmission",        pbsdf))
+                    if tr_tex and tr_tex.image:
+                        self._make_image_texture(tr_ext, "transmissionTexture",
+                                                  tr_tex.image, base_name + "_TransTex")
+
+        # Clearcoat (KHR_materials_clearcoat)
+        coat_sock = (pbsdf.inputs.get("Coat Weight") or  # 4.x
+                     pbsdf.inputs.get("Clearcoat"))      # 3.x
+        if coat_sock:
+            cv = float(coat_sock.default_value)
+            if cv > 0.001:
+                coat_ext = self.trv.processBasicNodeAddition(
+                    pm, "extensions", "ClearcoatMaterialExtension", base_name + "_CoatME")
+                if coat_ext:
+                    coat_ext.clearcoat = cv
+                    coat_rough = (pbsdf.inputs.get("Coat Roughness") or
+                                  pbsdf.inputs.get("Clearcoat Roughness"))
+                    if coat_rough:
+                        coat_ext.clearcoatRoughness = float(coat_rough.default_value)
+                    coat_nm = (self._find_image_texture(mat.node_tree, "Coat Normal",      pbsdf) or
+                               self._find_image_texture(mat.node_tree, "Clearcoat Normal", pbsdf))
+                    if coat_nm and coat_nm.image:
+                        self._make_image_texture(coat_ext, "clearcoatNormalTexture",
+                                                  coat_nm.image, base_name + "_CoatNormTex")
+
+        # Sheen (KHR_materials_sheen)
+        sheen_sock = (pbsdf.inputs.get("Sheen Weight") or  # 4.x
+                      pbsdf.inputs.get("Sheen"))           # 3.x
+        if sheen_sock:
+            sv = float(sheen_sock.default_value)
+            if sv > 0.001:
+                sheen_ext = self.trv.processBasicNodeAddition(
+                    pm, "extensions", "SheenMaterialExtension", base_name + "_SheenME")
+                if sheen_ext:
+                    tint = pbsdf.inputs.get("Sheen Tint")
+                    if tint:
+                        sc = tint.default_value
+                        if hasattr(sc, '__len__') and len(sc) >= 3:  # 4.x: color
+                            sheen_ext.sheenColor = (float(sc[0]) * sv,
+                                                     float(sc[1]) * sv,
+                                                     float(sc[2]) * sv)
+                        else:                                         # 3.x: float
+                            sheen_ext.sheenColor = (sv, sv, sv)
+                    sheen_rough = pbsdf.inputs.get("Sheen Roughness")
+                    if sheen_rough:
+                        sheen_ext.sheenRoughness = float(sheen_rough.default_value)
+
+        # Anisotropy (KHR_materials_anisotropy)
+        ani_sock = pbsdf.inputs.get("Anisotropic")
+        if ani_sock:
+            av = float(ani_sock.default_value)
+            if abs(av) > 0.001:
+                ani_ext = self.trv.processBasicNodeAddition(
+                    pm, "extensions", "AnisotropyMaterialExtension", base_name + "_AniME")
+                if ani_ext:
+                    ani_ext.anisotropyStrength = av
+                    ani_rot = pbsdf.inputs.get("Anisotropic Rotation")
+                    if ani_rot:
+                        ani_ext.anisotropyRotation = float(ani_rot.default_value)
+
+
+    def _build_packaged_composed_shader(self, x3dApp, mat, pbsdf, base_name,
+                                        is_gltf_mr=False):
+        """Export as PackagedShader (MTLX) + ComposedShader (GLSL).
+        Falls back to PhysicalMaterialExt when MaterialX is unavailable or
+        the shader is a glTF MR group (no direct MTLX equivalent)."""
+        try:
+            import MaterialX as mx
+            import MaterialX.PyMaterialXGenShader as mx_gen
+            import MaterialX.PyMaterialXGenGlsl   as mx_glsl
+        except ImportError:
+            print(f"[RawKee] MaterialX Python package not found — "
+                  f"falling back to PhysicalMaterialExt for '{mat.name}'.")
+            self._build_physical_material_ext(x3dApp, mat, pbsdf, base_name,
+                                              is_gltf_mr=is_gltf_mr)
+            return
+
+        if is_gltf_mr:
+            print(f"[RawKee] glTF MR group has no MTLX equivalent — "
+                  f"falling back to PhysicalMaterialExt for '{mat.name}'.")
+            self._build_physical_material_ext(x3dApp, mat, pbsdf, base_name,
+                                              is_gltf_mr=True)
+            return
+
+        export_base = os.path.join(os.path.dirname(self.fullPath),
+                                   self.rkMatXPath.lstrip('/\\'))
+        os.makedirs(export_base, exist_ok=True)
+
+        mtlx_path, mat_node_name = self._build_mtlx_document(mat, pbsdf, base_name,
+                                                               export_base)
+        if not mtlx_path:
+            print(f"[RawKee] MaterialX document build failed for '{mat.name}' — "
+                  f"falling back to PhysicalMaterialExt.")
+            self._build_physical_material_ext(x3dApp, mat, pbsdf, base_name)
+            return
+
+        frag_path = os.path.join(export_base, base_name + ".frag")
+        vert_path = os.path.join(export_base, base_name + ".vert")
+
+        ok = self._generate_glsl_from_mtlx(mtlx_path, mat_node_name, frag_path, vert_path)
+        if not ok:
+            print(f"[RawKee] GLSL generation failed for '{mat.name}' — "
+                  f"falling back to PhysicalMaterialExt.")
+            self._build_physical_material_ext(x3dApp, mat, pbsdf, base_name)
+            return
+
+        rel_base  = self.rkMatXPath.rstrip('/') + '/' + base_name
+        mtlx_rel  = rel_base + ".mtlx"
+        frag_rel  = rel_base + ".frag"
+        vert_rel  = rel_base + ".vert"
+
+        # PackagedShader — MaterialX document
+        pkg = self.trv.processBasicNodeAddition(x3dApp, "shaders", "PackagedShader",
+                                                 base_name + "_PkSdr")
+        if pkg:
+            pkg.language = "MTLX"
+            pkg.url = [mtlx_rel]
+
+        # ComposedShader — GLSL frag + vert
+        cmp = self.trv.processBasicNodeAddition(x3dApp, "shaders", "ComposedShader",
+                                                 base_name + "_CpSdr")
+        if cmp:
+            cmp.language = "GLSL"
+            frag = self.trv.processBasicNodeAddition(cmp, "parts", "ShaderPart",
+                                                      base_name + "_CpSdr_Frag")
+            if frag:
+                frag.url  = [frag_rel]
+                frag.type = "FRAGMENT"
+            vert = self.trv.processBasicNodeAddition(cmp, "parts", "ShaderPart",
+                                                      base_name + "_CpSdr_Vert")
+            if vert:
+                vert.url = [vert_rel]
+
+
+    def _build_mtlx_document(self, mat, pbsdf, base_name, export_dir):
+        """Build a minimal MaterialX gltf_pbr document from Principled BSDF inputs.
+        Returns (mtlx_path, material_node_name) or (None, None) on failure."""
+        import MaterialX as mx
+
+        safe    = mx.createValidName(base_name)
+        ng_name = f"NG_{safe}"
+        sr_name = f"SR_{safe}"
+        m_name  = f"M_{safe}"
+
+        doc = mx.createDocument()
+        ng  = doc.addNodeGraph(ng_name)
+
+        def _add_image_node(sock_name, mx_type, out_suffix):
+            """Add an image node to the nodegraph for the texture on sock_name.
+            Returns the output name, or None if no texture is found."""
+            img_node = self._find_image_texture(mat.node_tree, sock_name, pbsdf)
+            blender_img = img_node.image if img_node else None
+            if not blender_img:
+                return None
+
+            src = bpy.path.abspath(blender_img.filepath) if blender_img.filepath else ''
+            if not os.path.isfile(src) and blender_img.packed_file:
+                fname = os.path.basename(blender_img.name) or blender_img.name
+                if not os.path.splitext(fname)[1]:
+                    data  = blender_img.packed_file.data
+                    fname += '.png' if data[:4] == b'\x89PNG' else '.jpg'
+                src = os.path.join(export_dir, fname)
+                with open(src, 'wb') as f:
+                    f.write(blender_img.packed_file.data)
+            if not os.path.isfile(src):
+                return None
+
+            url = (self._copy_texture(src, os.path.dirname(self.fullPath))
+                   if self.rkConsolidate else src)
+
+            node_name = f"img_{out_suffix}"
+            out_name  = f"{out_suffix}_out"
+            img_mx    = ng.addNode("image", node_name, mx_type)
+            file_inp  = img_mx.addInput("file", "filename")
+            file_inp.setValueString(url)
+            out_port  = ng.addOutput(out_name, mx_type)
+            out_port.setNodeName(node_name)
+            return out_name
+
+        em_sock_name = ("Emission Color" if pbsdf.inputs.get("Emission Color")
+                        else "Emission")
+
+        base_out = _add_image_node("Base Color",  "color3",  "base_color")
+        mr_out   = (_add_image_node("Metallic",   "color3",  "metallic_roughness") or
+                    _add_image_node("Roughness",  "color3",  "roughness"))
+        norm_out = _add_image_node("Normal",      "vector3", "normal")
+        emis_out = _add_image_node(em_sock_name,  "color3",  "emissive")
+        occ_out  = _add_image_node("Occlusion",   "float",   "occlusion")
+
+        # gltf_pbr surface shader
+        sr = doc.addNode("gltf_pbr", sr_name, "surfaceshader")
+
+        def _sr_inp_ng(name, mx_type, ng_out):
+            inp = sr.addInput(name, mx_type)
+            inp.setNodeGraphString(ng_name)
+            inp.setOutputString(ng_out)
+
+        def _sr_inp_val(name, mx_type, val):
+            inp = sr.addInput(name, mx_type)
+            if hasattr(val, '__len__'):
+                inp.setValueString(', '.join(f"{v:.6f}" for v in val))
+            else:
+                inp.setValueString(f"{val:.6f}")
+
+        base_col_raw = self._get_pbsdf_input_value(pbsdf, "Base Color")
+        if base_out:
+            _sr_inp_ng("base_color", "color3", base_out)
+        elif base_col_raw:
+            _sr_inp_val("base_color", "color3",
+                        (base_col_raw[0], base_col_raw[1], base_col_raw[2]))
+
+        if mr_out:
+            _sr_inp_ng("metallic_roughness", "color3", mr_out)
+        else:
+            metal_val = self._get_pbsdf_input_value(pbsdf, "Metallic")
+            rough_val = self._get_pbsdf_input_value(pbsdf, "Roughness")
+            if metal_val is not None:
+                _sr_inp_val("metallic",  "float", float(metal_val))
+            if rough_val is not None:
+                _sr_inp_val("roughness", "float", float(rough_val))
+
+        if norm_out:
+            _sr_inp_ng("normal", "vector3", norm_out)
+
+        em_sock = pbsdf.inputs.get("Emission Color") or pbsdf.inputs.get("Emission")
+        if emis_out:
+            _sr_inp_ng("emissive", "color3", emis_out)
+        elif em_sock:
+            ec = em_sock.default_value
+            if any(v > 0.001 for v in (ec[0], ec[1], ec[2])):
+                _sr_inp_val("emissive", "color3", (ec[0], ec[1], ec[2]))
+
+        if occ_out:
+            _sr_inp_ng("occlusion", "float", occ_out)
+
+        alpha_val = self._get_pbsdf_input_value(pbsdf, "Alpha")
+        if alpha_val is not None:
+            _sr_inp_val("alpha", "float", float(alpha_val))
+
+        ior_val = self._get_pbsdf_input_value(pbsdf, "IOR")
+        if ior_val is not None:
+            _sr_inp_val("ior", "float", float(ior_val))
+
+        trans_sock = (pbsdf.inputs.get("Transmission Weight") or
+                      pbsdf.inputs.get("Transmission"))
+        if trans_sock:
+            tv = float(trans_sock.default_value)
+            if tv > 0.001:
+                _sr_inp_val("transmission", "float", tv)
+
+        # Surface material node
+        mat_mx = doc.addNode("surfacematerial", m_name, "material")
+        ss_inp = mat_mx.addInput("surfaceshader", "surfaceshader")
+        ss_inp.setNodeName(sr_name)
+
+        mtlx_path = os.path.join(export_dir, base_name + ".mtlx")
+        try:
+            mx.writeToXmlFile(doc, mtlx_path)
+            print(f"[RawKee] MaterialX document written: {mtlx_path}")
+        except Exception as e:
+            print(f"[RawKee] Failed to write MaterialX document: {e}")
+            return None, None
+
+        return mtlx_path, m_name
+
+
+    def _generate_glsl_from_mtlx(self, mtlx_path, mat_name, frag_path, vert_path):
+        """Generate GLSL frag/vert from a MaterialX document. Returns True on success."""
+        import MaterialX as mx
+        import MaterialX.PyMaterialXGenShader as mx_gen
+        import MaterialX.PyMaterialXGenGlsl   as mx_glsl
+
+        try:
+            doc   = mx.createDocument()
+            sPath = mx.FileSearchPath()
+            sPath.append(os.path.dirname(mtlx_path))
+            sPath.append(mx.getDefaultDataSearchPath())
+
+            for subfolder in ['libraries', 'libraries/stdlib', 'libraries/pbrlib']:
+                lib_doc = mx.createDocument()
+                mx.loadLibraries([subfolder], sPath.asString(), lib_doc)
+                doc.importLibrary(lib_doc)
+
+            mx.readFromXmlFile(doc, mtlx_path, sPath.asString())
+
+            materials = [n for n in doc.getNodes() if n.getCategory() == 'surfacematerial']
+            if not materials:
+                print(f"[RawKee] No surfacematerial node found in {mtlx_path}")
+                return False
+
+            target = next((m for m in materials if m.getName() == mat_name), materials[0])
+
+            gen     = mx_glsl.GlslShaderGenerator.create()
+            context = mx_gen.GenContext(gen)
+            context.registerSourceCodeSearchPath(sPath)
+            context.getOptions().shaderInterfaceType = mx_gen.SHADER_INTERFACE_COMPLETE
+
+            safe_name = mx.createValidName(target.getName())
+            shader    = gen.generate(safe_name, target, context)
+
+            v_stage = getattr(mx_gen, 'VERTEX_STAGE', 'vertex')
+            p_stage = getattr(mx_gen, 'PIXEL_STAGE',  'pixel')
+
+            with open(vert_path, 'w') as f:
+                f.write(shader.getSourceCode(v_stage))
+            with open(frag_path, 'w') as f:
+                f.write(shader.getSourceCode(p_stage))
+
+            print(f"[RawKee] GLSL files written:\n  {vert_path}\n  {frag_path}")
+            return True
+
+        except Exception as e:
+            print(f"[RawKee] GLSL generation error: {e}")
+            return False
 
 
     def _make_image_texture(self, parent_node, field_name, blender_image, def_name,
@@ -748,14 +1130,13 @@ class RKOrganizerBlender:
 
         src_abs = bpy.path.abspath(blender_image.filepath) if blender_image.filepath else ''
 
-        # Packed image: the file lives only inside the .blend — extract raw bytes.
+        # Packed image: extract raw bytes to the images directory.
         if (not src_abs or not os.path.isfile(src_abs)) and blender_image.packed_file:
             raw_name = os.path.basename(
                 blender_image.name.lstrip('/').lstrip('\\')
             ) or blender_image.name
             fname = raw_name
             if not os.path.splitext(fname)[1]:
-                # Detect format from file magic bytes
                 data = blender_image.packed_file.data
                 if data[:4] == b'\x89PNG':
                     fname += '.png'
@@ -771,22 +1152,74 @@ class RKOrganizerBlender:
             except Exception as e:
                 print(f"RKOrganizerBlender: packed image extract failed '{fname}': {e}")
                 return None
-            url = self.rkImagePath.lstrip('/') + '/' + fname
+            src_abs = dst
 
         elif not src_abs or not os.path.isfile(src_abs):
             return None   # no file and not packed — nothing to export
 
+        # Determine output URL.
+        # HDR/EXR: "Convert HDR/EXR to KTX2" decides the format; "Consolidate Media"
+        # decides where the file lands.  Other formats follow the normal copy logic.
+        file_ext = os.path.splitext(src_abs)[1].lower()
+        if self.rkConvertHDRToKTX2 and file_ext in ('.hdr', '.exr'):
+            import importlib, subprocess as _sp
+            # Find pip install locations for KTX2 deps and add to sys.path immediately
+            for _pkg in ('numpy', 'imageio', 'cv2', 'scipy'):
+                _show = _sp.run([sys.executable, "-m", "pip", "show",
+                                  "opencv-python" if _pkg == "cv2" else _pkg],
+                                 capture_output=True, text=True)
+                for _line in _show.stdout.splitlines():
+                    if _line.startswith("Location: "):
+                        _loc = os.path.normpath(_line[10:].strip())
+                        if _loc not in [os.path.normpath(p) for p in sys.path]:
+                            sys.path.insert(0, _loc)
+                        break
+            importlib.invalidate_caches()
+            def _importable(name):
+                try:
+                    __import__(name)
+                    return True
+                except Exception as e:
+                    _rk_log(f"[RawKee] Cannot import '{name}': {type(e).__name__}: {e}")
+                    return False
+            _missing = [m for m in ('numpy', 'imageio', 'cv2', 'scipy') if not _importable(m)]
+            if _missing:
+                _rk_log(f"[RawKee] KTX2 skipped — missing packages: {_missing}\n"
+                      f"[RawKee] Fix: run blender_rawkee_install.py to install them.")
+                url_list = [src_abs]
+            else:
+                fname_ktx2 = os.path.splitext(os.path.basename(src_abs))[0] + '.ktx2'
+                if self.rkConsolidate:
+                    os.makedirs(self.imageMoveDir, exist_ok=True)
+                    dst_ktx2 = os.path.join(self.imageMoveDir, fname_ktx2)
+                    url_list  = [fname_ktx2, self.rkImagePath + fname_ktx2]
+                else:
+                    out_dir  = os.path.dirname(self.fullPath)
+                    dst_ktx2 = os.path.join(out_dir, fname_ktx2)
+                    url_list  = [fname_ktx2]
+                try:
+                    RKTools.hdri2ktx2(src_abs, dst_ktx2, file_ext == '.exr',
+                                      self.rkMaxCubeMapFaceSize)
+                    _rk_log(f"[RawKee] KTX2 conversion succeeded: {dst_ktx2}")
+                except Exception as e:
+                    import traceback
+                    _rk_log(f"[RawKee] KTX2 conversion FAILED for '{src_abs}': {e}")
+                    traceback.print_exc()
+                    url_list = [src_abs]  # fall back to original path on failure
+
         elif self.rkConsolidate:
-            url = self._copy_texture(src_abs, os.path.dirname(self.fullPath))
+            fname    = os.path.basename(src_abs)
+            rel_url  = self._copy_texture(src_abs, os.path.dirname(self.fullPath))
+            url_list = [fname, rel_url]  # ["texture.jpg", "images/texture.jpg"]
 
         else:
-            url = src_abs
+            url_list = [src_abs]
 
         tex = self.trv.processBasicNodeAddition(
             parent_node, field_name, node_type, def_name
         )
         if tex:
-            tex.url = [url]
+            tex.url = url_list
         return tex
 
 
@@ -1045,7 +1478,7 @@ class RKOrganizerBlender:
         if spkr.sound and spkr.sound.filepath:
             src_abs = bpy.path.abspath(spkr.sound.filepath)
             if self.rkConsolidate:
-                url = self.rkAudioPath.lstrip('/') + '/' + os.path.basename(src_abs)
+                url = self.rkAudioPath + os.path.basename(src_abs)
                 dst = os.path.join(self.audioMoveDir, os.path.basename(src_abs))
                 if os.path.isfile(src_abs) and not os.path.isfile(dst):
                     try:

--- a/rawkee4blender/blender/RKWeb3DBlenderUI.py
+++ b/rawkee4blender/blender/RKWeb3DBlenderUI.py
@@ -32,68 +32,18 @@ _timer_live  = False
 
 def _pump_qt_events():
     """Blender timer callback: keep Qt responsive. Returns next interval or None to stop."""
-    global _editor_win, _timer_live
-    if _editor_win is None or not _editor_win.isVisible():
-        _editor_win  = None
-        _timer_live  = False
-        return None  # unregisters the timer
+    global _editor_win, _timer_live, _qt_app
     try:
-        from PySide6.QtWidgets import QApplication
-        QApplication.processEvents()
+        if _qt_app is None or _editor_win is None or not _editor_win.isVisible():
+            _editor_win = None
+            _timer_live = False
+            return None  # unregisters the timer
+        _qt_app.processEvents()
     except Exception:
-        pass
-    return 0.016  # ~60 fps
-
-
-class RAWKEE_OT_InstallPySide6(bpy.types.Operator):
-    """Install PySide6 into Blender's bundled Python via pip"""
-    bl_idname  = "rawkee.install_pyside6"
-    bl_label   = "Install PySide6"
-    bl_options = {'REGISTER'}
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width=420)
-
-    def draw(self, context):
-        layout = self.layout
-        layout.label(text="PySide6 is required for the RawKee X3D Interaction Editor.", icon='INFO')
-        layout.separator()
-        layout.label(text="Click OK to install it via pip into Blender's Python.")
-        layout.label(text="Requires internet access and may take 1-2 minutes.", icon='TIME')
-        layout.label(text="Blender must be restarted after installation.", icon='ERROR')
-
-    def execute(self, context):
-        import subprocess
-        import glob
-
-        # sys.executable is blender.exe; find the real Python binary via sys.prefix
-        if sys.platform == 'win32':
-            candidates = glob.glob(os.path.join(sys.prefix, 'bin', 'python*.exe'))
-        else:
-            candidates = [p for p in glob.glob(os.path.join(sys.prefix, 'bin', 'python3*'))
-                          if not p.endswith('-config')]
-        if not candidates:
-            self.report({'ERROR'}, f"Could not locate Python binary under {sys.prefix}")
-            return {'CANCELLED'}
-        python_exe = candidates[0]
-
-        # Install into Blender's user modules dir, which is already on sys.path
-        target_dir = bpy.utils.user_resource('SCRIPTS', path='modules')
-        os.makedirs(target_dir, exist_ok=True)
-
-        self.report({'INFO'}, f"Installing PySide6 to {target_dir} …")
-        try:
-            result = subprocess.run(
-                [python_exe, '-m', 'pip', 'install', 'PySide6', '--target', target_dir],
-                capture_output=True, text=True, timeout=300
-            )
-            if result.returncode == 0:
-                self.report({'INFO'}, "PySide6 installed. Please restart Blender, then open the X3D Interaction Editor.")
-            else:
-                self.report({'ERROR'}, f"pip install failed: {result.stderr[-300:]}")
-        except Exception as exc:
-            self.report({'ERROR'}, f"Installation failed: {exc}")
-        return {'FINISHED'}
+        _editor_win = None
+        _timer_live = False
+        return None
+    return 0.016 if bpy.app.version >= (5, 0, 0) else 0.05  # 60fps on 5+, 20fps on 4.x
 
 
 class RAWKEE_OT_OpenSceneEditor(bpy.types.Operator):
@@ -104,17 +54,30 @@ class RAWKEE_OT_OpenSceneEditor(bpy.types.Operator):
 
     def execute(self, context):
         global _qt_app, _editor_win, _timer_live
+        if bpy.app.version < (5, 0, 0):
+            self.report({'WARNING'},
+                "The X3D Interaction Editor requires Blender 5.0 or later. "
+                "Use the standalone RawKee PE application instead.")
+            return {'CANCELLED'}
+        # Ensure PySide6's Qt DLLs are on the Windows DLL search path
+        try:
+            import importlib.util, os as _os
+            _spec = importlib.util.find_spec('PySide6')
+            if _spec and _spec.origin and hasattr(_os, 'add_dll_directory'):
+                _os.add_dll_directory(_os.path.dirname(_spec.origin))
+        except Exception:
+            pass
         try:
             from PySide6.QtWidgets import QApplication
             from rawkee.editor.RKSceneEditor import RKSceneEditor
-        except ImportError:
-            bpy.ops.rawkee.install_pyside6('INVOKE_DEFAULT')
+        except Exception as e:
+            self.report({'ERROR'},
+                f"Cannot open X3D Interaction Editor: {type(e).__name__}: {e}. "
+                "Run blender_rawkee_install.py, then restart Blender.")
             return {'CANCELLED'}
 
         if _qt_app is None:
             _qt_app = QApplication.instance() or QApplication([])
-            from rawkee.editor.RKSceneEditor import apply_dark_palette
-            apply_dark_palette(_qt_app)
             from rawkee.editor.RKSceneEditor import apply_dark_palette
             apply_dark_palette(_qt_app)
 
@@ -152,11 +115,6 @@ def _run_export(operator, context, filepath, encoding, selected_only):
         rko.prepForSceneTraversal(context)
         x3dDoc       = rko.trv.getX3DObject()
         x3dDoc.Scene = rko.trv.getSceneObject()
-        bkNode = rko.trv.processBasicNodeAddition(
-            x3dDoc.Scene, "children", "Background", "DefaultBackground")
-        if bkNode and context.scene.world:
-            c = context.scene.world.color
-            bkNode.skyColor[0] = (c.r, c.g, c.b)
         fext = os.path.splitext(filepath)[1].lstrip('.')
         enc  = fext if fext in ('x3d','x3dv','x3dj','json') else encoding
         if selected_only:
@@ -170,7 +128,7 @@ def _run_export(operator, context, filepath, encoding, selected_only):
             except Exception:
                 pass
         del x3dDoc, rko
-        operator.report({'INFO'}, f"X3D export complete: {filepath}")
+        operator.report({'INFO'}, f"X3D export complete: {filepath}  |  Log: Scripting workspace → Text Editor → 'RawKee Export Log'")
         return {'FINISHED'}
     except Exception as e:
         import traceback; traceback.print_exc()
@@ -187,6 +145,11 @@ class RAWKEE_OT_ExportX3DAll(bpy.types.Operator, ExportHelper):
     filename_ext = ".x3d"
     filter_glob: StringProperty(default="*.x3d;*.x3dv;*.x3dj;*.json", options={'HIDDEN'})
     encoding: EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    def invoke(self, context, event):
+        prj = context.scene.rk_export_opts.prj_dir
+        if prj:
+            self.filepath = prj
+        return ExportHelper.invoke(self, context, event)
     def execute(self, context):
         return _run_export(self, context, self.filepath, self.encoding, False)
     def draw(self, context):
@@ -201,6 +164,11 @@ class RAWKEE_OT_ExportX3DSelected(bpy.types.Operator, ExportHelper):
     filename_ext = ".x3d"
     filter_glob: StringProperty(default="*.x3d;*.x3dv;*.x3dj;*.json", options={'HIDDEN'})
     encoding: EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    def invoke(self, context, event):
+        prj = context.scene.rk_export_opts.prj_dir
+        if prj:
+            self.filepath = prj
+        return ExportHelper.invoke(self, context, event)
     def execute(self, context):
         return _run_export(self, context, self.filepath, self.encoding, True)
     def draw(self, context):
@@ -258,41 +226,20 @@ class RAWKEE_OT_ShowMSF(bpy.types.Operator):
 # ---------------------------------------------------------------------------
 class RKMainPanel(bpy.types.Panel):
     """RawKee PE (X3D) main sidebar panel"""
-    bl_label       = "RawKee (.X3D)"
+    bl_label       = "RawKee X3D for Blender"
     bl_idname      = "RAWKEE_PT_MainPanel"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     def draw(self, context):
-        self.layout.label(text="RawKee PE (X3D) v0.1 - Blender 5", icon='WORLD')
-
-
-class RAWKEE_PT_SubPanel_Export(bpy.types.Panel):
-    """File Import / Export actions"""
-    bl_label       = "File - Import / Export"
-    bl_idname      = "RAWKEE_PT_SubPanel_Export"
-    bl_space_type  = 'VIEW_3D'
-    bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
-    bl_parent_id   = 'RAWKEE_PT_MainPanel'
-    def draw(self, context):
-        col = self.layout.column(align=True)
-        col.operator("rawkee.export_x3d_all",      icon='EXPORT', text="Export All X3D")
-        col.operator("rawkee.export_x3d_selected", icon='EXPORT', text="Export Selected X3D")
-        col.separator()
-        col.operator("rawkee.set_project", icon='FILE_FOLDER', text="Set RawKee Project")
-
-
-class RAWKEE_PT_SubPanel_SceneEditor(bpy.types.Panel):
-    """Launch the standalone RawKee X3D Interaction Editor"""
-    bl_label       = "X3D Interaction Editor"
-    bl_idname      = "RAWKEE_PT_SubPanel_SceneEditor"
-    bl_space_type  = 'VIEW_3D'
-    bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
-    bl_parent_id   = 'RAWKEE_PT_MainPanel'
-    def draw(self, context):
-        self.layout.operator("rawkee.open_scene_editor", icon='WINDOW', text="X3D Interaction Editor")
+        layout = self.layout
+        row = layout.row()
+        row.alignment = 'LEFT'
+        row.operator("rawkee.export_options_dialog", icon='PREFERENCES', text="X3D Export Options")
+        layout.separator()
+        row = layout.row()
+        row.alignment = 'LEFT'
+        row.operator("rawkee.open_scene_editor",     icon='WINDOW',       text="X3D Interaction Editor")
 
 
 class RAWKEE_PT_SubPanel_AddNodes(bpy.types.Panel):
@@ -301,36 +248,64 @@ class RAWKEE_PT_SubPanel_AddNodes(bpy.types.Panel):
     bl_idname      = "RAWKEE_PT_SubPanel_AddNodes"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
     def draw(self, context):
         col = self.layout.column(align=True)
         col.operator("rawkee.add_x3d_sound", icon='SPEAKER', text="Add X3D Sound")
-        col.operator("rawkee.add_anim_pack",  icon='ACTION',  text="Add RK AnimPack")
 
 
 class RAWKEE_PT_SubPanel_Links(bpy.types.Panel):
-    """3rd party X3D tools and viewers"""
-    bl_label       = "3rd Party Tools & Viewers"
+    """X3D external websites"""
+    bl_label       = "X3D External Websites"
     bl_idname      = "RAWKEE_PT_SubPanel_Links"
     bl_space_type  = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category    = 'RawKee (.X3D)'
+    bl_category    = 'RawKee X3D for Blender'
     bl_parent_id   = 'RAWKEE_PT_MainPanel'
     bl_options     = {'DEFAULT_CLOSED'}
     def draw(self, context):
-        layout = self.layout
-        col = layout.column(align=True)
-        col.label(text="X3D Viewers:", icon='WORLD_DATA')
-        col.operator("rawkee.show_x_ite",   icon='URL')
-        col.operator("rawkee.show_cge",     icon='URL')
-        col.operator("rawkee.show_x3dom",   icon='URL')
-        col.separator()
-        col.label(text="X3D Editors:", icon='NODE_COMPOSITING')
-        col.operator("rawkee.show_sunrize", icon='URL')
-        col.separator()
-        col.label(text="Resources:", icon='BOOKMARKS')
+        pass
+
+
+class RAWKEE_PT_ExternalWebsites_Viewers(bpy.types.Panel):
+    bl_label       = "X3D Viewers"
+    bl_idname      = "RAWKEE_PT_ExternalWebsites_Viewers"
+    bl_space_type  = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category    = 'RawKee X3D for Blender'
+    bl_parent_id   = 'RAWKEE_PT_SubPanel_Links'
+    bl_options     = {'DEFAULT_CLOSED'}
+    def draw(self, context):
+        col = self.layout.column(align=True)
+        col.operator("rawkee.show_x_ite",  icon='URL')
+        col.operator("rawkee.show_cge",    icon='URL')
+        col.operator("rawkee.show_x3dom",  icon='URL')
+
+
+class RAWKEE_PT_ExternalWebsites_Editors(bpy.types.Panel):
+    bl_label       = "X3D Editors"
+    bl_idname      = "RAWKEE_PT_ExternalWebsites_Editors"
+    bl_space_type  = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category    = 'RawKee X3D for Blender'
+    bl_parent_id   = 'RAWKEE_PT_SubPanel_Links'
+    bl_options     = {'DEFAULT_CLOSED'}
+    def draw(self, context):
+        self.layout.operator("rawkee.show_sunrize", icon='URL')
+
+
+class RAWKEE_PT_ExternalWebsites_Resources(bpy.types.Panel):
+    bl_label       = "Resources"
+    bl_idname      = "RAWKEE_PT_ExternalWebsites_Resources"
+    bl_space_type  = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category    = 'RawKee X3D for Blender'
+    bl_parent_id   = 'RAWKEE_PT_SubPanel_Links'
+    bl_options     = {'DEFAULT_CLOSED'}
+    def draw(self, context):
+        col = self.layout.column(align=True)
         col.operator("rawkee.show_help_wiki",  icon='URL')
         col.operator("rawkee.show_dream_lab",  icon='URL')
         col.operator("rawkee.show_web3d",      icon='URL')
@@ -344,10 +319,14 @@ def _menu_export(self, context):
         text="RawKee X3D (.x3d / .x3dv / .x3dj)",
         icon='WORLD_DATA',
     )
+    self.layout.operator(
+        "rawkee.export_options_dialog",
+        text="RawKee X3D - Export Options",
+        icon='PREFERENCES',
+    )
 
 
 _own_classes = [
-    RAWKEE_OT_InstallPySide6,
     RAWKEE_OT_OpenSceneEditor,
     RAWKEE_OT_ExportX3DAll,
     RAWKEE_OT_ExportX3DSelected,
@@ -361,10 +340,11 @@ _own_classes = [
     RAWKEE_OT_ShowWeb3D,
     RAWKEE_OT_ShowMSF,
     RKMainPanel,
-    RAWKEE_PT_SubPanel_SceneEditor,
-    RAWKEE_PT_SubPanel_Export,
     RAWKEE_PT_SubPanel_AddNodes,
     RAWKEE_PT_SubPanel_Links,
+    RAWKEE_PT_ExternalWebsites_Viewers,
+    RAWKEE_PT_ExternalWebsites_Editors,
+    RAWKEE_PT_ExternalWebsites_Resources,
 ]
 
 _sub_modules = [
@@ -380,7 +360,21 @@ _sub_modules = [
 ]
 
 
+def _setup_pip_paths():
+    """Ensure user site-packages is on sys.path at addon startup."""
+    import importlib, os as _os
+    try:
+        import site as _site
+        user_site = _os.path.normpath(_site.getusersitepackages())
+        if user_site not in [_os.path.normpath(p) for p in sys.path]:
+            sys.path.insert(0, user_site)
+            importlib.invalidate_caches()
+    except Exception as e:
+        print(f"[RawKee] _setup_pip_paths failed: {e}")
+
+
 def register():
+    _setup_pip_paths()
     for cls in _own_classes:
         bpy.utils.register_class(cls)
 
@@ -395,7 +389,7 @@ def register():
 
     bpy.types.TOPBAR_MT_file_export.append(_menu_export)
     print("[RawKee] Addon registered. "
-          "In the 3D Viewport press N and select the 'RawKee (.X3D)' tab. "
+          "In the 3D Viewport press N and select the 'RawKee X3D for Blender' tab. "
           "File > Export also has a 'RawKee X3D' entry.")
 
 


### PR DESCRIPTION
Blender 4.2+ and Blender 5+, support of PBR materials, EnvironmentLight, IndexedFaceSet, and more nodes. HDRI conversion to KTX2, and X3D Interaction Editor.
This pull request introduces several improvements to the RawKee X3D Blender add-on, focusing on enhanced dependency management, persistent export option defaults, and UI/UX improvements for export settings. The changes ensure smoother installation, more robust export option handling, and a more user-friendly interface.

**Dependency management and installation:**
* Added automatic checking and installation of required Python pip packages (`numpy`, `imageio`, `opencv-python`, `scipy`, `PySide6`, `MaterialX`) during add-on installation, ensuring immediate availability in the Blender session. The installer now adds the installed package locations to `sys.path` and reports status to the user. (`blender_rawkee_install.py`) [[1]](diffhunk://#diff-416bb382383012d1870a70018082bd09a7e3941b63e73591df611635c9b17a62R148-R213) [[2]](diffhunk://#diff-416bb382383012d1870a70018082bd09a7e3941b63e73591df611635c9b17a62R268) [[3]](diffhunk://#diff-416bb382383012d1870a70018082bd09a7e3941b63e73591df611635c9b17a62R280-R281) [[4]](diffhunk://#diff-5c6d02acb19f0d2cd74b4d14bba4e0b7e43a0d6e7a6946929f5b1ff0454c0506R29-R39)
* Updated the supported Blender version in the add-on metadata to `(4, 2, 0)`. (`Blender_RawKee_Python_X3D.py`)

**Export options persistence and UI improvements:**
* Added persistent export option defaults using a JSON config file, mirroring Maya's `optionVar` behavior. Export options are now saved/restored across Blender sessions and when loading files. (`rawkee4blender/blender/RKBExportOptions.py`) [[1]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R17-R79) [[2]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L86-R159) [[3]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R465-L356) [[4]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R478-R487)
* Refactored the export options UI: replaced the sidebar panel with a popup dialog (`RAWKEE_OT_ExportOptionsDialog`) that allows users to save options and directly launch export actions. Added "Save Options & Export All/Selected" buttons and improved the reset-to-defaults workflow. (`rawkee4blender/blender/RKBExportOptions.py`) [[1]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L223-R294) [[2]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L298-R321) [[3]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R349-R456)
* Added new export options for HDR/EXR-to-KTX2 conversion and cube map face size, with corresponding UI controls. (`rawkee4blender/blender/RKBExportOptions.py`) [[1]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R196-R205) [[2]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L298-R321)

**UI/UX consistency:**
* Updated the `bl_category` label for all RawKee panels to "RawKee X3D for Blender" for improved clarity and consistency. (`rawkee4blender/blender/RKBBindPoseEditor.py`, `rawkee4blender/blender/RKBCharacterAnimationClipEditor.py`, `rawkee4blender/blender/RKBCharacterEditor.py`, `rawkee4blender/blender/RKBHAnimHumanoidSetupEditor.py`) [[1]](diffhunk://#diff-0ef085215be3d87d2c5c07a0f65ec3dbe814a91aa9dd87d4ea039bb3ff3738e7L215-R215) [[2]](diffhunk://#diff-b43a072e7a17af14d46c0ba6c71df2091e05b3f27acc545c09e881de3bc6b920L208-R208) [[3]](diffhunk://#diff-84f4c378f8e2f5b5c932ae87d33a72ed6e2bcd7222651302a39b9b4ec85e539eL212-R212) [[4]](diffhunk://#diff-d00d3cd3914e28fece0ef500985f7e9d2a6294f37e708d0397f2cc73affc5afbL151-R151)

**Export path defaults:**
* Changed default export sub-paths to not start with a slash (e.g., `images/` instead of `/images`) for better cross-platform compatibility and user experience. (`rawkee4blender/blender/RKBExportOptions.py`) [[1]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L86-R159) [[2]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892L223-R294) [[3]](diffhunk://#diff-47c06f8ef8f1c57e418bec52ba7087726936254fc3e23f182c02d20248e97892R349-R456)

These changes collectively improve installation reliability, user experience, and the robustness of export settings in the RawKee Blender add-on.