### PR TITLE
The Blender ExportHelper object was preventing the user from choosing the *.x3dv and *.x3dj export options. Implemented manual control of the file chooser, which fixed the problem.

### DIFF
--- a/rawkee4blender/blender/RKOrganizerBlender.py
+++ b/rawkee4blender/blender/RKOrganizerBlender.py
@@ -89,18 +89,8 @@ def _safe_name(name):
     return name.replace(' ', '_').replace('.', '_').replace(':', '_')
 
 
-_RK_LOG_NAME = "RawKee Export Log"
-
-
 def _rk_log(msg):
-    """Write to system console AND the 'RawKee Export Log' text block in the Text Editor."""
     print(msg)
-    try:
-        if _RK_LOG_NAME not in bpy.data.texts:
-            bpy.data.texts.new(_RK_LOG_NAME)
-        bpy.data.texts[_RK_LOG_NAME].write(msg + "\n")
-    except Exception:
-        pass
 
 
 # ---------------------------------------------------------------------------

--- a/rawkee4blender/blender/RKWeb3DBlenderUI.py
+++ b/rawkee4blender/blender/RKWeb3DBlenderUI.py
@@ -14,8 +14,7 @@ _addon_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 if _addon_dir not in sys.path:
     sys.path.insert(0, _addon_dir)
 
-from bpy_extras.io_utils import ExportHelper
-from bpy.props           import StringProperty, EnumProperty
+from bpy.props import StringProperty, EnumProperty
 
 from rawkee.io.RKSceneTraversal        import RKSceneTraversal
 from rawkee4blender.blender.RKOrganizerBlender import RKOrganizerBlender
@@ -128,7 +127,7 @@ def _run_export(operator, context, filepath, encoding, selected_only):
             except Exception:
                 pass
         del x3dDoc, rko
-        operator.report({'INFO'}, f"X3D export complete: {filepath}  |  Log: Scripting workspace → Text Editor → 'RawKee Export Log'")
+        operator.report({'INFO'}, f"X3D export complete: {filepath}")
         return {'FINISHED'}
     except Exception as e:
         import traceback; traceback.print_exc()
@@ -137,38 +136,68 @@ def _run_export(operator, context, filepath, encoding, selected_only):
 
 
 # ---------------------------------------------------------------------------
-class RAWKEE_OT_ExportX3DAll(bpy.types.Operator, ExportHelper):
+_EXT_MAP = {'x3d': '.x3d', 'x3dv': '.x3dv', 'x3dj': '.x3dj', 'json': '.json'}
+_KNOWN_EXTS = set(_EXT_MAP.values())
+
+
+def _sync_filepath_ext(op):
+    """Return True if filepath was changed to match encoding."""
+    new_ext = _EXT_MAP.get(op.encoding, '.x3d')
+    base, cur_ext = os.path.splitext(op.filepath)
+    if cur_ext.lower() in _KNOWN_EXTS:
+        new_path = base + new_ext
+    elif os.path.basename(op.filepath):
+        new_path = op.filepath + new_ext
+    else:
+        return False
+    if new_path != op.filepath:
+        op.filepath = new_path
+        return True
+    return False
+
+
+def _default_filepath(context, encoding):
+    blend = context.blend_data.filepath
+    base = os.path.splitext(blend)[0] if blend else "untitled"
+    return base + _EXT_MAP.get(encoding, '.x3d')
+
+
+class RAWKEE_OT_ExportX3DAll(bpy.types.Operator):
     """Export the entire Blender scene as an X3D file"""
     bl_idname = "rawkee.export_x3d_all"
     bl_label  = "RawKee -- Export All X3D"
     bl_options = {'REGISTER'}
-    filename_ext = ".x3d"
+    filepath:    StringProperty(subtype='FILE_PATH')
     filter_glob: StringProperty(default="*.x3d;*.x3dv;*.x3dj;*.json", options={'HIDDEN'})
-    encoding: EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    encoding:    EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    def check(self, context):
+        return _sync_filepath_ext(self)
     def invoke(self, context, event):
         prj = context.scene.rk_export_opts.prj_dir
-        if prj:
-            self.filepath = prj
-        return ExportHelper.invoke(self, context, event)
+        self.filepath = prj if prj else _default_filepath(context, self.encoding)
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
     def execute(self, context):
         return _run_export(self, context, self.filepath, self.encoding, False)
     def draw(self, context):
         self.layout.prop(self, "encoding")
 
 
-class RAWKEE_OT_ExportX3DSelected(bpy.types.Operator, ExportHelper):
+class RAWKEE_OT_ExportX3DSelected(bpy.types.Operator):
     """Export only selected objects as an X3D file"""
     bl_idname = "rawkee.export_x3d_selected"
     bl_label  = "RawKee -- Export Selected X3D"
     bl_options = {'REGISTER'}
-    filename_ext = ".x3d"
+    filepath:    StringProperty(subtype='FILE_PATH')
     filter_glob: StringProperty(default="*.x3d;*.x3dv;*.x3dj;*.json", options={'HIDDEN'})
-    encoding: EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    encoding:    EnumProperty(name="Encoding", items=ENCODING_ITEMS, default='x3d')
+    def check(self, context):
+        return _sync_filepath_ext(self)
     def invoke(self, context, event):
         prj = context.scene.rk_export_opts.prj_dir
-        if prj:
-            self.filepath = prj
-        return ExportHelper.invoke(self, context, event)
+        self.filepath = prj if prj else _default_filepath(context, self.encoding)
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
     def execute(self, context):
         return _run_export(self, context, self.filepath, self.encoding, True)
     def draw(self, context):


### PR DESCRIPTION
The Blender ExportHelper object was preventing the user from choosing the *.x3dv and *.x3dj export options. Implemented manual control of the file chooser, which fixed the problem.

This pull request refactors the X3D export UI and logging in the Blender add-on to simplify the codebase, improve file extension handling, and remove unnecessary dependencies. The most important changes are grouped below:

**Export UI and File Extension Handling Improvements:**
* Removed the dependency on `ExportHelper` for both `RAWKEE_OT_ExportX3DAll` and `RAWKEE_OT_ExportX3DSelected` operators, replacing it with custom logic for file selection and extension management. This allows for better control and compatibility with multiple export formats. [[1]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL17) [[2]](diffhunk://#diff-38979e947b20dd9c062254bff73022c731ea34b68698316824959632bec3463aL140-R200)
* Added `_EXT_MAP`, `_KNOWN_EXTS`, `_sync_filepath_ext`, and `_default_filepath` helpers to automatically sync the file extension with the selected encoding and provide sensible default file paths. This ensures users export files with the correct extension for the chosen format.
* Modified the `check` and `invoke` methods in both export operators to use the new helpers, improving the user experience during file export.

**Logging and Messaging Changes:**
* Simplified the `_rk_log` function by removing the logic that wrote export logs to the Blender Text Editor, leaving only standard output logging.
* Updated the export completion message to remove references to the now-removed Text Editor log.