### PR TITLE
Added the lidar tool package and support for GaussianSplats.

### DIFF
--- a/rawkee/io/RKSceneTraversal.py
+++ b/rawkee/io/RKSceneTraversal.py
@@ -46,7 +46,7 @@ class RKSceneTraversal():
                             'EventUtilities':1,         'Shaders':1,                'CADGeometry':2,            'Texturing3D':2,
                             'CubeMapTexturing':3,       'Layering':1,               'Layout':2,                 'RigidBodyPhysics':2,
                             'Picking':3,                'Followers':1,              'ParticleSystems':3,        'VolumeRendering':4,
-                            'TextureProjection':2}
+                            'TextureProjection':2,      'GaussianSplats':1}
 
         # 20
         self.immersive      = {'Core':2,                'Time':1,                   'Networking':3,             'Grouping':2,
@@ -216,7 +216,8 @@ class RKSceneTraversal():
                         #print('S Field: ' + keyp[3])
                     else:
                         #if getattr(compNode,keyp[3]) != value:
-                        sNodeList.append(keyp[3])
+                        if keyp[3] != 'IS':
+                            sNodeList.append(keyp[3])
 
         compNode = None
         

--- a/rawkee/io/RKx3d.py
+++ b/rawkee/io/RKx3d.py
@@ -221,6 +221,24 @@ def assertValidClosureType(fieldName, value):
         return True
     raise X3DTypeError(fieldName + ' value=\'' + MFString(value).XML() + '\' does not match allowed enumerations in CLOSURETYPECHOICES=' + str(CLOSURETYPECHOICES))
 
+COLORSPACECHOICES = (
+    # strict set of allowed values follow, no other values are valid
+    'SRGB_REC709_DISPLAY',  # sRGB color space with Rec. 709 primaries, display-referred
+    'LIN_REC709_DISPLAY'   # linear color space with Rec. 709 primaries, display-referred
+)
+def assertValidColorSpace(fieldName, value):
+    """
+    Utility function to assert type validity of colorSpaceChoices value, otherwise raise X3DTypeError with diagnostic message.
+    Note MFString enumeration values are provided in XML syntax, so check validity accordingly.
+    """
+    if  not value:
+        return True # no failure on empty defaults
+    if str(MFString(value).XML()) in COLORSPACECHOICES:
+        return True
+    if isinstance(value, (SFString, str)) and str(SFString(value).XML()) in COLORSPACECHOICES:
+        return True
+    raise X3DTypeError(fieldName + ' value=\'' + MFString(value).XML() + '\' does not match allowed enumerations in COLORSPACECHOICES=' + str(COLORSPACECHOICES))
+
 COMPONENTNAMECHOICES = (
     # strict set of allowed values follow, no other values are valid
     'Core',  # The Core component supplies the base functionality for the X3D run-time system, including the abstract base node type, field types, the event model, and routing.
@@ -231,6 +249,7 @@ COMPONENTNAMECHOICES = (
     'EnvironmentalSensor',  # The Environment Sensor nodes emit events indicating activity in the scene environment, usually based on interactions between the viewer and the world.
     'EventUtilities',  # The Event Utility nodes provide the capability to filter, trigger, convert, or sequence numerous event-types for common interactive applications without the use of a Script node.
     'Followers',  # The Follower nodes (Chasers and Dampers) support dynamic creation of smooth parameter transitions at run time.
+    'GaussianSplats',  # The Gaussian Splats component provides support for direct real-time radiance field rendering without converting into surface or line primitives.
     'Geometry2D',  # The Geometry2D component defines how two-dimensional geometry is specified and what shapes are available.
     'Geometry3D',  # The Geometry3D component describes how three-dimensional geometry is specified and defines ElevationGrid, Extrusion, IndexedFaceSet, and most primitive geometry nodes (Box, Cone, Cylinder, Sphere).
     'Geospatial',  # The Geospatial component defines how to associate real-world locations in an X3D scene and specifies nodes particularly tuned for geospatial applications.
@@ -340,7 +359,9 @@ FIELDTYPECHOICES = (
     'SFMatrix4d',  # Single Field (singleton) 4×4 matrix of double-precision floating point numbers
     'MFMatrix4d',  # Multiple Field (list) 4×4 matric3w of double-precision floating point numbers
     'SFMatrix4f',  # Single Field (singleton) 4×4 matrix of single-precision floating point numbers
-    'MFMatrix4f'  # Multiple Field (list) 4×4 matrices of single-precision floating point numbers
+    'MFMatrix4f',  # Multiple Field (list) 4×4 matrices of single-precision floating point numbers
+    'SFQuaternion',  # Single Field (singleton) unit quaternion value (x,y,z,w)
+    'MFQuaternion'  # Multiple Field (list) unit quaternion values (x,y,z,w)
 )
 def assertValidFieldType(fieldName, value):
     """
@@ -5465,6 +5486,48 @@ def assertValidMFVec4f(value):
         # https://stackoverflow.com/questions/66995878/consider-explicitly-re-raising-using-the-from-keyword-pylint-suggestion
         print(flush=True)
         raise X3DTypeError(str(value)[:100] + ' has type ' + str(type(value)) + ' but is not a valid MFVec4f') from error
+
+def isValidSFQuaternion(value):
+    """
+    Utility function to determine type validity of a SFQuaternion value.
+    """
+    try:
+        SFQuaternion(value)
+        return True
+    except Exception:
+        return False
+
+def assertValidSFQuaternion(value):
+    """
+    Utility function to assert type validity of a SFQuaternion value, otherwise raise X3DTypeError with diagnostic message.
+    """
+    try:
+        SFQuaternion(value)
+    except Exception as error:
+        print(flush=True)
+        raise X3DTypeError(str(value)[:100] + ' has type ' + str(type(value)) + ' but is not a valid SFQuaternion') from error
+    return True
+
+def isValidMFQuaternion(value):
+    """
+    Utility function to determine type validity of a MFQuaternion value.
+    """
+    try:
+        MFQuaternion(value)
+        return True
+    except Exception:
+        return False
+
+def assertValidMFQuaternion(value):
+    """
+    Utility function to assert type validity of a MFQuaternion value, otherwise raise X3DTypeError with diagnostic message.
+    """
+    try:
+        MFQuaternion(value)
+    except Exception as error:
+        print(flush=True)
+        raise X3DTypeError(str(value)[:100] + ' has type ' + str(type(value)) + ' but is not a valid MFQuaternion') from error
+    return True
     # if _DEBUG: print('...DEBUG... debug value.__class__=' + str(value.__class__) + ', issubclass(value.__class__, _X3DField)=' + str(issubclass(value.__class__, _X3DField)) + ', super(value.__class__)=' + str(super(value.__class__)), flush=True)
     # if _DEBUG: print('value=', value, 'str(value)=', str(value))
     ### if isinstance(value, _X3DField) and not isinstance(value, SFVec4f) and not isinstance(value, MFVec4f):
@@ -5565,6 +5628,10 @@ def assertValidFieldInitializationValue(name, fieldType, value, parent=''):
         assertValidSFVec4f(value)
     elif fieldType == 'MFVec4f':
         assertValidMFVec4f(value)
+    elif fieldType == 'SFQuaternion':
+        assertValidSFQuaternion(value)
+    elif fieldType == 'MFQuaternion':
+        assertValidMFQuaternion(value)
     elif fieldType == 'SFVec2d':
         assertValidSFVec2d(value)
     elif fieldType == 'MFVec2d':
@@ -5905,6 +5972,14 @@ class FieldType(_X3DField):
     def MFVec4f():
         """ Type MFVec4f https://www.web3d.org/x3d/tooltips/X3dTooltips.html#MFVec4f """
         return 'MFVec4f'
+    @staticmethod
+    def SFQuaternion():
+        """ Type SFQuaternion: unit quaternion (x,y,z,w), introduced in X3D 4.1 for GaussianSplats. """
+        return 'SFQuaternion'
+    @staticmethod
+    def MFQuaternion():
+        """ Type MFQuaternion: array of unit quaternions (x,y,z,w), introduced in X3D 4.1 for GaussianSplats. """
+        return 'MFQuaternion'
 
 class SFBool(_X3DField):
     """
@@ -9815,6 +9890,145 @@ class MFVec4f(_X3DArrayField):
     def __len__(self):
         return len(self.__value)
 
+class SFQuaternion(_X3DField):
+    """
+    Field type SFQuaternion is a unit quaternion value stored as a 4-tuple (x,y,z,w). Introduced in X3D 4.1.
+    """
+    @classmethod
+    def NAME(cls):
+        """ Name of this X3D Field class. """
+        return 'SFQuaternion'
+    @classmethod
+    def SPECIFICATION_URL(cls):
+        """ Extensible 3D (X3D) Graphics International Standard governs X3D architecture for all file formats and programming languages. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def TOOLTIP_URL(cls):
+        """ X3D Tooltips provide authoring tips, hints and warnings for each node and field in X3D. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def DEFAULT_VALUE(cls):
+        """ Default value defined for this data type by the X3D Specification """
+        return (0.0, 0.0, 0.0, 1.0)  # identity quaternion
+    @classmethod
+    def ARRAY_TYPE(cls):
+        """ Whether or not this field class is array based. """
+        return False
+    @classmethod
+    def TUPLE_SIZE(cls):
+        """ How many values make up each data tuple. """
+        return 4
+    @classmethod
+    def REGEX_PYTHON(cls):
+        """ Regular expression for validating Python values. """
+        return r'\s*\(\s*(([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*\,?\s*){3}([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*\)\s*'
+    @classmethod
+    def REGEX_XML(cls):
+        """ Regular expression for validating XML values. """
+        return r'\s*(([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s+){3}([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*'
+    def __init__(self, value=None):
+        self.value = value
+    @property
+    def value(self):
+        """ Provide typed value of this field instance. """
+        return self.__value
+    @value.setter
+    def value(self, value):
+        """ The value setter only allows correctly typed and sized values. """
+        if isinstance(value, SFQuaternion):
+            value = value.value  # dereference
+        elif value is None:
+            value = SFQuaternion.DEFAULT_VALUE()
+        elif isinstance(value, list):
+            if len(value) == 4:
+                value = (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+        elif isinstance(value, MFQuaternion) and isinstance(value.value, list) and len(value.value) == 1:
+            value = value.value[0]  # dereference
+        self.__value = value
+    def __bool__(self):
+        return self.__value is not None
+
+class MFQuaternion(_X3DArrayField):
+    """
+    Field type MFQuaternion is zero or more SFQuaternion values, each a unit quaternion (x,y,z,w). Introduced in X3D 4.1.
+    """
+    @classmethod
+    def NAME(cls):
+        """ Name of this X3D Field class. """
+        return 'MFQuaternion'
+    @classmethod
+    def SPECIFICATION_URL(cls):
+        """ Extensible 3D (X3D) Graphics International Standard governs X3D architecture for all file formats and programming languages. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def TOOLTIP_URL(cls):
+        """ X3D Tooltips provide authoring tips, hints and warnings for each node and field in X3D. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def DEFAULT_VALUE(cls):
+        """ Default value defined for this data type by the X3D Specification """
+        return []  # use empty list object, don't keep resetting a mutable python DEFAULT_VALUE
+    @classmethod
+    def ARRAY_TYPE(cls):
+        """ Whether or not this field class is array based. """
+        return True
+    @classmethod
+    def TUPLE_SIZE(cls):
+        """ How many values make up each data tuple. """
+        return 4
+    @classmethod
+    def REGEX_PYTHON(cls):
+        """ Regular expression for validating Python values. """
+        return r'\s*\[?\s*(\s*\(?\s*((([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*\,?\s*){3}([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*,?\s*)*\)?\s*\,?)*\s*\]?\s*'
+    @classmethod
+    def REGEX_XML(cls):
+        """ Regular expression for validating XML values. """
+        return r'\s*((([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s+){3}([+-]?((0|[1-9][0-9]*)(\.[0-9]*)?|\.[0-9]+)([Ee][+-]?[0-9]+)?)\s*,?\s*)*'
+    def __init__(self, value=None):
+        if value is None:
+            value = self.DEFAULT_VALUE()
+        self.value = value
+    @property
+    def value(self):
+        """ Provide typed value of this field instance. """
+        return self.__value
+    @value.setter
+    def value(self, value):
+        """ The value setter only allows correctly typed and sized values. """
+        if isinstance(value, SFQuaternion):
+            value = value.value  # dereference
+        elif value is None:
+            value = MFQuaternion.DEFAULT_VALUE()
+        elif isinstance(value, list):
+            result = []
+            for each in value:
+                if isinstance(each, SFQuaternion):
+                    result.append(each.value)
+                elif isinstance(each, (tuple, list)) and len(each) == 4:
+                    result.append((float(each[0]), float(each[1]), float(each[2]), float(each[3])))
+                else:
+                    result.append(each)
+            value = result
+        elif isinstance(value, str):
+            value = []
+        self.__value = value
+    def append(self, value=None):
+        """ Add to existing value list, first ensuring that a correctly typed value is applied. """
+        if value is not None:
+            if isinstance(value, SFQuaternion):
+                self.__value.append(value.value)  # dereference
+            elif not isinstance(value, list) and not isinstance(value, MFQuaternion):
+                self.__value.append(SFQuaternion(value).value)  # checks validity
+            elif (isinstance(value, list) and len(value) > 0) or isinstance(value, MFQuaternion):
+                for each in value:
+                    self.__value.append(SFQuaternion(each).value)  # checks validity
+    def __bool__(self):
+        if not isinstance(self.__value, list):
+            print('*** x3d.py internal error, MFQuaternion self.__value type=' + str(type(self.__value)) + ' is not a list', flush=True)
+        return len(self.__value) > 0
+    def __len__(self):
+        return len(self.__value)
+
 class _X3DNode:
     """
     All instantiable nodes implement X3DNode, which corresponds to SFNode type in the X3D specification.
@@ -10927,6 +11141,20 @@ class _X3DBoundedObject(_X3DNode):
     def SPECIFICATION_URL(cls):
         """ Extensible 3D (X3D) Graphics International Standard governs X3D architecture for all file formats and programming languages. """
         return 'https://www.web3d.org/specifications/X3Dv4/ISO-IEC19775-1v4-IS/Part01/components/grouping.html#X3DBoundedObject'
+
+class _X3DGaussianSplatsNode(_X3DChildNode, _X3DBoundedObject):
+    """
+    X3DGaussianSplatsNode is the abstract base type for all Gaussian splats nodes.
+    """
+    # immutable constant functions have getter but no setter - - - - - - - - - -
+    @classmethod
+    def NAME(cls):
+        """ Name of this X3D Abstract Type class. """
+        return '_X3DGaussianSplatsNode'
+    @classmethod
+    def SPECIFICATION_URL(cls):
+        """ Extensible 3D (X3D) Graphics International Standard governs X3D architecture for all file formats and programming languages. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#X3DGaussianSplatsNode'
 
 class _X3DFogObject(_X3DNode):
     """
@@ -26255,6 +26483,432 @@ class Gain(_X3DSoundProcessingNode):
     def hasChild(self):
         """ Whether or not this node has any child node or statement """
         return self.IS or self.metadata or (len(self.children) > 0)
+    # output function - - - - - - - - - -
+
+class GaussianSplats(_X3DGaussianSplatsNode):
+    """
+    GaussianSplats provides direct real-time radiance field rendering using 3D Gaussian splat primitives.
+    """
+    # immutable constant functions have getter but no setter - - - - - - - - - -
+    @classmethod
+    def NAME(cls):
+        """ Name of this X3D Node class. """
+        return 'GaussianSplats'
+    @classmethod
+    def SPECIFICATION_URL(cls):
+        """ Extensible 3D (X3D) Graphics International Standard governs X3D architecture for all file formats and programming languages. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def TOOLTIP_URL(cls):
+        """ X3D Tooltips provide authoring tips, hints and warnings for each node and field in X3D. """
+        return 'https://www.web3d.org/specifications/X3Dv4Draft/ISO-IEC19775-1v4.1-CD/Part01/components/gaussianSplats.html#GaussianSplats'
+    @classmethod
+    def FIELD_DECLARATIONS(cls):
+        """ Field declarations for this node: name, defaultValue, type, accessType, inheritedFrom """
+        return [
+        ('bboxCenter', (0, 0, 0), FieldType.SFVec3f, AccessType.initializeOnly, 'X3DGaussianSplatsNode'),
+        ('bboxDisplay', False, FieldType.SFBool, AccessType.inputOutput, 'X3DGaussianSplatsNode'),
+        ('bboxSize', (-1, -1, -1), FieldType.SFVec3f, AccessType.initializeOnly, 'X3DGaussianSplatsNode'),
+        ('castShadow', False, FieldType.SFBool, AccessType.inputOutput, 'X3DGaussianSplatsNode'),
+        ('colorSpace', 'SRGB_REC709_DISPLAY', FieldType.SFString, AccessType.inputOutput, 'X3DGaussianSplatsNode'),
+        ('opacities', [], FieldType.MFFloat, AccessType.inputOutput, 'GaussianSplats'),
+        ('orientations', [], FieldType.MFQuaternion, AccessType.inputOutput, 'GaussianSplats'),
+        ('pointerEvents', False, FieldType.SFBool, AccessType.inputOutput, 'X3DGaussianSplatsNode'),
+        ('positions', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('scales', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree0Coef0', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree1Coef0', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree1Coef1', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree1Coef2', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree2Coef0', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree2Coef1', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree2Coef2', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree2Coef3', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree2Coef4', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef0', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef1', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef2', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef3', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef4', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef5', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('sphericalHarmonicsDegree3Coef6', [], FieldType.MFVec3f, AccessType.inputOutput, 'GaussianSplats'),
+        ('visible', True, FieldType.SFBool, AccessType.inputOutput, 'X3DGaussianSplatsNode'),
+        ('DEF', '', FieldType.SFString, AccessType.inputOutput, 'X3DNode'),
+        ('USE', '', FieldType.SFString, AccessType.inputOutput, 'X3DNode'),
+        ('IS', None, FieldType.SFNode, AccessType.inputOutput, 'X3DNode'),
+        ('metadata', None, FieldType.SFNode, AccessType.inputOutput, 'X3DNode'),
+        ('class_', '', FieldType.SFString, AccessType.inputOutput, 'X3DNode'),
+        ('id_', '', FieldType.SFString, AccessType.inputOutput, 'X3DNode'),
+        ('style_', '', FieldType.SFString, AccessType.inputOutput, 'X3DNode')]
+    def __init__(self,
+        bboxCenter=(0, 0, 0),
+        bboxDisplay=False,
+        bboxSize=(-1, -1, -1),
+        castShadow=False,
+        colorSpace='SRGB_REC709_DISPLAY',
+        opacities=None,
+        orientations=None,
+        pointerEvents=False,
+        positions=None,
+        scales=None,
+        sphericalHarmonicsDegree0Coef0=None,
+        sphericalHarmonicsDegree1Coef0=None,
+        sphericalHarmonicsDegree1Coef1=None,
+        sphericalHarmonicsDegree1Coef2=None,
+        sphericalHarmonicsDegree2Coef0=None,
+        sphericalHarmonicsDegree2Coef1=None,
+        sphericalHarmonicsDegree2Coef2=None,
+        sphericalHarmonicsDegree2Coef3=None,
+        sphericalHarmonicsDegree2Coef4=None,
+        sphericalHarmonicsDegree3Coef0=None,
+        sphericalHarmonicsDegree3Coef1=None,
+        sphericalHarmonicsDegree3Coef2=None,
+        sphericalHarmonicsDegree3Coef3=None,
+        sphericalHarmonicsDegree3Coef4=None,
+        sphericalHarmonicsDegree3Coef5=None,
+        sphericalHarmonicsDegree3Coef6=None,
+        visible=True,
+        DEF='',
+        USE='',
+        IS=None,
+        metadata=None,
+        class_='',
+        id_='',
+        style_=''):
+        # if _DEBUG: print('...DEBUG... in ConcreteNode GaussianSplats __init__ calling super.__init__(' + str(DEF) + ',' + str(USE) + ',' + str(class_) + ',' + str(id_) + ',' + str(style_) + ',' + str(metadata) + ',' + str(IS) + ')', flush=True)
+        super().__init__(DEF, USE, class_, id_, style_, IS, metadata) # fields for _X3DNode only
+        self.bboxCenter = bboxCenter
+        self.bboxDisplay = bboxDisplay
+        self.bboxSize = bboxSize
+        self.castShadow = castShadow
+        self.colorSpace = colorSpace
+        self.opacities = opacities
+        self.orientations = orientations
+        self.pointerEvents = pointerEvents
+        self.positions = positions
+        self.scales = scales
+        self.sphericalHarmonicsDegree0Coef0 = sphericalHarmonicsDegree0Coef0
+        self.sphericalHarmonicsDegree1Coef0 = sphericalHarmonicsDegree1Coef0
+        self.sphericalHarmonicsDegree1Coef1 = sphericalHarmonicsDegree1Coef1
+        self.sphericalHarmonicsDegree1Coef2 = sphericalHarmonicsDegree1Coef2
+        self.sphericalHarmonicsDegree2Coef0 = sphericalHarmonicsDegree2Coef0
+        self.sphericalHarmonicsDegree2Coef1 = sphericalHarmonicsDegree2Coef1
+        self.sphericalHarmonicsDegree2Coef2 = sphericalHarmonicsDegree2Coef2
+        self.sphericalHarmonicsDegree2Coef3 = sphericalHarmonicsDegree2Coef3
+        self.sphericalHarmonicsDegree2Coef4 = sphericalHarmonicsDegree2Coef4
+        self.sphericalHarmonicsDegree3Coef0 = sphericalHarmonicsDegree3Coef0
+        self.sphericalHarmonicsDegree3Coef1 = sphericalHarmonicsDegree3Coef1
+        self.sphericalHarmonicsDegree3Coef2 = sphericalHarmonicsDegree3Coef2
+        self.sphericalHarmonicsDegree3Coef3 = sphericalHarmonicsDegree3Coef3
+        self.sphericalHarmonicsDegree3Coef4 = sphericalHarmonicsDegree3Coef4
+        self.sphericalHarmonicsDegree3Coef5 = sphericalHarmonicsDegree3Coef5
+        self.sphericalHarmonicsDegree3Coef6 = sphericalHarmonicsDegree3Coef6
+        self.visible = visible
+        self.id_ = id_
+        self.style_ = style_
+    @property # getter - - - - - - - - - -
+    def bboxCenter(self):
+        """Bounding box center accompanies bboxSize and provides an optional hint for bounding box position offset from origin of local coordinate system."""
+        return self.__bboxCenter
+    @bboxCenter.setter
+    def bboxCenter(self, bboxCenter):
+        if  bboxCenter is None:
+            bboxCenter = (0, 0, 0)  # default
+        assertValidSFVec3f(bboxCenter)
+        self.__bboxCenter = bboxCenter
+    @property # getter - - - - - - - - - -
+    def bboxDisplay(self):
+        """Whether to display bounding box for associated geometry, aligned with world coordinates."""
+        return self.__bboxDisplay
+    @bboxDisplay.setter
+    def bboxDisplay(self, bboxDisplay):
+        if  bboxDisplay is None:
+            bboxDisplay = False  # default
+        assertValidSFBool(bboxDisplay)
+        self.__bboxDisplay = bboxDisplay
+    @property # getter - - - - - - - - - -
+    def bboxSize(self):
+        """or [0,+infinity) Bounding box size is usually omitted, and can easily be calculated automatically by an X3D player at scene-loading time with minimal computational cost."""
+        return self.__bboxSize
+    @bboxSize.setter
+    def bboxSize(self, bboxSize):
+        if  bboxSize is None:
+            bboxSize = (-1, -1, -1)  # default
+        assertValidSFVec3f(bboxSize)
+        assertBoundingBox('bboxSize', bboxSize)
+        self.__bboxSize = bboxSize
+    @property # getter - - - - - - - - - -
+    def castShadow(self):
+        """Whether this node casts shadows."""
+        return self.__castShadow
+    @castShadow.setter
+    def castShadow(self, castShadow):
+        if  castShadow is None:
+            castShadow = False  # default
+        assertValidSFBool(castShadow)
+        self.__castShadow = castShadow
+    @property # getter - - - - - - - - - -
+    def colorSpace(self):
+        """Color space of the reconstructed Gaussian splat color values as determined by the training process."""
+        return self.__colorSpace
+    @colorSpace.setter
+    def colorSpace(self, colorSpace):
+        if  colorSpace is None:
+            colorSpace = 'SRGB_REC709_DISPLAY'  # default
+        assertValidSFString(colorSpace)
+        assertValidColorSpace('colorSpace', colorSpace)
+        self.__colorSpace = colorSpace
+    @property # getter - - - - - - - - - -
+    def opacities(self):
+        """Opacity of each individual Gaussian splat, normalized between 0.0 (transparent) and 1.0 (opaque)."""
+        return self.__opacities
+    @opacities.setter
+    def opacities(self, opacities):
+        if  opacities is None:
+            opacities = MFFloat.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(MFFloat.DEFAULT_VALUE()))
+        assertValidMFFloat(opacities)
+        self.__opacities = opacities
+    @property # getter - - - - - - - - - -
+    def orientations(self):
+        """Orientation of each splat as a unit quaternion (x,y,z,w) in local space."""
+        return self.__orientations
+    @orientations.setter
+    def orientations(self, orientations):
+        if  orientations is None:
+            orientations = MFQuaternion.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(MFQuaternion.DEFAULT_VALUE()))
+        assertValidMFQuaternion(orientations)
+        self.__orientations = orientations
+    @property # getter - - - - - - - - - -
+    def pointerEvents(self):
+        """Whether this GaussianSplats node is a target for pointer events."""
+        return self.__pointerEvents
+    @pointerEvents.setter
+    def pointerEvents(self, pointerEvents):
+        if  pointerEvents is None:
+            pointerEvents = False  # default
+        assertValidSFBool(pointerEvents)
+        self.__pointerEvents = pointerEvents
+    @property # getter - - - - - - - - - -
+    def positions(self):
+        """Position (mean vector) of each individual Gaussian splat defining the center of its ellipsoid in local space."""
+        return self.__positions
+    @positions.setter
+    def positions(self, positions):
+        if  positions is None:
+            positions = MFVec3f.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(MFVec3f.DEFAULT_VALUE()))
+        assertValidMFVec3f(positions)
+        self.__positions = positions
+    @property # getter - - - - - - - - - -
+    def scales(self):
+        """Spread of the Gaussian along its local principal axes; values are linear and nonnegative."""
+        return self.__scales
+    @scales.setter
+    def scales(self, scales):
+        if  scales is None:
+            scales = MFVec3f.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(MFVec3f.DEFAULT_VALUE()))
+        assertValidMFVec3f(scales)
+        assertNonNegative('scales', scales)
+        self.__scales = scales
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree0Coef0(self):
+        """Degree-0 spherical harmonics coefficient 0 (DC term) defining base color."""
+        return self.__sphericalHarmonicsDegree0Coef0
+    @sphericalHarmonicsDegree0Coef0.setter
+    def sphericalHarmonicsDegree0Coef0(self, sphericalHarmonicsDegree0Coef0):
+        if  sphericalHarmonicsDegree0Coef0 is None:
+            sphericalHarmonicsDegree0Coef0 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree0Coef0)
+        self.__sphericalHarmonicsDegree0Coef0 = sphericalHarmonicsDegree0Coef0
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree1Coef0(self):
+        """Degree-1 spherical harmonics coefficient 0."""
+        return self.__sphericalHarmonicsDegree1Coef0
+    @sphericalHarmonicsDegree1Coef0.setter
+    def sphericalHarmonicsDegree1Coef0(self, sphericalHarmonicsDegree1Coef0):
+        if  sphericalHarmonicsDegree1Coef0 is None:
+            sphericalHarmonicsDegree1Coef0 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree1Coef0)
+        self.__sphericalHarmonicsDegree1Coef0 = sphericalHarmonicsDegree1Coef0
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree1Coef1(self):
+        """Degree-1 spherical harmonics coefficient 1."""
+        return self.__sphericalHarmonicsDegree1Coef1
+    @sphericalHarmonicsDegree1Coef1.setter
+    def sphericalHarmonicsDegree1Coef1(self, sphericalHarmonicsDegree1Coef1):
+        if  sphericalHarmonicsDegree1Coef1 is None:
+            sphericalHarmonicsDegree1Coef1 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree1Coef1)
+        self.__sphericalHarmonicsDegree1Coef1 = sphericalHarmonicsDegree1Coef1
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree1Coef2(self):
+        """Degree-1 spherical harmonics coefficient 2."""
+        return self.__sphericalHarmonicsDegree1Coef2
+    @sphericalHarmonicsDegree1Coef2.setter
+    def sphericalHarmonicsDegree1Coef2(self, sphericalHarmonicsDegree1Coef2):
+        if  sphericalHarmonicsDegree1Coef2 is None:
+            sphericalHarmonicsDegree1Coef2 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree1Coef2)
+        self.__sphericalHarmonicsDegree1Coef2 = sphericalHarmonicsDegree1Coef2
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree2Coef0(self):
+        """Degree-2 spherical harmonics coefficient 0."""
+        return self.__sphericalHarmonicsDegree2Coef0
+    @sphericalHarmonicsDegree2Coef0.setter
+    def sphericalHarmonicsDegree2Coef0(self, sphericalHarmonicsDegree2Coef0):
+        if  sphericalHarmonicsDegree2Coef0 is None:
+            sphericalHarmonicsDegree2Coef0 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree2Coef0)
+        self.__sphericalHarmonicsDegree2Coef0 = sphericalHarmonicsDegree2Coef0
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree2Coef1(self):
+        """Degree-2 spherical harmonics coefficient 1."""
+        return self.__sphericalHarmonicsDegree2Coef1
+    @sphericalHarmonicsDegree2Coef1.setter
+    def sphericalHarmonicsDegree2Coef1(self, sphericalHarmonicsDegree2Coef1):
+        if  sphericalHarmonicsDegree2Coef1 is None:
+            sphericalHarmonicsDegree2Coef1 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree2Coef1)
+        self.__sphericalHarmonicsDegree2Coef1 = sphericalHarmonicsDegree2Coef1
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree2Coef2(self):
+        """Degree-2 spherical harmonics coefficient 2."""
+        return self.__sphericalHarmonicsDegree2Coef2
+    @sphericalHarmonicsDegree2Coef2.setter
+    def sphericalHarmonicsDegree2Coef2(self, sphericalHarmonicsDegree2Coef2):
+        if  sphericalHarmonicsDegree2Coef2 is None:
+            sphericalHarmonicsDegree2Coef2 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree2Coef2)
+        self.__sphericalHarmonicsDegree2Coef2 = sphericalHarmonicsDegree2Coef2
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree2Coef3(self):
+        """Degree-2 spherical harmonics coefficient 3."""
+        return self.__sphericalHarmonicsDegree2Coef3
+    @sphericalHarmonicsDegree2Coef3.setter
+    def sphericalHarmonicsDegree2Coef3(self, sphericalHarmonicsDegree2Coef3):
+        if  sphericalHarmonicsDegree2Coef3 is None:
+            sphericalHarmonicsDegree2Coef3 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree2Coef3)
+        self.__sphericalHarmonicsDegree2Coef3 = sphericalHarmonicsDegree2Coef3
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree2Coef4(self):
+        """Degree-2 spherical harmonics coefficient 4."""
+        return self.__sphericalHarmonicsDegree2Coef4
+    @sphericalHarmonicsDegree2Coef4.setter
+    def sphericalHarmonicsDegree2Coef4(self, sphericalHarmonicsDegree2Coef4):
+        if  sphericalHarmonicsDegree2Coef4 is None:
+            sphericalHarmonicsDegree2Coef4 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree2Coef4)
+        self.__sphericalHarmonicsDegree2Coef4 = sphericalHarmonicsDegree2Coef4
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef0(self):
+        """Degree-3 spherical harmonics coefficient 0."""
+        return self.__sphericalHarmonicsDegree3Coef0
+    @sphericalHarmonicsDegree3Coef0.setter
+    def sphericalHarmonicsDegree3Coef0(self, sphericalHarmonicsDegree3Coef0):
+        if  sphericalHarmonicsDegree3Coef0 is None:
+            sphericalHarmonicsDegree3Coef0 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef0)
+        self.__sphericalHarmonicsDegree3Coef0 = sphericalHarmonicsDegree3Coef0
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef1(self):
+        """Degree-3 spherical harmonics coefficient 1."""
+        return self.__sphericalHarmonicsDegree3Coef1
+    @sphericalHarmonicsDegree3Coef1.setter
+    def sphericalHarmonicsDegree3Coef1(self, sphericalHarmonicsDegree3Coef1):
+        if  sphericalHarmonicsDegree3Coef1 is None:
+            sphericalHarmonicsDegree3Coef1 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef1)
+        self.__sphericalHarmonicsDegree3Coef1 = sphericalHarmonicsDegree3Coef1
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef2(self):
+        """Degree-3 spherical harmonics coefficient 2."""
+        return self.__sphericalHarmonicsDegree3Coef2
+    @sphericalHarmonicsDegree3Coef2.setter
+    def sphericalHarmonicsDegree3Coef2(self, sphericalHarmonicsDegree3Coef2):
+        if  sphericalHarmonicsDegree3Coef2 is None:
+            sphericalHarmonicsDegree3Coef2 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef2)
+        self.__sphericalHarmonicsDegree3Coef2 = sphericalHarmonicsDegree3Coef2
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef3(self):
+        """Degree-3 spherical harmonics coefficient 3."""
+        return self.__sphericalHarmonicsDegree3Coef3
+    @sphericalHarmonicsDegree3Coef3.setter
+    def sphericalHarmonicsDegree3Coef3(self, sphericalHarmonicsDegree3Coef3):
+        if  sphericalHarmonicsDegree3Coef3 is None:
+            sphericalHarmonicsDegree3Coef3 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef3)
+        self.__sphericalHarmonicsDegree3Coef3 = sphericalHarmonicsDegree3Coef3
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef4(self):
+        """Degree-3 spherical harmonics coefficient 4."""
+        return self.__sphericalHarmonicsDegree3Coef4
+    @sphericalHarmonicsDegree3Coef4.setter
+    def sphericalHarmonicsDegree3Coef4(self, sphericalHarmonicsDegree3Coef4):
+        if  sphericalHarmonicsDegree3Coef4 is None:
+            sphericalHarmonicsDegree3Coef4 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef4)
+        self.__sphericalHarmonicsDegree3Coef4 = sphericalHarmonicsDegree3Coef4
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef5(self):
+        """Degree-3 spherical harmonics coefficient 5."""
+        return self.__sphericalHarmonicsDegree3Coef5
+    @sphericalHarmonicsDegree3Coef5.setter
+    def sphericalHarmonicsDegree3Coef5(self, sphericalHarmonicsDegree3Coef5):
+        if  sphericalHarmonicsDegree3Coef5 is None:
+            sphericalHarmonicsDegree3Coef5 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef5)
+        self.__sphericalHarmonicsDegree3Coef5 = sphericalHarmonicsDegree3Coef5
+    @property # getter - - - - - - - - - -
+    def sphericalHarmonicsDegree3Coef6(self):
+        """Degree-3 spherical harmonics coefficient 6."""
+        return self.__sphericalHarmonicsDegree3Coef6
+    @sphericalHarmonicsDegree3Coef6.setter
+    def sphericalHarmonicsDegree3Coef6(self, sphericalHarmonicsDegree3Coef6):
+        if  sphericalHarmonicsDegree3Coef6 is None:
+            sphericalHarmonicsDegree3Coef6 = MFVec3f.DEFAULT_VALUE()
+        assertValidMFVec3f(sphericalHarmonicsDegree3Coef6)
+        self.__sphericalHarmonicsDegree3Coef6 = sphericalHarmonicsDegree3Coef6
+    @property # getter - - - - - - - - - -
+    def visible(self):
+        """Whether or not renderable content within this node is visually displayed."""
+        return self.__visible
+    @visible.setter
+    def visible(self, visible):
+        if  visible is None:
+            visible = True  # default
+        assertValidSFBool(visible)
+        self.__visible = visible
+    @property # getter - - - - - - - - - -
+    def id_(self):
+        """ id_ attribute is a unique identifier for use within HTML pages. Appended underscore to field name to avoid naming collision with Python reserved word. """
+        return self.__id_
+    @id_.setter
+    def id_(self, id_):
+        if  id_ is None:
+            id_ = SFString.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(SFString.DEFAULT_VALUE()))
+        assertValidSFString(id_)
+        self.__id_ = id_
+    @property # getter - - - - - - - - - -
+    def style_(self):
+        """ Space-separated list of classes, reserved for use by CSS cascading style_sheets. Appended underscore to field name to avoid naming collision with Python reserved word. """
+        return self.__style_
+    @style_.setter
+    def style_(self, style_):
+        if  style_ is None:
+            style_ = SFString.DEFAULT_VALUE()
+            # if _DEBUG: print('...DEBUG... set value to .DEFAULT_VALUE()=' + str(SFString.DEFAULT_VALUE()))
+        assertValidSFString(style_)
+        self.__style_ = style_
+    # hasChild() function - - - - - - - - - -
+    def hasChild(self):
+        """ Whether or not this node has any child node or statement """
+        return self.IS or self.metadata
     # output function - - - - - - - - - -
 
 class GeneratedCubeMapTexture(_X3DEnvironmentTextureNode):
@@ -60275,6 +60929,7 @@ def instantiateNodeFromString(x3dType, _cache={}):
         'ForcePhysicsModel':(ForcePhysicsModel(), {'Core':1, 'Grouping':1, 'ParticleSystems':1, 'Rendering':1, 'Shape':1}),
         ####################################### G
         'Gain':(Gain(), {'Core':1, 'Sound':2, 'Time':1}),
+        'GaussianSplats':(GaussianSplats(), {'Core':1, 'GaussianSplats':1, 'Grouping':1, 'Rendering':1, 'Shape':1}),
         'GeneratedCubeMapTexture':(GeneratedCubeMapTexture(), {'Core':1, 'Grouping':1, 'Rendering':1, 'Shape':1, 'CubeMapTexturing':3, 'Texturing':1}),
         'GeoCoordinate':(GeoCoordinate(), {'Core':1, 'Geometry3D':1, 'Geospatial':1, 'Grouping':3, 'Interpolation':1, 'Navigation':1, 'Networking':1, 'PointDeviceSensor':1, 'Rendering':1, 'Shape':1, 'Time':1}),
         'GeoElevationGrid':(GeoElevationGrid(), {'Core':1, 'Geometry3D':1, 'Geospatial':1, 'Grouping':3, 'Interpolation':1, 'Navigation':1, 'Networking':1, 'PointDeviceSensor':1, 'Rendering':1, 'Shape':1, 'Time':1}),

--- a/rawkee/tools/lidar/README.md
+++ b/rawkee/tools/lidar/README.md
@@ -1,0 +1,426 @@
+# RawKee Lidar
+
+**RawKee Lidar** (`rawkee.tools.lidar`) is an open-source GPU-accelerated pipeline that converts raw data from mobile LiDAR scanners and photogrammetry platforms into interoperable 3D assets — textured polygon meshes and Gaussian splat radiance fields — ready for display in web browsers, game engines, XR headsets, and any X3D-capable viewer.
+
+It is part of the [RawKee](https://github.com/und-dream-lab/rawkee) project developed at the University of North Dakota DREAM Lab.
+
+---
+
+## Table of Contents
+
+1. [What RawKee Lidar Does](#1-what-rawkee-lidar-does)
+2. [Supported Input Platforms](#2-supported-input-platforms)
+3. [Supported Output Formats](#3-supported-output-formats)
+4. [Desktop User Guide](#4-desktop-user-guide)
+5. [Desktop Installation](#5-desktop-installation)
+6. [HPC / SLURM Usage](#6-hpc--slurm-usage)
+7. [HPC System Administrator Guide](#7-hpc-system-administrator-guide)
+
+---
+
+## 1. What RawKee Lidar Does
+
+RawKee Lidar reads raw scan data from a variety of mobile LiDAR and photogrammetry platforms and runs two parallel processing pipelines:
+
+| Pipeline | What it builds | Best for |
+|---|---|---|
+| **Mesh** | Textured polygon mesh via Poisson surface reconstruction | CAD, GIS, BIM, print, real-time rendering |
+| **Gaussian Splat** | 3D Gaussian splat radiance field via differentiable rasterisation | Photorealistic web/XR viewing, neural rendering |
+
+Both pipelines support **georeferenced output**: when surveyed control points are available the output is positioned in a real-world coordinate system (UTM) and wrapped in the appropriate X3D geospatial nodes (`GeoLocation` / `GeoTransform`).
+
+The mesh pipeline additionally generates an **HDRI environment map** from the scan cameras and embeds it as a `PhysicalMaterial` + `EnvironmentLight` + `ImageCubeMapTexture` in the X3D output, giving photorealistic image-based lighting out of the box.
+
+---
+
+## 2. Supported Input Platforms
+
+RawKee Lidar auto-detects the input format from the file path. Pass any of the following to `--dataset`:
+
+| Platform | `--platform` value | What to pass to `--dataset` |
+|---|---|---|
+| **NavVis VLX / G11** (rec-v4) | `navvis` | Dataset folder (contains `dataset.json`) |
+| **Agisoft Metashape** | `metashape` | `.psx` project file |
+| **Meshroom / AliceVision** | `meshroom` | `.mg` project file |
+| **Pix4Dmapper** | `pix4d` | `.p4d` project file or project folder |
+| **COLMAP** | `colmap` | Sparse reconstruction folder (`cameras.txt` / `cameras.bin`) |
+| **E57 point cloud** | `e57` | `.e57` file |
+| `auto` *(default)* | — | Any of the above; format is inferred automatically |
+
+> **RealityCapture users:** RealityCapture's native `.rcproj` format is proprietary and cannot be read directly. Use one of these two export paths instead:
+>
+> - **Option A** — Export *Camera positions and orientations* as **Metashape cameras.xml**, then use `--platform metashape`.
+> - **Option B** *(recommended)* — Export as **COLMAP** format, then use `--platform colmap` (or let auto-detection pick it up). RealityCapture supports COLMAP export natively under *Export → Registration → COLMAP*.
+
+### Georeferencing
+
+For NavVis datasets, provide a **Trimble survey CSV** (semicolon-delimited: `point_id;lat;lon;elev`) via `--geo-csv`. The pipeline converts WGS84 coordinates to UTM automatically using `pyproj` (with a pure-Python Helmert fallback if pyproj is not installed).
+
+For Metashape, Meshroom, and Pix4D, georeferencing is read directly from the project file — no separate CSV is needed.
+
+---
+
+## 3. Supported Output Formats
+
+### Mesh pipeline outputs
+
+| Format | Flag | Notes |
+|---|---|---|
+| **X3D** *(default)* | `--format x3d` | Full PBR materials, EnvironmentLight, geospatial nodes |
+| **X3DV** | `--format x3dv` | X3D Classic (VRML-style) encoding |
+| **X3DJ** | `--format x3dj` | X3D JSON encoding |
+| **OBJ + MTL** | `--format obj` | Widely compatible; no PBR or georef |
+| **GLB** | `--format glb` | glTF 2.0 binary; compatible with Three.js, Babylon.js, Unity, Unreal |
+
+### Gaussian splat pipeline outputs
+
+| Format | Flag | Notes |
+|---|---|---|
+| **X3D** *(default)* | `--format x3d` | `GaussianSplats` node (X3D 4.1 draft); geospatial nodes included when georeferenced |
+| **X3DV** | `--format x3dv` | X3D Classic encoding |
+| **X3DJ** | `--format x3dj` | X3D JSON encoding |
+| **PLY** | `--format ply` | 3DGS-standard binary PLY; compatible with Gaussian Splatting viewers |
+| **SPLAT** | `--format splat` | Packed 32-byte binary; compatible with Luma AI web viewer and similar tools |
+| **GLB** | `--format glb` | glTF 2.0 with `KHR_gaussian_splatting` extension |
+
+---
+
+## 4. Desktop User Guide
+
+### Launching the GUI
+
+```bash
+python rawkee/tools/lidar/scan_gui.py
+```
+
+The GUI window has two tabs — **Mesh** and **Gaussian Splat** — sharing a common options panel at the top.
+
+#### Common options panel
+
+| Control | Description |
+|---|---|
+| **Platform** | Auto-detected when you browse; override manually if needed |
+| **Output format** | Select from the supported formats for each pipeline |
+| **Geo CSV** | Optional Trimble survey CSV for NavVis georeferencing |
+| **Skip georeferencing** | Check to suppress georef even if a CSV is provided |
+| **EPSG code** | Target projected CRS (default 32605 = UTM Zone 5N) |
+
+#### Browsing for your dataset
+
+Click the **Browse ▾** button to open a menu:
+
+- **Browse Folder…** — for NavVis dataset folders or Pix4D project folders
+- **Browse .psx File…** — for Metashape projects
+- **Browse .mg File…** — for Meshroom projects
+- **Browse .p4d File…** — for Pix4D `.p4d` files
+- **Browse .e57 File…** — for E57 point clouds
+- **Browse COLMAP Folder…** — for COLMAP sparse reconstruction folders
+
+After selection, the platform label auto-updates to show what was detected.
+
+#### Running a pipeline
+
+1. Set the **Dataset** path and **Output folder**.
+2. Adjust any pipeline-specific parameters (Poisson depth, atlas size, iterations, etc.).
+3. Click **Run Mesh Pipeline** or **Run Splat Pipeline**.
+4. Progress appears in the log panel. A dialog confirms completion or reports errors.
+
+### Running from the command line
+
+```bash
+# Mesh pipeline
+python rawkee/tools/lidar/run_pipeline.py mesh \
+    --dataset /path/to/dataset \
+    --output  /path/to/output \
+    --format  x3d \
+    --geo-csv /path/to/survey.csv \
+    --verbose
+
+# Gaussian splat pipeline
+python rawkee/tools/lidar/run_pipeline.py splat \
+    --dataset /path/to/dataset \
+    --output  /path/to/output \
+    --format  x3d \
+    --verbose
+```
+
+Run `python run_pipeline.py mesh --help` or `splat --help` for the full list of parameters.
+
+#### Key CLI flags (both pipelines)
+
+| Flag | Default | Description |
+|---|---|---|
+| `--platform` | `auto` | `navvis` \| `metashape` \| `meshroom` \| `pix4d` \| `colmap` \| `e57` \| `auto` |
+| `--format` | `x3d` | Output format (see tables above) |
+| `--geo-csv FILE` | — | Trimble survey CSV for NavVis georeferencing |
+| `--no-georef` | off | Skip georeferencing even if `--geo-csv` is set |
+| `--epsg INT` | `32605` | Target projected CRS EPSG code |
+| `--verbose` | off | Enable detailed logging |
+
+#### Mesh-specific flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--poisson-depth` | 9 | Poisson reconstruction depth (higher = more detail, slower) |
+| `--atlas-size` | 4096 | Texture atlas resolution in pixels |
+| `--colorise-stride` | 10 | Process every Nth frame for colorisation (lower = better quality) |
+| `--depth-stride` | 5 | Use every Nth frame for depth estimation fallback |
+| `--hdri-frame` | auto | Frame index used for HDRI environment map generation |
+| `--envmap-width/height` | 4096/2048 | HDRI environment map resolution |
+
+#### Splat-specific flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--image-size` | 512 | Training image size in pixels |
+| `--sh-degree` | 3 | Spherical harmonics degree (0–3; higher = better colour) |
+| `--iterations` | 10000 | Training iterations |
+| `--frame-stride` | 5 | Use every Nth frame for training |
+| `--init-points` | 100000 | Number of Gaussians at initialisation |
+
+---
+
+## 5. Desktop Installation
+
+### Requirements
+
+- Python 3.10 or newer
+- NVIDIA GPU with CUDA support (required for Gaussian splat training; mesh pipeline works on CPU but is slow)
+- CUDA driver ≥ 525 (for CUDA 12.x)
+
+### Quick install
+
+Run the bundled installer script. It detects your CUDA driver, installs the matching PyTorch wheel, and installs all other dependencies:
+
+```bash
+python rawkee/tools/lidar/install_workstation_deps.py
+```
+
+Options:
+
+```bash
+# Non-interactive
+python install_workstation_deps.py --yes
+
+# Preview without installing anything
+python install_workstation_deps.py --dry-run --yes
+
+# After a GPU driver update, reinstall PyTorch for the new CUDA version
+python install_workstation_deps.py --reinstall-torch --yes
+```
+
+### Manual installation
+
+```bash
+pip install numpy scipy Pillow "imageio[freeimage]" PySide6 open3d
+pip install torch --index-url https://download.pytorch.org/whl/cu124   # adjust for your CUDA
+pip install gsplat rawpy rosbags pye57 pyproj transformers
+```
+
+Then install RawKee itself (from the repository root):
+
+```bash
+pip install -e .
+# or
+export PYTHONPATH=/path/to/rawkee:$PYTHONPATH
+```
+
+### Verifying your installation
+
+```bash
+python rawkee/tools/lidar/hpc_preflight_check.py
+```
+
+---
+
+## 6. HPC / SLURM Usage
+
+### Pre-built SLURM scripts
+
+Three ready-to-use SLURM scripts are provided in `rawkee/tools/lidar/`:
+
+| Script | Target | GPU | Notes |
+|---|---|---|---|
+| `slurm_scan_gpu.sh` | Generic GPU cluster | Any CUDA GPU | Single-node, both pipelines |
+| `slurm_scan_dgx_spark.sh` | DGX Spark (GB10 / Blackwell) | 128 GB unified memory | Single-node, both pipelines |
+| `slurm_scan_ddp_dgx_spark.sh` | DGX Spark cluster | Multi-node | Gaussian splat training only; uses PyTorch DDP via `torchrun` |
+
+Edit the path variables at the top of each script before submitting:
+
+```bash
+DATASET=/path/to/dataset
+OUTPUT_MESH=/path/to/output/mesh
+OUTPUT_SPLAT=/path/to/output/splat
+GEO_CSV=/path/to/survey.csv        # optional
+PIPELINE_SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+```
+
+Then submit:
+
+```bash
+sbatch slurm_scan_gpu.sh
+```
+
+### Writing your own SLURM script
+
+Minimum recommended resources:
+
+| Pipeline | Nodes | CPUs | RAM | GPU |
+|---|---|---|---|---|
+| Mesh (standard) | 1 | 16 | 128 GB | 1× V100 16 GB or better |
+| Mesh (DGX Spark) | 1 | 20 | 112 GB | 1× GB10 |
+| Gaussian splat | 1 | 16 | 128 GB | 1× A100 40 GB or better |
+| Gaussian splat (DDP) | 2–8 | 20/node | 112 GB/node | 1× GB10/node |
+
+#### Single-node example
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=rawkee-lidar
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=128G
+#SBATCH --gres=gpu:1
+#SBATCH --time=04:00:00
+
+source /path/to/venv/bin/activate
+export OPENCV_IO_ENABLE_OPENEXR=1
+export PYTHONUNBUFFERED=1
+
+SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+
+python "$SCRIPT" mesh  --dataset "$DATASET" --output "$OUT_MESH"  --format x3d --verbose
+python "$SCRIPT" splat --dataset "$DATASET" --output "$OUT_SPLAT" --format x3d --no-georef --verbose
+```
+
+#### Multi-node Gaussian splat (DDP)
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=128G
+
+source /path/to/venv/bin/activate
+export NCCL_SOCKET_IFNAME=ib0   # adjust to your fabric interface
+MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+
+srun torchrun \
+    --nproc_per_node=1 --nnodes=$SLURM_NNODES \
+    --rdzv_backend=c10d --rdzv_endpoint="${MASTER_ADDR}:29500" \
+    "$SCRIPT" splat --dataset "$DATASET" --output "$OUT_SPLAT" \
+        --format x3d --iterations 50000 --verbose
+```
+
+> DDP is supported for the **Gaussian splat pipeline only**. The mesh pipeline runs single-node. In a DDP job, only rank 0 writes the output file.
+
+### Grace/Hopper and DGX Spark notes
+
+Both architectures use **NVLink-C2C unified memory** (CPU + GPU share a single pool). Add these environment variables to your job:
+
+```bash
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export OMP_NUM_THREADS=20   # all Arm Cortex-X925 cores on DGX Spark
+```
+
+The pipeline automatically detects sm_90+ and sm_100 architectures and sets the memory fraction to 90%.
+
+---
+
+## 7. HPC System Administrator Guide
+
+### Preflight environment check
+
+RawKee Lidar ships a read-only diagnostic script that checks all dependencies, CUDA/PyTorch compatibility, driver version, GPU compute capability, and NCCL availability:
+
+```bash
+python rawkee/tools/lidar/hpc_preflight_check.py
+```
+
+Options:
+
+```bash
+# Machine-readable JSON output (for ticketing/monitoring systems)
+python hpc_preflight_check.py --json > report.json
+
+# Exit 1 if any WARNING or ERROR is found (use in SLURM prologue)
+python hpc_preflight_check.py --strict
+```
+
+### Required Python packages
+
+| Package | Purpose | Required |
+|---|---|---|
+| `numpy ≥ 1.24` | Numeric arrays throughout | Yes |
+| `scipy` | KDTree, UTM math | Yes |
+| `Pillow` | Image resizing | Yes |
+| `imageio[freeimage]` | HDR / PNG saving | Yes |
+| `open3d` | Poisson reconstruction, E57 fallback | Yes |
+| `torch` (CUDA build) | GPU acceleration (mesh + splat) | Yes |
+| `gsplat` | Gaussian splat rasteriser | Yes (splat) |
+| `PySide6` | Desktop GUI | GUI only |
+| `rawpy` | DNG/RAW camera image decoding | Recommended |
+| `rosbags` | NavVis LiDAR ROS bag reading | NavVis only |
+| `pye57` | E57 point cloud reading | E57 only |
+| `pyproj` | Precise UTM georeferencing | Recommended |
+| `transformers` | Depth Anything V2 (LiDAR fallback) | Optional |
+
+### PyTorch / CUDA wheel selection
+
+| NVIDIA driver version | Recommended PyTorch wheel |
+|---|---|
+| ≥ 570 (Blackwell) | NGC container `nvcr.io/nvidia/pytorch:26.05-py3` or `--index-url .../cu128` |
+| ≥ 545 | `pip install torch --index-url https://download.pytorch.org/whl/cu124` |
+| ≥ 528 | `pip install torch --index-url https://download.pytorch.org/whl/cu121` |
+| No GPU | `pip install torch --index-url https://download.pytorch.org/whl/cpu` |
+
+Verify after install:
+
+```bash
+python -c "import torch; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+### gsplat compilation requirements
+
+`gsplat` compiles CUDA kernels during `pip install`. The **CUDA toolkit** (`nvcc`) must be present and must match the PyTorch CUDA build:
+
+```bash
+nvcc --version          # check toolkit version
+module load cuda/12.4   # load matching toolkit module
+pip install gsplat
+```
+
+If compilation fails, build `gsplat` on a build node and install into a shared venv or container that compute nodes mount read-only.
+
+### Recommended module environment (example)
+
+```bash
+module load python/3.11
+module load cuda/12.4
+source /shared/venvs/rawkee/bin/activate
+```
+
+Or use the provided NGC container for Blackwell nodes:
+
+```bash
+#SBATCH --container-image=nvcr.io/nvidia/pytorch:26.05-py3
+#SBATCH --container-mounts=/shared/data:/data
+```
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `torch.cuda.is_available()` returns `False` | Driver/wheel CUDA version mismatch | Reinstall torch for your driver version (see table above) |
+| `gsplat` import error / missing `.so` | Not compiled for current CUDA | Recompile on build node with matching `nvcc` |
+| NCCL timeout in DDP jobs | Fabric interface mismatch | Set `NCCL_SOCKET_IFNAME=ib0` (or `eth0`) to match your interconnect |
+| HDR output fails | FreeImage binary not installed | `pip install "imageio[freeimage]"` |
+| `rosbags` not found | NavVis LiDAR unavailable | `pip install rosbags`; pipeline falls back to Depth Anything V2 |
+| OOM on Grace/Hopper | Memory fraction not set | Add `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` to job |
+| `pye57` import error | E57 support unavailable | `pip install pye57`; pipeline falls back to `open3d` reader |
+
+Run `python hpc_preflight_check.py` on the compute node image after any environment change to confirm everything is correct before re-enabling job submission.

--- a/rawkee/tools/lidar/__init__.py
+++ b/rawkee/tools/lidar/__init__.py
@@ -1,0 +1,15 @@
+"""rawkee.tools.lidar — RawKee Lidar: Mobile LiDAR / 360-camera scan-to-X3D mesh and Gaussian splat pipelines."""
+from .dataset import ScanDataset, OCamModel, CameraModel
+from .hdri import HDRIGenerator
+from .mesh_pipeline import MeshPipeline
+from .splat_pipeline import SplatPipeline
+from .export import export_mesh, export_splat
+
+__all__ = [
+    'ScanDataset', 'OCamModel', 'CameraModel',
+    'HDRIGenerator',
+    'MeshPipeline',
+    'SplatPipeline',
+    'export_mesh',
+    'export_splat',
+]

--- a/rawkee/tools/lidar/dataset.py
+++ b/rawkee/tools/lidar/dataset.py
@@ -1,0 +1,1648 @@
+"""Scan dataset reader with support for multiple mobile LiDAR platforms."""
+from __future__ import annotations
+import csv
+import json
+import logging
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+try:
+    import torch
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Platform auto-detection
+# ---------------------------------------------------------------------------
+
+def _detect_platform(path: str | Path) -> str:
+    """Return 'navvis', 'metashape', 'meshroom', 'pix4d', 'colmap', or 'e57'."""
+    p = Path(path)
+    if p.suffix.lower() == '.psx':
+        return 'metashape'
+    if p.suffix.lower() == '.mg':
+        return 'meshroom'
+    if p.suffix.lower() == '.p4d':
+        return 'pix4d'
+    if p.suffix.lower() == '.e57':
+        return 'e57'
+    if p.is_dir():
+        if (p / 'dataset.json').exists():
+            return 'navvis'
+        if list(p.glob('*.psx')):
+            return 'metashape'
+        if list(p.glob('*.mg')):
+            return 'meshroom'
+        if list(p.glob('*.p4d')) or (p / '1_initial' / 'params').exists():
+            return 'pix4d'
+        if (p / 'cameras.txt').exists() or (p / 'cameras.bin').exists():
+            return 'colmap'
+        for sub in ('sparse', 'sparse/0', 'dense/sparse'):
+            sp = p / sub
+            if (sp / 'cameras.txt').exists() or (sp / 'cameras.bin').exists():
+                return 'colmap'
+        if list(p.glob('*.e57')):
+            return 'e57'
+    raise ValueError(
+        f'Cannot detect platform from: {path}\n'
+        '  Expected a NavVis folder, Metashape .psx, Meshroom .mg,\n'
+        '  Pix4D .p4d / folder, COLMAP sparse folder, or E57 file.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pinhole camera model (Metashape Brown-Conrady convention)
+# ---------------------------------------------------------------------------
+
+class PinholeModel:
+    """Standard perspective camera with Brown-Conrady distortion.
+
+    Metashape convention: cx/cy are offsets from image centre in pixels.
+    """
+
+    def __init__(
+        self,
+        f: float,
+        cx_off: float, cy_off: float,
+        k1: float, k2: float,
+        p1: float, p2: float,
+        width: int, height: int,
+        sensor_name: str = 'cam0',
+        k3: float = 0.0,
+    ) -> None:
+        self.f  = f
+        self.cx = width  / 2.0 + cx_off   # principal point col from image origin
+        self.cy = height / 2.0 + cy_off   # principal point row from image origin
+        self.k1 = k1
+        self.k2 = k2
+        self.k3 = k3
+        self.p1 = p1
+        self.p2 = p2
+        self.width  = width
+        self.height = height
+        self.sensor_name = sensor_name
+        # These allow PinholeModel to be used wherever CameraModel.ocam is expected
+        self.position = np.zeros(3, dtype=np.float64)
+        self.R        = np.eye(3,  dtype=np.float64)
+        self.ocam     = self   # duck-type: code that calls cam.ocam.project_gpu works transparently
+        # world2cam[0] used by _ocam_to_pinhole_approx in splat_pipeline
+        self.world2cam = np.array([f])
+
+    def project(self, xyz: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Project (N,3) camera-frame points → (col,row) pixel coords + valid mask."""
+        X, Y, Z = xyz[:, 0], xyz[:, 1], xyz[:, 2]
+        valid  = Z > 0
+        Zs = np.where(valid, Z, 1.0)
+        xn, yn = X / Zs, Y / Zs
+        r2  = xn**2 + yn**2
+        rad = 1.0 + self.k1 * r2 + self.k2 * r2**2 + self.k3 * r2**3
+        xd  = xn * rad + 2.0 * self.p1 * xn * yn      + self.p2 * (r2 + 2.0 * xn**2)
+        yd  = yn * rad + self.p1 * (r2 + 2.0 * yn**2) + 2.0 * self.p2 * xn * yn
+        col = self.f * xd + self.cx
+        row = self.f * yd + self.cy
+        mask = valid & (col >= 0) & (col < self.width) & (row >= 0) & (row < self.height)
+        return np.stack([col, row], axis=-1), mask
+
+    def project_gpu(
+        self, xyz: 'torch.Tensor', device: 'torch.device'
+    ) -> tuple['torch.Tensor', 'torch.Tensor']:
+        """GPU projection; returns grid_sample-style (col_n, row_n) in [-1,1] + mask."""
+        import torch
+        X, Y, Z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
+        valid = Z > 0
+        Zs = torch.where(valid, Z, torch.ones_like(Z))
+        xn, yn = X / Zs, Y / Zs
+        r2  = xn**2 + yn**2
+        rad = 1.0 + self.k1 * r2 + self.k2 * r2**2 + self.k3 * r2**3
+        xd  = xn * rad + 2.0 * self.p1 * xn * yn      + self.p2 * (r2 + 2.0 * xn**2)
+        yd  = yn * rad + self.p1 * (r2 + 2.0 * yn**2) + 2.0 * self.p2 * xn * yn
+        col = self.f * xd + self.cx
+        row = self.f * yd + self.cy
+        col_n = (col / (self.width  - 1)) * 2.0 - 1.0
+        row_n = (row / (self.height - 1)) * 2.0 - 1.0
+        mask = valid & (col >= 0) & (col < self.width) & (row >= 0) & (row < self.height)
+        return torch.stack([col_n, row_n], dim=-1), mask
+
+    def unproject(self, uv_colrow: np.ndarray) -> np.ndarray:
+        """Back-project (N,2) pixel (col,row) → unit 3D ray directions (N,3)."""
+        col, row = uv_colrow[:, 0], uv_colrow[:, 1]
+        xn = (col - self.cx) / self.f
+        yn = (row - self.cy) / self.f
+        r2   = xn**2 + yn**2
+        corr = 1.0 + self.k1 * r2 + self.k2 * r2**2 + self.k3 * r2**3
+        xu, yu = xn / corr, yn / corr
+        dirs = np.stack([xu, yu, np.ones(len(xu), dtype=np.float64)], axis=-1)
+        norms = np.linalg.norm(dirs, axis=-1, keepdims=True)
+        return dirs / np.maximum(norms, 1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Coordinate conversion — WGS84 geographic → UTM projected (Karney / Helmert)
+# ---------------------------------------------------------------------------
+
+def _wgs84_to_utm(lat_deg: float, lon_deg: float, epsg: int) -> tuple[float, float]:
+    """Convert WGS84 lat/lon to Easting/Northing using pyproj if available,
+    otherwise falling back to a pure-Python Transverse Mercator implementation
+    accurate to better than 1 mm within a single UTM zone.
+    """
+    try:
+        from pyproj import Transformer
+        t = Transformer.from_crs('EPSG:4326', f'EPSG:{epsg}', always_xy=True)
+        easting, northing = t.transform(lon_deg, lat_deg)
+        return easting, northing
+    except ImportError:
+        pass
+
+    # Pure-Python UTM (WGS84 ellipsoid, Helmert series, accurate to ~1 mm)
+    # Derive zone and hemisphere from EPSG code: 326XX = N, 327XX = S, zone = XX
+    if 32601 <= epsg <= 32660:
+        zone = epsg - 32600
+        northern = True
+    elif 32701 <= epsg <= 32760:
+        zone = epsg - 32700
+        northern = False
+    else:
+        raise ValueError(
+            f'EPSG:{epsg} is not a UTM zone code. '
+            'Install pyproj for arbitrary projections: pip install pyproj'
+        )
+
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg)
+    lon0 = math.radians((zone - 1) * 6 - 180 + 3)   # central meridian
+
+    # WGS84 ellipsoid parameters
+    a  = 6378137.0
+    f  = 1 / 298.257223563
+    b  = a * (1 - f)
+    e2 = 1 - (b / a) ** 2
+    e  = math.sqrt(e2)
+    n  = f / (2 - f)
+    k0 = 0.9996
+    E0 = 500000.0
+    N0 = 0.0 if northern else 10000000.0
+
+    # Meridional arc (Helmert series)
+    A  = a / (1 + n) * (1 + n**2/4 + n**4/64)
+    a2 = -3/2  * (n - 9/16  * n**3)
+    a4 =  15/16 * (n**2 - 3/4 * n**4)
+    a6 = -35/48 * n**3
+    a8 =  315/512 * n**4
+
+    t_   = math.sinh(math.atanh(math.sin(lat)) - 2*math.sqrt(n)/(1+n) *
+                     math.atanh(2*math.sqrt(n)/(1+n) * math.sin(lat)))
+    xi_  = math.atan2(t_, math.cos(lon - lon0))
+    eta_ = math.atanh(math.sin(lon - lon0) / math.sqrt(1 + t_**2))
+
+    xi  = xi_  + sum(
+        c * math.sin(2*j * xi_) * math.cosh(2*j * eta_)
+        for j, c in enumerate([a2, a4, a6, a8], 1)
+    )
+    eta = eta_ + sum(
+        c * math.cos(2*j * xi_) * math.sinh(2*j * eta_)
+        for j, c in enumerate([a2, a4, a6, a8], 1)
+    )
+
+    easting  = E0 + k0 * A * eta
+    northing = N0 + k0 * A * xi
+    return easting, northing
+
+
+def _colmap_num_params(model: str) -> int:
+    """Return the number of parameters for a COLMAP camera model."""
+    return {
+        'SIMPLE_PINHOLE': 3, 'PINHOLE': 4,
+        'SIMPLE_RADIAL': 4,  'RADIAL': 5,
+        'OPENCV': 8,         'OPENCV_FISHEYE': 8,
+        'FULL_OPENCV': 12,   'THIN_PRISM_FISHEYE': 12,
+        'FOV': 5,            'SIMPLE_RADIAL_FISHEYE': 4,
+        'RADIAL_FISHEYE': 5,
+    }.get(model, 4)
+
+
+def _colmap_params_to_model(model: str, w: int, h: int, params: list) -> 'PinholeModel':
+    """Convert COLMAP camera model parameters to a PinholeModel."""
+    # All COLMAP models: params[0] = f (or fx), principal point near centre
+    f   = float(params[0])
+    fy  = float(params[1]) if model == 'PINHOLE' and len(params) > 1 else f
+    # Principal point: stored as absolute pixel coords in COLMAP
+    if model == 'SIMPLE_PINHOLE':
+        cx_off = float(params[1]) - w / 2.0
+        cy_off = float(params[2]) - h / 2.0
+        k1 = k2 = p1 = p2 = k3 = 0.0
+    elif model in ('PINHOLE',):
+        # Average fx/fy; PinholeModel has one focal length
+        f      = (float(params[0]) + float(params[1])) / 2.0
+        cx_off = float(params[2]) - w / 2.0
+        cy_off = float(params[3]) - h / 2.0
+        k1 = k2 = p1 = p2 = k3 = 0.0
+    elif model == 'SIMPLE_RADIAL':
+        cx_off = float(params[1]) - w / 2.0
+        cy_off = float(params[2]) - h / 2.0
+        k1 = float(params[3]) if len(params) > 3 else 0.0
+        k2 = p1 = p2 = k3 = 0.0
+    elif model == 'RADIAL':
+        cx_off = float(params[1]) - w / 2.0
+        cy_off = float(params[2]) - h / 2.0
+        k1 = float(params[3]) if len(params) > 3 else 0.0
+        k2 = float(params[4]) if len(params) > 4 else 0.0
+        p1 = p2 = k3 = 0.0
+    else:   # OPENCV and variants: f, f, cx, cy, k1, k2, p1, p2, [k3...]
+        cx_off = float(params[2]) - w / 2.0 if len(params) > 2 else 0.0
+        cy_off = float(params[3]) - h / 2.0 if len(params) > 3 else 0.0
+        k1 = float(params[4]) if len(params) > 4 else 0.0
+        k2 = float(params[5]) if len(params) > 5 else 0.0
+        p1 = float(params[6]) if len(params) > 6 else 0.0
+        p2 = float(params[7]) if len(params) > 7 else 0.0
+        k3 = float(params[8]) if len(params) > 8 else 0.0
+    return PinholeModel(f=f, cx_off=cx_off, cy_off=cy_off,
+                        k1=k1, k2=k2, p1=p1, p2=p2, k3=k3, width=w, height=h)
+
+
+def _pix4d_cam_to_model(kv: dict) -> 'PinholeModel':
+    """Convert a Pix4D .cam key-value dict to a PinholeModel."""
+    w   = int(float(kv.get('image_width',  kv.get('width',  '4000'))))
+    h   = int(float(kv.get('image_height', kv.get('height', '3000'))))
+    f   = float(kv.get('focal_length_px', kv.get('focal_length', w)))
+    cx  = float(kv.get('principal_point_x_px', kv.get('principal_point_x', '0')))
+    cy  = float(kv.get('principal_point_y_px', kv.get('principal_point_y', '0')))
+    k1  = float(kv.get('r1', kv.get('k1', '0')))
+    k2  = float(kv.get('r2', kv.get('k2', '0')))
+    k3  = float(kv.get('r3', kv.get('k3', '0')))
+    p1  = float(kv.get('t1', kv.get('p1', '0')))
+    p2  = float(kv.get('t2', kv.get('p2', '0')))
+    return PinholeModel(f=f, cx_off=cx, cy_off=cy, k1=k1, k2=k2, p1=p1, p2=p2, k3=k3, width=w, height=h)
+
+
+class OCamModel:
+    """Scaramuzza omnidirectional camera model (OCamCalib convention).
+
+    Coordinate convention:
+      - Principal point: cx = row-center, cy = col-center (Matlab/Scaramuzza)
+      - Camera frame: z-axis pointing toward the scene (z < 0 = in front)
+      - Affine matrix [c d; e 1] corrects for minor sensor misalignment
+    """
+
+    def __init__(
+        self,
+        c: float, d: float, e: float,
+        cx: float, cy: float,
+        cam2world_coeffs: list[float],
+        world2cam_coeffs: list[float],
+        width: int, height: int,
+    ) -> None:
+        self.c = c
+        self.d = d
+        self.e = e
+        self.cx = cx   # row center
+        self.cy = cy   # col center
+        self.cam2world = np.array(cam2world_coeffs, dtype=np.float64)
+        self.world2cam = np.array(world2cam_coeffs, dtype=np.float64)
+        self.width = width
+        self.height = height
+        # Precompute affine inverse for back-projection
+        det = c - d * e
+        self._inv_a = 1.0 / det
+        self._inv_b = -d / det
+        self._inv_c = -e / det
+        self._inv_d = c / det
+
+    # ------------------------------------------------------------------
+    # CPU paths (NumPy)
+    # ------------------------------------------------------------------
+
+    def project(self, xyz: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Project (N,3) camera-frame points to (N,2) pixel coords + valid mask.
+
+        Returns pixel coordinates as (col, row) pairs.
+        """
+        X, Y, Z = xyz[:, 0], xyz[:, 1], xyz[:, 2]
+        rho = np.sqrt(X ** 2 + Y ** 2)
+        safe = rho > 1e-8
+
+        rho_s = np.where(safe, rho, 1.0)
+        theta = np.arctan2(-Z, rho_s)
+
+        # Evaluate world2cam polynomial
+        r = np.zeros(len(theta))
+        tp = np.ones(len(theta))
+        for coeff in self.world2cam:
+            r += coeff * tp
+            tp *= theta
+
+        # Undistorted offsets in (row-dir, col-dir)
+        a = r * X / rho_s
+        b = r * Y / rho_s
+
+        # Affine + principal point → pixel (row, col)
+        row = self.c * a + self.d * b + self.cx
+        col = self.e * a + b + self.cy
+
+        in_bounds = (col >= 0) & (col < self.width) & (row >= 0) & (row < self.height)
+        mask = safe & in_bounds & (Z < 0)
+        return np.stack([col, row], axis=-1), mask
+
+    def unproject(self, uv_colrow: np.ndarray) -> np.ndarray:
+        """Back-project (N,2) pixel (col,row) coords to unit 3D directions (N,3)."""
+        col, row = uv_colrow[:, 0], uv_colrow[:, 1]
+        # Undo principal point
+        row_off = row - self.cx
+        col_off = col - self.cy
+        # Undo affine
+        a = self._inv_a * row_off + self._inv_b * col_off
+        b = self._inv_c * row_off + self._inv_d * col_off
+
+        rho = np.sqrt(a ** 2 + b ** 2)
+        # Evaluate cam2world polynomial
+        z = np.zeros(len(rho))
+        rp = np.ones(len(rho))
+        for coeff in self.cam2world:
+            z += coeff * rp
+            rp *= rho
+
+        dirs = np.stack([a, b, z], axis=-1)
+        norms = np.linalg.norm(dirs, axis=-1, keepdims=True)
+        return dirs / np.maximum(norms, 1e-8)
+
+    # ------------------------------------------------------------------
+    # GPU paths (PyTorch) — used by HDRIGenerator
+    # ------------------------------------------------------------------
+
+    def project_gpu(
+        self,
+        xyz: 'torch.Tensor',   # (H, W, 3) or (N, 3)
+        device: 'torch.device',
+    ) -> tuple['torch.Tensor', 'torch.Tensor']:
+        """GPU-accelerated projection. Returns (uvs_norm, mask).
+
+        uvs_norm: grid_sample-style (col_norm, row_norm) in [-1, 1], shape (*input_shape[:-1], 2)
+        mask:     bool tensor, same leading shape
+        """
+        X = xyz[..., 0]
+        Y = xyz[..., 1]
+        Z = xyz[..., 2]
+
+        rho = torch.sqrt(X ** 2 + Y ** 2).clamp(min=1e-8)
+        theta = torch.atan2(-Z, rho)
+
+        # Polynomial world2cam
+        w2c = torch.tensor(self.world2cam, device=device, dtype=torch.float32)
+        r = torch.zeros_like(theta)
+        tp = torch.ones_like(theta)
+        for coeff in w2c:
+            r = r + coeff * tp
+            tp = tp * theta
+
+        a = r * X / rho
+        b = r * Y / rho
+
+        row = self.c * a + self.d * b + self.cx
+        col = self.e * a + b + self.cy
+
+        # Normalized for F.grid_sample: x=col_norm, y=row_norm in [-1,1]
+        col_n = (col / (self.width  - 1)) * 2.0 - 1.0
+        row_n = (row / (self.height - 1)) * 2.0 - 1.0
+        uvs = torch.stack([col_n, row_n], dim=-1)
+
+        mask = (
+            (col >= 0) & (col < self.width) &
+            (row >= 0) & (row < self.height) &
+            (Z < 0)
+        )
+        return uvs, mask
+
+
+def _quat_to_rot(q: np.ndarray) -> np.ndarray:
+    """Quaternion (w, x, y, z) → 3×3 rotation matrix (column vectors = axes)."""
+    w, x, y, z = q
+    return np.array([
+        [1 - 2 * (y * y + z * z),     2 * (x * y - w * z),     2 * (x * z + w * y)],
+        [    2 * (x * y + w * z), 1 - 2 * (x * x + z * z),     2 * (y * z - w * x)],
+        [    2 * (x * z - w * y),     2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+    ], dtype=np.float64)
+
+
+class CameraModel:
+    """Individual camera within a NavVis sensor head."""
+
+    def __init__(
+        self,
+        sensor_name: str,
+        position: np.ndarray,       # (3,) offset from cam_head origin
+        quaternion: np.ndarray,     # (w, x, y, z) rotation from cam to head frame
+        ocam: OCamModel,
+        width: int,
+        height: int,
+    ) -> None:
+        self.sensor_name = sensor_name
+        self.position = position
+        self.quaternion = quaternion
+        self.ocam = ocam
+        self.width = width
+        self.height = height
+        # R_cam_in_head: columns are cam-frame axes expressed in head frame
+        self.R = _quat_to_rot(quaternion)
+
+    def head_to_cam(self, pts_head: np.ndarray) -> np.ndarray:
+        """Transform (N,3) points from camera-head frame into this camera's frame."""
+        return (pts_head - self.position) @ self.R
+
+    def world_to_cam(
+        self, pts_world: np.ndarray, head_pos: np.ndarray, R_head: np.ndarray
+    ) -> np.ndarray:
+        """Transform (N,3) world-frame points into this camera's frame."""
+        pts_head = (pts_world - head_pos) @ R_head
+        return self.head_to_cam(pts_head)
+
+
+class ScanDataset:
+    """Reads a mobile LiDAR scan dataset directory.
+
+    Parameters
+    ----------
+    dataset_dir: path to the dataset root directory or a .psx file
+    platform:    'navvis' | 'metashape' | 'auto' (default — auto-detected)
+    """
+
+    def __init__(self, dataset_dir: str | Path, platform: str = 'auto') -> None:
+        self.root = Path(dataset_dir)
+        self.platform = platform.lower() if platform.lower() != 'auto' else _detect_platform(dataset_dir)
+        self._meta: Optional[dict] = None
+        self._cameras: Optional[list] = None
+        self._poses: Optional[list[dict]] = None
+        if self.platform == 'metashape':
+            self._parse_metashape()
+        elif self.platform == 'meshroom':
+            self._parse_meshroom()
+        elif self.platform == 'pix4d':
+            self._parse_pix4d()
+        elif self.platform == 'colmap':
+            self._parse_colmap()
+        elif self.platform == 'e57':
+            self._parse_e57()
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    @property
+    def meta(self) -> dict:
+        if self._meta is None:
+            with open(self.root / 'dataset.json') as f:
+                self._meta = json.load(f)
+        return self._meta
+
+    @property
+    def num_frames(self) -> int:
+        return int(self.meta['statistics']['capture_locations'])
+
+    @property
+    def dataset_name(self) -> str:
+        return self.meta['dataset']['name']
+
+    # ------------------------------------------------------------------
+    # Cameras
+    # ------------------------------------------------------------------
+
+    @property
+    def cameras(self) -> list[CameraModel]:
+        if self._cameras is None:
+            self._cameras = self._parse_sensor_frame()
+        return self._cameras
+
+    def _parse_sensor_frame(self) -> list[CameraModel]:
+        tree = ET.parse(self.root / 'sensor_frame.xml')
+        root = tree.getroot()
+        head = root.find('CameraHead')
+        cams = []
+        for elem in head.findall('CameraModel'):
+            name = elem.find('SensorName').text
+            pose = elem.find('Pose')
+            pos = np.array([
+                float(pose.find('position/x').text),
+                float(pose.find('position/y').text),
+                float(pose.find('position/z').text),
+            ])
+            ori = np.array([
+                float(pose.find('orientation/w').text),
+                float(pose.find('orientation/x').text),
+                float(pose.find('orientation/y').text),
+                float(pose.find('orientation/z').text),
+            ])
+            sz = elem.find('ImageSize')
+            w, h = int(sz.find('Width').text), int(sz.find('Height').text)
+            ocm = elem.find('OCamModel')
+            c2w = [float(x.text) for x in ocm.find('cam2world').findall('coeff')]
+            w2c = [float(x.text) for x in ocm.find('world2cam').findall('coeff')]
+            ocam = OCamModel(
+                c=float(ocm.find('c').text),
+                d=float(ocm.find('d').text),
+                e=float(ocm.find('e').text),
+                cx=float(ocm.find('cx').text),
+                cy=float(ocm.find('cy').text),
+                cam2world_coeffs=c2w,
+                world2cam_coeffs=w2c,
+                width=w, height=h,
+            )
+            cams.append(CameraModel(name, pos, ori, ocam, w, h))
+        return cams
+
+    # ------------------------------------------------------------------
+    # Frame poses
+    # ------------------------------------------------------------------
+
+    @property
+    def poses(self) -> list[dict]:
+        if self._poses is None:
+            info = self.root / 'info'
+            self._poses = []
+            for i in range(self.num_frames):
+                with open(info / f'{i:05d}-info.json') as f:
+                    self._poses.append(json.load(f))
+        return self._poses
+
+    def frame_position(self, idx: int) -> np.ndarray:
+        return np.array(self.poses[idx]['cam_head']['position'])
+
+    def frame_quaternion(self, idx: int) -> np.ndarray:
+        """Returns (w, x, y, z)."""
+        q = self.poses[idx]['cam_head']['quaternion']
+        return np.array([q[0], q[1], q[2], q[3]])
+
+    def frame_transform(self, idx: int) -> tuple[np.ndarray, np.ndarray]:
+        """Returns (position, R) where R transforms camera/head→world."""
+        pose = self.poses[idx]
+        if '_transform_matrix' in pose:
+            T = np.array(pose['_transform_matrix'], dtype=np.float64).reshape(4, 4)
+            return T[:3, 3], T[:3, :3]
+        pos = self.frame_position(idx)
+        q   = self.frame_quaternion(idx)
+        return pos, _quat_to_rot(q)
+
+    def frame_timestamp(self, idx: int) -> float:
+        return float(self.poses[idx]['timestamp'])
+
+    def is_valid_frame(self, idx: int) -> bool:
+        return str(self.poses[idx].get('valid', 'true')).lower() == 'true'
+
+    # ------------------------------------------------------------------
+    # File paths
+    # ------------------------------------------------------------------
+
+    def dng_path(self, frame_idx: int, cam_idx: int) -> Path:
+        return self.root / 'cam' / f'{frame_idx:05d}-cam{cam_idx}.dng'
+
+    def image_path(self, frame_idx: int, cam_idx: int) -> Path:
+        """Return image path for any platform."""
+        if self.platform in ('metashape', 'meshroom', 'pix4d', 'colmap', 'e57'):
+            return Path(self.poses[frame_idx]['_image_path'])
+        return self.dng_path(frame_idx, cam_idx)
+
+    def has_dng(self, frame_idx: int, cam_idx: int) -> bool:
+        return self.dng_path(frame_idx, cam_idx).exists()
+
+    def bag_path(self, name: str = 'trajectory_slam') -> Path:
+        return self.root / 'internal' / 'bags' / f'{name}.bag'
+
+    def local_bag_path(self) -> Path:
+        return self.root / 'internal' / 'artifacts' / 'trajectory_local.bag'
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def valid_frame_indices(self) -> list[int]:
+        return [i for i in range(self.num_frames) if self.is_valid_frame(i)]
+
+    def select_reference_frame(self) -> int:
+        """Choose a representative frame near the centre of the trajectory."""
+        valid = self.valid_frame_indices()
+        mid = len(valid) // 2
+        return valid[mid]
+
+    # ------------------------------------------------------------------
+    # Metashape .psx parser
+    # ------------------------------------------------------------------
+
+    def _parse_metashape(self) -> None:
+        """Parse a Metashape .psx project file (ZIP containing doc.xml)."""
+        import zipfile
+
+        psx_path = self.root
+        if psx_path.is_dir():
+            candidates = sorted(psx_path.glob('*.psx'))
+            if not candidates:
+                raise FileNotFoundError(f'No .psx file found in {psx_path}')
+            psx_path = candidates[0]
+
+        with zipfile.ZipFile(psx_path, 'r') as zf:
+            with zf.open('doc.xml') as fh:
+                xml_content = fh.read()
+
+        root_elem = ET.fromstring(xml_content)
+        chunk = self._metashape_find_chunk(root_elem)
+
+        self._meta = {
+            'dataset': {
+                'name': chunk.get('label', psx_path.stem),
+                'dataset_id': psx_path.stem,
+            }
+        }
+
+        sensors = self._metashape_parse_sensors(chunk)
+        if not sensors:
+            raise ValueError(f'No frame sensors found in {psx_path.name}')
+
+        chunk_T = self._metashape_chunk_transform(chunk)
+        self._cameras = [sensors[sid] for sid in sorted(sensors, key=int)]
+        self._sensor_id_to_cam_idx = {sid: i for i, sid in enumerate(sorted(sensors, key=int))}
+
+        self._poses = []
+        psx_dir = psx_path.parent
+        cameras_elem = chunk.find('cameras')
+        if cameras_elem is None:
+            raise ValueError('No cameras element found in Metashape project')
+
+        for cam_elem in cameras_elem.findall('camera'):
+            if cam_elem.get('enabled', 'true').lower() == 'false':
+                continue
+            sensor_id = cam_elem.get('sensor_id', '0')
+            if sensor_id not in sensors:
+                continue
+            t_elem = cam_elem.find('transform')
+            if t_elem is None:
+                continue
+
+            vals = [float(v) for v in t_elem.text.split()]
+            if len(vals) == 16:
+                T_local = np.array(vals).reshape(4, 4)
+            elif len(vals) == 12:
+                T_local = np.eye(4)
+                T_local[:3, :] = np.array(vals).reshape(3, 4)
+            else:
+                continue
+
+            T_world = chunk_T @ T_local
+
+            # Image path
+            photo = cam_elem.find('photo')
+            img_str = (photo.get('path', '') if photo is not None else '') or cam_elem.get('label', '')
+            img_path = Path(img_str) if Path(img_str).is_absolute() else psx_dir / img_str
+
+            # GPS reference
+            ref_elem = cam_elem.find('reference')
+            reference = {}
+            if ref_elem is not None and ref_elem.get('enabled', 'true').lower() != 'false':
+                for attr in ('x', 'y', 'z', 'yaw', 'pitch', 'roll'):
+                    val = ref_elem.get(attr)
+                    if val is not None:
+                        reference[attr] = float(val)
+
+            pos = T_world[:3, 3].tolist()
+            R   = T_world[:3, :3]
+            qw, qx, qy, qz = self._rot_to_quat(R)
+
+            self._poses.append({
+                'cam_head': {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                'footprint': {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                'timestamp': 0.0,
+                'valid': 'true',
+                'capture_mode': 'Metashape',
+                '_image_path': str(img_path),
+                '_sensor_id': sensor_id,
+                '_reference': reference,
+                '_transform_matrix': T_world.tolist(),
+            })
+
+    @staticmethod
+    def _metashape_find_chunk(root_elem: ET.Element) -> ET.Element:
+        chunks = root_elem.find('chunks')
+        if chunks is not None:
+            for c in chunks.findall('chunk'):
+                if c.get('enabled', 'true').lower() != 'false':
+                    return c
+        chunk = root_elem.find('chunk')
+        if chunk is not None:
+            return chunk
+        raise ValueError('No chunk found in Metashape project')
+
+    @staticmethod
+    def _metashape_parse_sensors(chunk: ET.Element) -> dict[str, 'PinholeModel']:
+        sensors: dict[str, PinholeModel] = {}
+        sensors_elem = chunk.find('sensors')
+        if sensors_elem is None:
+            return sensors
+        for s in sensors_elem.findall('sensor'):
+            if s.get('type', 'frame') != 'frame':
+                continue
+            sid = s.get('id', '0')
+            res = s.find('resolution')
+            w = int(res.get('width',  4000)) if res is not None else 4000
+            h = int(res.get('height', 3000)) if res is not None else 3000
+            calib = next(
+                (c for c in s.findall('calibration') if c.get('class') == 'adjusted'),
+                s.find('calibration'),
+            )
+
+            def _f(tag, default=0.0):
+                t = calib.find(tag) if calib is not None else None
+                return float(t.text) if (t is not None and t.text) else default
+
+            cal_res = calib.find('resolution') if calib is not None else None
+            if cal_res is not None:
+                w = int(cal_res.get('width', w))
+                h = int(cal_res.get('height', h))
+
+            sensors[sid] = PinholeModel(
+                f=_f('f', w), cx_off=_f('cx'), cy_off=_f('cy'),
+                k1=_f('k1'), k2=_f('k2'), p1=_f('p1'), p2=_f('p2'),
+                width=w, height=h,
+                sensor_name=s.get('label', f'cam{sid}'),
+            )
+        return sensors
+
+    @staticmethod
+    def _metashape_chunk_transform(chunk: ET.Element) -> np.ndarray:
+        T = np.eye(4, dtype=np.float64)
+        t_elem = chunk.find('transform')
+        if t_elem is not None:
+            rot = t_elem.find('rotation')
+            tra = t_elem.find('translation')
+            sca = t_elem.find('scale')
+            if rot is not None and tra is not None:
+                s = float(sca.text) if sca is not None else 1.0
+                T[:3, :3] = np.array(rot.text.split(), dtype=np.float64).reshape(3, 3) * s
+                T[:3,  3] = np.array(tra.text.split(), dtype=np.float64)
+        return T
+
+    @staticmethod
+    def _rot_to_quat(R: np.ndarray) -> tuple[float, float, float, float]:
+        """Convert 3×3 rotation matrix → (w, x, y, z) quaternion."""
+        import math as _m
+        tr = R[0, 0] + R[1, 1] + R[2, 2]
+        if tr > 0:
+            s = 0.5 / _m.sqrt(tr + 1.0)
+            return (0.25 / s, (R[2,1]-R[1,2])*s, (R[0,2]-R[2,0])*s, (R[1,0]-R[0,1])*s)
+        elif R[0,0] > R[1,1] and R[0,0] > R[2,2]:
+            s = 2.0 * _m.sqrt(1.0 + R[0,0] - R[1,1] - R[2,2])
+            return ((R[2,1]-R[1,2])/s, 0.25*s, (R[0,1]+R[1,0])/s, (R[0,2]+R[2,0])/s)
+        elif R[1,1] > R[2,2]:
+            s = 2.0 * _m.sqrt(1.0 + R[1,1] - R[0,0] - R[2,2])
+            return ((R[0,2]-R[2,0])/s, (R[0,1]+R[1,0])/s, 0.25*s, (R[1,2]+R[2,1])/s)
+        else:
+            s = 2.0 * _m.sqrt(1.0 + R[2,2] - R[0,0] - R[1,1])
+            return ((R[1,0]-R[0,1])/s, (R[0,2]+R[2,0])/s, (R[1,2]+R[2,1])/s, 0.25*s)
+
+    # ------------------------------------------------------------------
+    # Georeferencing — unified for both platforms
+    # ------------------------------------------------------------------
+
+    def apply_trimble_georef(
+        self,
+        trimble_csv: str | Path,
+        epsg: int = 32605,
+        overwrite: bool = False,
+    ) -> None:
+        """Parse a Trimble survey CSV and write georeferenced anchor_poses.txt.
+
+        The CSV format is: point_id;lat_deg;lon_deg;elev_m (semicolon-separated).
+        Anchor names are matched by stripping the dash from the anchor name:
+        anchor '14-00' matches Trimble point '1400'.
+        Coordinates are converted from WGS84 to the given EPSG projection
+        (default 32605 = UTM Zone 5N).
+        """
+        trimble_csv = Path(trimble_csv)
+
+        # Parse Trimble CSV → {point_id_str: (easting, northing, height)}
+        survey: dict[str, tuple[float, float, float]] = {}
+        with open(trimble_csv, newline='') as f:
+            for row in csv.reader(f, delimiter=';'):
+                if len(row) < 4:
+                    continue
+                pt_id = row[0].strip()
+                try:
+                    lat, lon, elev = float(row[1]), float(row[2]), float(row[3])
+                except ValueError:
+                    continue
+                easting, northing = _wgs84_to_utm(lat, lon, epsg)
+                survey[pt_id] = (easting, northing, elev)
+
+        if not survey:
+            raise ValueError(f'No valid points parsed from {trimble_csv}')
+        log.info('Parsed %d Trimble control points from %s', len(survey), trimble_csv.name)
+
+        # Read anchor names from anchors.txt
+        anchor_names = self._read_anchor_names()
+        if not anchor_names:
+            log.warning('No anchors found in anchors.txt — skipping georeferencing')
+            return
+
+        # Match anchor names to survey points
+        matched: dict[str, tuple[float, float, float]] = {}
+        for name in anchor_names:
+            key = name.replace('-', '')   # '14-00' → '1400'
+            if key in survey:
+                matched[name] = survey[key]
+            else:
+                log.warning('Anchor %r has no matching Trimble point (tried %r)', name, key)
+
+        if not matched:
+            raise ValueError('No anchors could be matched to Trimble survey points')
+
+        poses_path = self.root / 'anchors' / 'anchor_poses.txt'
+        if poses_path.exists() and not overwrite:
+            # Check if it already has data beyond the header comments
+            content = poses_path.read_text()
+            data_lines = [l for l in content.splitlines()
+                          if l.strip() and not l.startswith('#') and l.strip() != '1.1']
+            if data_lines:
+                log.info('anchor_poses.txt already populated — skipping (use overwrite=True)')
+                return
+
+        # Write anchor_poses.txt
+        header = (
+            '#\n'
+            '# SLAM Anchor Pose File Format Version 1.1\n'
+            '#\n'
+            '# Generated by rawkee NavVis pipeline from Trimble CSV: '
+            f'{trimble_csv.name}\n'
+            f'# Projection: EPSG:{epsg}  '
+            '(X=Easting, Y=Northing, Z=Height, right-handed)\n'
+            '#\n'
+            '1.1\n'
+        )
+        lines = [header]
+        for name, (e, n, h) in matched.items():
+            lines.append(f'"{name}" {e:.4f} {n:.4f} {h:.4f} 0.0\n')
+
+        poses_path.write_text(''.join(lines))
+        log.info(
+            'Wrote %d georeferenced anchors to %s', len(matched), poses_path
+        )
+
+    def geo_origin(self) -> tuple[float, float, float, int] | None:
+        """Return (easting, northing, height, epsg) centroid, or None.
+
+        NavVis: anchor_poses.txt. Metashape: GPS reference tags.
+        Meshroom: EXIF GPS. Pix4D: calibrated camera positions (already UTM).
+        """
+        if self.platform == 'metashape':
+            return self._geo_origin_metashape()
+        if self.platform == 'meshroom':
+            return self._geo_origin_meshroom()
+        if self.platform == 'pix4d':
+            return self._geo_origin_pix4d()
+        if self.platform in ('colmap', 'e57'):
+            return self._geo_origin_pix4d()   # reuse: both use _utm key in poses
+        return self._geo_origin_navvis()
+
+    def _geo_origin_navvis(self) -> tuple[float, float, float, int] | None:
+        """Read UTM centroid from populated anchor_poses.txt."""
+        path = self.root / 'anchors' / 'anchor_poses.txt'
+        if not path.exists():
+            return None
+        epsg = None
+        coords = []
+        for line in path.read_text().splitlines():
+            stripped = line.strip()
+            if 'EPSG:' in stripped:
+                try:
+                    epsg = int(stripped.split('EPSG:')[1].split()[0])
+                except (ValueError, IndexError):
+                    pass
+            if not stripped or stripped.startswith('#'):
+                continue
+            parts = stripped.split()
+            if len(parts) < 5:
+                continue
+            try:
+                float(parts[0])   # version line is a float; skip it
+                continue
+            except ValueError:
+                pass
+            try:
+                e, n, h = float(parts[1]), float(parts[2]), float(parts[3])
+                coords.append((e, n, h))
+            except (ValueError, IndexError):
+                continue
+        if not coords:
+            return None
+        e_mean = sum(c[0] for c in coords) / len(coords)
+        n_mean = sum(c[1] for c in coords) / len(coords)
+        h_mean = sum(c[2] for c in coords) / len(coords)
+        return (e_mean, n_mean, h_mean, epsg or 32605)
+
+    def _geo_origin_metashape(self) -> tuple[float, float, float, int] | None:
+        """Compute UTM centroid from Metashape camera GPS reference tags."""
+        coords = []
+        for pose in self.poses:
+            ref = pose.get('_reference', {})
+            if 'x' in ref and 'y' in ref and 'z' in ref:
+                coords.append((ref['x'], ref['y'], ref['z']))
+        if not coords:
+            return None
+        x_c = sum(c[0] for c in coords) / len(coords)
+        y_c = sum(c[1] for c in coords) / len(coords)
+        z_c = sum(c[2] for c in coords) / len(coords)
+        # Detect geographic (lon/lat) vs. projected (easting/northing)
+        if -180.0 <= x_c <= 180.0 and -90.0 <= y_c <= 90.0:
+            # Metashape geographic: x=longitude, y=latitude
+            zone    = int((x_c + 180.0) / 6.0) + 1
+            epsg    = 32600 + zone if y_c >= 0 else 32700 + zone
+            e, n    = _wgs84_to_utm(y_c, x_c, epsg)   # lat, lon
+            return (e, n, z_c, epsg)
+        # Already projected — return as-is with a generic EPSG fallback
+        return (x_c, y_c, z_c, 32605)
+
+    def _geo_origin_meshroom(self) -> tuple[float, float, float, int] | None:
+        """Compute UTM centroid from EXIF GPS metadata embedded in cameras.sfm views."""
+        coords = []
+        for pose in self.poses:
+            ref = pose.get('_reference', {})
+            if 'lat' in ref and 'lon' in ref:
+                coords.append((ref['lat'], ref['lon'], ref.get('alt', 0.0)))
+        if not coords:
+            return None
+        lat_c = sum(c[0] for c in coords) / len(coords)
+        lon_c = sum(c[1] for c in coords) / len(coords)
+        alt_c = sum(c[2] for c in coords) / len(coords)
+        zone  = int((lon_c + 180.0) / 6.0) + 1
+        epsg  = 32600 + zone if lat_c >= 0 else 32700 + zone
+        e, n  = _wgs84_to_utm(lat_c, lon_c, epsg)
+        return (e, n, alt_c, epsg)
+
+    # ------------------------------------------------------------------
+    # Meshroom .mg parser
+    # ------------------------------------------------------------------
+
+    def _parse_meshroom(self) -> None:
+        """Parse a Meshroom .mg project file and locate cameras.sfm in the cache."""
+        mg_path = self.root
+        if mg_path.is_dir():
+            candidates = sorted(mg_path.glob('*.mg'))
+            if not candidates:
+                raise FileNotFoundError(f'No .mg file found in {mg_path}')
+            mg_path = candidates[0]
+
+        with open(mg_path, 'r', encoding='utf-8') as fh:
+            mg = json.load(fh)
+
+        # Locate the StructureFromMotion node and its cache hash
+        sfm_path = self._meshroom_find_sfm(mg, mg_path.parent)
+
+        with open(sfm_path, 'r', encoding='utf-8') as fh:
+            sfm = json.load(fh)
+
+        self._meta = {'dataset': {'name': mg_path.stem, 'dataset_id': mg_path.stem}}
+
+        # Parse intrinsics → PinholeModel
+        intrinsics: dict[str, PinholeModel] = {}
+        for intr in sfm.get('intrinsics', []):
+            iid = intr['intrinsicId']
+            w   = int(intr.get('width',  '4000'))
+            h   = int(intr.get('height', '3000'))
+            f   = float(intr.get('pxFocalLength', w))
+            pp  = intr.get('principalPoint', ['0', '0'])
+            cx_off, cy_off = float(pp[0]), float(pp[1])
+            dist = [float(v) for v in intr.get('distortionParams', [])]
+            itype = intr.get('type', 'radial3')
+            # Map AliceVision distortion types to k1,k2,k3,p1,p2
+            k1 = dist[0] if len(dist) > 0 else 0.0
+            k2 = dist[1] if len(dist) > 1 else 0.0
+            k3 = dist[2] if len(dist) > 2 and 'radial' in itype else 0.0
+            p1 = dist[2] if len(dist) > 2 and 'radial' not in itype else 0.0
+            p2 = dist[3] if len(dist) > 3 else 0.0
+            intrinsics[iid] = PinholeModel(
+                f=f, cx_off=cx_off, cy_off=cy_off,
+                k1=k1, k2=k2, p1=p1, p2=p2, k3=k3,
+                width=w, height=h,
+                sensor_name=intr.get('serialNumber', f'cam{iid}'),
+            )
+
+        # Parse poses: rotation is world→camera (row-major 9-element flat array)
+        poses_dict: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        for p in sfm.get('poses', []):
+            pid = p['poseId']
+            t   = p['pose']['transform']
+            R_w2c = np.array([float(v) for v in t['rotation']], dtype=np.float64).reshape(3, 3)
+            center = np.array([float(v) for v in t['center']], dtype=np.float64)
+            R_c2w  = R_w2c.T
+            poses_dict[pid] = (center, R_c2w)
+
+        # Build view index for fast lookup
+        view_index: dict[str, dict] = {v['viewId']: v for v in sfm.get('views', [])}
+
+        self._cameras = list(intrinsics.values()) or [
+            PinholeModel(f=3000.0, cx_off=0.0, cy_off=0.0, k1=0.0, k2=0.0,
+                         p1=0.0, p2=0.0, width=4000, height=3000)
+        ]
+        self._poses = []
+
+        for view in sfm.get('views', []):
+            pid = view.get('poseId', '')
+            if pid not in poses_dict:
+                continue   # unregistered image
+            iid = view.get('intrinsicId', '')
+            if iid not in intrinsics:
+                continue
+
+            center, R_c2w = poses_dict[pid]
+            qw, qx, qy, qz = self._rot_to_quat(R_c2w)
+
+            # GPS from EXIF metadata
+            meta = view.get('metadata', {})
+            reference = self._meshroom_parse_gps(meta)
+
+            self._poses.append({
+                'cam_head': {'position': center.tolist(), 'quaternion': [qw, qx, qy, qz]},
+                'footprint': {'position': center.tolist(), 'quaternion': [qw, qx, qy, qz]},
+                'timestamp': float(meta.get('Exif:DateTimeOriginal', 0) or 0),
+                'valid': 'true',
+                'capture_mode': 'Meshroom',
+                '_image_path': view.get('path', ''),
+                '_sensor_id': iid,
+                '_reference': reference,
+                '_transform_matrix': np.block([
+                    [R_c2w, center[:, None]],
+                    [np.zeros((1, 3)), np.ones((1, 1))]
+                ]).tolist(),
+            })
+
+    @staticmethod
+    def _meshroom_find_sfm(mg: dict, project_dir: Path) -> Path:
+        """Locate cameras.sfm from the Meshroom project graph."""
+        graph = mg.get('graph', {})
+        for node_name, node in graph.items():
+            if node.get('nodeType') != 'StructureFromMotion':
+                continue
+            uid = node.get('uids', {}).get('0', '')
+            if uid:
+                candidate = project_dir / 'MeshroomCache' / 'StructureFromMotion' / uid / 'cameras.sfm'
+                if candidate.exists():
+                    return candidate
+        # Fallback: scan the cache directory for any cameras.sfm
+        cache_dir = project_dir / 'MeshroomCache' / 'StructureFromMotion'
+        if cache_dir.exists():
+            candidates = sorted(cache_dir.rglob('cameras.sfm'), key=lambda p: p.stat().st_mtime)
+            if candidates:
+                return candidates[-1]
+        raise FileNotFoundError(
+            f'cameras.sfm not found in {project_dir}/MeshroomCache/StructureFromMotion/\n'
+            '  Run the Meshroom StructureFromMotion node to completion first.'
+        )
+
+    @staticmethod
+    def _meshroom_parse_gps(meta: dict) -> dict:
+        """Extract decimal-degree GPS from AliceVision EXIF metadata dict."""
+        lat_raw = meta.get('Exif:GPSLatitude',   meta.get('GPS:Latitude',   ''))
+        lon_raw = meta.get('Exif:GPSLongitude',  meta.get('GPS:Longitude',  ''))
+        alt_raw = meta.get('Exif:GPSAltitude',   meta.get('GPS:Altitude',   '0'))
+        lat_ref = meta.get('Exif:GPSLatitudeRef', 'N')
+        lon_ref = meta.get('Exif:GPSLongitudeRef', 'E')
+        if not lat_raw or not lon_raw:
+            return {}
+        try:
+            def _dms_to_dec(s: str, ref: str) -> float:
+                s = s.strip()
+                if 'deg' in s or "'" in s:
+                    parts = s.replace('deg', ' ').replace("'", ' ').replace('"', ' ').split()
+                    d = float(parts[0])
+                    m = float(parts[1]) if len(parts) > 1 else 0.0
+                    sc = float(parts[2]) if len(parts) > 2 else 0.0
+                    v = d + m / 60.0 + sc / 3600.0
+                else:
+                    v = float(s)
+                if ref in ('S', 'W'):
+                    v = -v
+                return v
+            return {
+                'lat': _dms_to_dec(lat_raw, lat_ref),
+                'lon': _dms_to_dec(lon_raw, lon_ref),
+                'alt': float(str(alt_raw).split('/')[0]),
+            }
+        except Exception:
+            return {}
+
+    # ------------------------------------------------------------------
+    # Pix4Dmapper parser
+    # ------------------------------------------------------------------
+
+    def _parse_pix4d(self) -> None:
+        """Parse a Pix4Dmapper project folder or .p4d file."""
+        p4d_path = self.root
+        project_dir: Path
+
+        if p4d_path.suffix.lower() == '.p4d':
+            project_dir = p4d_path.parent
+        else:
+            project_dir = p4d_path
+            candidates = sorted(project_dir.glob('*.p4d'))
+            p4d_path = candidates[0] if candidates else None
+
+        params_dir = project_dir / '1_initial' / 'params'
+        if not params_dir.exists():
+            raise FileNotFoundError(
+                f'1_initial/params/ not found under {project_dir}.\n'
+                '  Run Pix4Dmapper Initial Processing (Step 1) to completion first.'
+            )
+
+        stem = project_dir.name
+
+        # --- Coordinate offset ---
+        offset = np.zeros(3, dtype=np.float64)
+        for f in params_dir.glob('*_offset.xyz'):
+            try:
+                vals = f.read_text().split()
+                offset = np.array([float(v) for v in vals[:3]])
+            except Exception:
+                pass
+            break
+
+        # --- Intrinsics (.cam file) ---
+        intrinsics: dict[str, 'PinholeModel'] = {}
+        for cam_file in params_dir.glob('*_calibrated_internal_camera_parameters.cam'):
+            intrinsics = self._pix4d_parse_cam(cam_file)
+            break
+        default_model = next(iter(intrinsics.values())) if intrinsics else PinholeModel(
+            f=3000.0, cx_off=0.0, cy_off=0.0, k1=0.0, k2=0.0,
+            p1=0.0, p2=0.0, width=4000, height=3000,
+        )
+        self._cameras = list(intrinsics.values()) or [default_model]
+
+        # --- Image paths from .p4d XML ---
+        image_path_map: dict[str, Path] = {}
+        if p4d_path and p4d_path.exists():
+            image_path_map = self._pix4d_parse_image_paths(p4d_path, project_dir)
+
+        # --- Poses from calibrated camera parameters ---
+        poses_file = next(params_dir.glob('*_calibrated_camera_parameters.txt'), None)
+        if poses_file is None:
+            raise FileNotFoundError(
+                f'No *_calibrated_camera_parameters.txt found in {params_dir}'
+            )
+
+        self._meta = {'dataset': {'name': project_dir.name, 'dataset_id': project_dir.name}}
+        self._poses = []
+
+        for line in poses_file.read_text(encoding='utf-8', errors='replace').splitlines():
+            line = line.strip()
+            if not line or line.startswith('#') or line.lower().startswith('label'):
+                continue
+            parts = [p.strip() for p in line.split(',')]
+            if len(parts) < 7:
+                parts = line.split()
+            if len(parts) < 7:
+                continue
+            try:
+                label = parts[0]
+                x = float(parts[1]) + offset[0]
+                y = float(parts[2]) + offset[1]
+                z = float(parts[3]) + offset[2]
+                omega = float(parts[4])
+                phi   = float(parts[5])
+                kappa = float(parts[6])
+            except (ValueError, IndexError):
+                continue
+
+            R_c2w = self._opk_to_rot(omega, phi, kappa)
+            qw, qx, qy, qz = self._rot_to_quat(R_c2w)
+            pos = [x, y, z]
+
+            img_path = image_path_map.get(label, project_dir / label)
+
+            self._poses.append({
+                'cam_head': {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                'footprint': {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                'timestamp': 0.0,
+                'valid': 'true',
+                'capture_mode': 'Pix4D',
+                '_image_path': str(img_path),
+                '_sensor_id': '0',
+                '_reference': {'x': x, 'y': y, 'z': z},
+                '_transform_matrix': np.block([
+                    [R_c2w, np.array(pos)[:, None]],
+                    [np.zeros((1, 3)), np.ones((1, 1))]
+                ]).tolist(),
+                '_utm': (x, y, z),
+            })
+
+    @staticmethod
+    def _pix4d_parse_cam(cam_file: Path) -> dict[str, 'PinholeModel']:
+        """Parse a Pix4D .cam intrinsics file (INI-style, one group per camera model)."""
+        models: dict[str, PinholeModel] = {}
+        current: dict[str, str] = {}
+        group_id = '0'
+
+        for raw in cam_file.read_text(encoding='utf-8', errors='replace').splitlines():
+            line = raw.strip()
+            if line.startswith('['):
+                if current:
+                    models[group_id] = _pix4d_cam_to_model(current)
+                    current = {}
+                group_id = line.strip('[]').split('_')[-1]
+            elif '=' in line and not line.startswith('#'):
+                k, _, v = line.partition('=')
+                current[k.strip().lower()] = v.strip()
+        if current:
+            models[group_id] = _pix4d_cam_to_model(current)
+        return models
+
+    @staticmethod
+    def _pix4d_parse_image_paths(p4d_path: Path, project_dir: Path) -> dict[str, Path]:
+        """Extract image name → absolute path from a Pix4D .p4d XML project file."""
+        paths: dict[str, Path] = {}
+        try:
+            tree = ET.parse(p4d_path)
+            for img_elem in tree.getroot().iter('Image'):
+                name = (img_elem.findtext('name') or '').strip()
+                path_str = (img_elem.findtext('path') or '').strip()
+                if name and path_str:
+                    p = Path(path_str)
+                    if not p.is_absolute():
+                        p = project_dir / p
+                    paths[name] = p
+        except Exception:
+            pass
+        return paths
+
+    @staticmethod
+    def _opk_to_rot(omega_deg: float, phi_deg: float, kappa_deg: float) -> np.ndarray:
+        """Convert photogrammetric OPK angles (degrees) to camera-to-world rotation matrix."""
+        omega = math.radians(omega_deg)
+        phi   = math.radians(phi_deg)
+        kappa = math.radians(kappa_deg)
+        co, so = math.cos(omega), math.sin(omega)
+        cp, sp = math.cos(phi),   math.sin(phi)
+        ck, sk = math.cos(kappa), math.sin(kappa)
+        Rx = np.array([[1, 0,  0 ], [0, co, -so], [0, so,  co]], dtype=np.float64)
+        Ry = np.array([[cp, 0, sp], [0,  1,   0 ], [-sp, 0, cp]], dtype=np.float64)
+        Rz = np.array([[ck, -sk, 0], [sk, ck, 0], [0, 0, 1]], dtype=np.float64)
+        return Rz @ Ry @ Rx
+
+    def _geo_origin_pix4d(self) -> tuple[float, float, float, int] | None:
+        """Return UTM centroid from already-georeferenced Pix4D camera positions."""
+        coords = [p['_utm'] for p in (self._poses or []) if '_utm' in p]
+        if not coords:
+            return None
+        e = sum(c[0] for c in coords) / len(coords)
+        n = sum(c[1] for c in coords) / len(coords)
+        h = sum(c[2] for c in coords) / len(coords)
+        # Attempt to read EPSG from .p4d XML; fall back to 32605
+        epsg = self._pix4d_read_epsg()
+        return (e, n, h, epsg)
+
+    def _pix4d_read_epsg(self) -> int:
+        """Try to read the EPSG code from the .p4d project file."""
+        import re as _re
+        try:
+            project_dir = self.root if self.root.is_dir() else self.root.parent
+            for p4d in project_dir.glob('*.p4d'):
+                text = ET.parse(p4d).getroot().iter().__next__() and p4d.read_text(errors='ignore')
+                m = _re.search(r'EPSG[:\s]+?(\d{4,5})\b', text, _re.IGNORECASE)
+                if m:
+                    return int(m.group(1))
+        except Exception:
+            pass
+        return 32605
+
+    # ------------------------------------------------------------------
+    # COLMAP sparse reconstruction parser (text + binary formats)
+    # ------------------------------------------------------------------
+
+    def _parse_colmap(self) -> None:
+        """Parse a COLMAP sparse reconstruction folder.
+
+        Accepts either the text format (cameras.txt / images.txt) or binary
+        format (cameras.bin / images.bin). Searches for the sparse model in the
+        given folder and common sub-paths: sparse/, sparse/0/, dense/sparse/.
+        """
+        sparse_dir = self._colmap_find_sparse(self.root)
+
+        self._meta = {'dataset': {'name': self.root.name, 'dataset_id': self.root.name}}
+
+        # --- Cameras (intrinsics) ---
+        cameras: dict[int, 'PinholeModel'] = {}
+        cam_txt = sparse_dir / 'cameras.txt'
+        cam_bin = sparse_dir / 'cameras.bin'
+        if cam_txt.exists():
+            cameras = self._colmap_read_cameras_txt(cam_txt)
+        elif cam_bin.exists():
+            cameras = self._colmap_read_cameras_bin(cam_bin)
+        else:
+            raise FileNotFoundError(f'cameras.txt / cameras.bin not found in {sparse_dir}')
+
+        default_model = next(iter(cameras.values())) if cameras else PinholeModel(
+            f=3000.0, cx_off=0.0, cy_off=0.0, k1=0.0, k2=0.0,
+            p1=0.0, p2=0.0, width=4000, height=3000,
+        )
+        self._cameras = list(cameras.values()) or [default_model]
+
+        # --- Images (extrinsics + filenames) ---
+        img_txt = sparse_dir / 'images.txt'
+        img_bin = sparse_dir / 'images.bin'
+        if img_txt.exists():
+            image_data = self._colmap_read_images_txt(img_txt)
+        elif img_bin.exists():
+            image_data = self._colmap_read_images_bin(img_bin)
+        else:
+            raise FileNotFoundError(f'images.txt / images.bin not found in {sparse_dir}')
+
+        # Resolve image paths: COLMAP stores names; look in sibling images/ folder
+        images_dir = self.root / 'images'
+
+        self._poses = []
+        for img in image_data:
+            cam = cameras.get(img['camera_id'], default_model)
+            # COLMAP quaternion is (qw, qx, qy, qz) world→camera
+            qw, qx, qy, qz = img['qw'], img['qx'], img['qy'], img['qz']
+            # Convert world→camera quaternion to rotation matrix
+            R_w2c = _quat_to_rot(np.array([qw, qx, qy, qz]))
+            R_c2w = R_w2c.T
+            # Camera center in world: C = -R_w2c^T @ t
+            t = img['t']
+            center = -R_c2w @ t
+            q2w_arr = np.array(self._rot_to_quat(R_c2w))
+
+            img_path = images_dir / img['name'] if images_dir.exists() else self.root / img['name']
+
+            self._poses.append({
+                'cam_head': {'position': center.tolist(), 'quaternion': q2w_arr.tolist()},
+                'footprint': {'position': center.tolist(), 'quaternion': q2w_arr.tolist()},
+                'timestamp': 0.0,
+                'valid': 'true',
+                'capture_mode': 'COLMAP',
+                '_image_path': str(img_path),
+                '_sensor_id': str(img['camera_id']),
+                '_reference': {},
+                '_transform_matrix': np.block([
+                    [R_c2w, center[:, None]],
+                    [np.zeros((1, 3)), np.ones((1, 1))]
+                ]).tolist(),
+                '_utm': tuple(center.tolist()),
+            })
+
+    @staticmethod
+    def _colmap_find_sparse(root: Path) -> Path:
+        """Locate the COLMAP sparse model directory."""
+        for sub in ('', 'sparse', 'sparse/0', 'dense/sparse'):
+            d = root / sub if sub else root
+            if (d / 'cameras.txt').exists() or (d / 'cameras.bin').exists():
+                return d
+        # Also try sparse/N for any integer N
+        sparse = root / 'sparse'
+        if sparse.exists():
+            for sub in sorted(sparse.iterdir()):
+                if sub.is_dir() and ((sub / 'cameras.txt').exists() or (sub / 'cameras.bin').exists()):
+                    return sub
+        raise FileNotFoundError(f'COLMAP sparse model not found under {root}')
+
+    @staticmethod
+    def _colmap_read_cameras_txt(path: Path) -> dict[int, 'PinholeModel']:
+        """Parse COLMAP cameras.txt → dict of camera_id → PinholeModel."""
+        models: dict[int, PinholeModel] = {}
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            parts = line.split()
+            cid  = int(parts[0])
+            model = parts[1].upper()
+            w, h  = int(parts[2]), int(parts[3])
+            params = [float(v) for v in parts[4:]]
+            models[cid] = _colmap_params_to_model(model, w, h, params)
+        return models
+
+    @staticmethod
+    def _colmap_read_cameras_bin(path: Path) -> dict[int, 'PinholeModel']:
+        """Parse COLMAP cameras.bin → dict of camera_id → PinholeModel."""
+        import struct
+        models: dict[int, PinholeModel] = {}
+        COLMAP_CAMERA_MODELS = {
+            0: 'SIMPLE_PINHOLE', 1: 'PINHOLE', 2: 'SIMPLE_RADIAL',
+            3: 'RADIAL', 4: 'OPENCV', 5: 'OPENCV_FISHEYE',
+            6: 'FULL_OPENCV', 7: 'FOV', 8: 'SIMPLE_RADIAL_FISHEYE',
+            9: 'RADIAL_FISHEYE', 10: 'THIN_PRISM_FISHEYE',
+        }
+        with open(path, 'rb') as f:
+            num_cameras = struct.unpack('<Q', f.read(8))[0]
+            for _ in range(num_cameras):
+                cid        = struct.unpack('<i', f.read(4))[0]
+                model_id   = struct.unpack('<i', f.read(4))[0]
+                w          = struct.unpack('<Q', f.read(8))[0]
+                h          = struct.unpack('<Q', f.read(8))[0]
+                model_name = COLMAP_CAMERA_MODELS.get(model_id, 'PINHOLE')
+                n_params   = _colmap_num_params(model_name)
+                params     = list(struct.unpack(f'<{n_params}d', f.read(8 * n_params)))
+                models[cid] = _colmap_params_to_model(model_name, w, h, params)
+        return models
+
+    @staticmethod
+    def _colmap_read_images_txt(path: Path) -> list[dict]:
+        """Parse COLMAP images.txt → list of image dicts."""
+        images = []
+        lines = [l for l in path.read_text().splitlines() if l.strip() and not l.startswith('#')]
+        i = 0
+        while i < len(lines):
+            parts = lines[i].split()
+            if len(parts) >= 9:
+                images.append({
+                    'image_id':  int(parts[0]),
+                    'qw': float(parts[1]), 'qx': float(parts[2]),
+                    'qy': float(parts[3]), 'qz': float(parts[4]),
+                    't':  np.array([float(parts[5]), float(parts[6]), float(parts[7])]),
+                    'camera_id': int(parts[8]),
+                    'name': parts[9] if len(parts) > 9 else f'image_{parts[0]}',
+                })
+            i += 2   # skip the keypoints line
+        return images
+
+    @staticmethod
+    def _colmap_read_images_bin(path: Path) -> list[dict]:
+        """Parse COLMAP images.bin → list of image dicts."""
+        import struct
+        images = []
+        with open(path, 'rb') as f:
+            num_images = struct.unpack('<Q', f.read(8))[0]
+            for _ in range(num_images):
+                image_id  = struct.unpack('<i', f.read(4))[0]
+                qw, qx, qy, qz = struct.unpack('<4d', f.read(32))
+                tx, ty, tz      = struct.unpack('<3d', f.read(24))
+                camera_id       = struct.unpack('<i', f.read(4))[0]
+                name_bytes = b''
+                while True:
+                    c = f.read(1)
+                    if c == b'\x00':
+                        break
+                    name_bytes += c
+                name = name_bytes.decode('utf-8', errors='replace')
+                num_pts = struct.unpack('<Q', f.read(8))[0]
+                f.read(num_pts * 24)   # skip 2D keypoints + 3D point ids
+                images.append({
+                    'image_id': image_id,
+                    'qw': qw, 'qx': qx, 'qy': qy, 'qz': qz,
+                    't': np.array([tx, ty, tz]),
+                    'camera_id': camera_id,
+                    'name': name,
+                })
+        return images
+
+    # ------------------------------------------------------------------
+    # E57 point cloud parser
+    # ------------------------------------------------------------------
+
+    def _parse_e57(self) -> None:
+        """Parse an E57 file or folder containing an E57 file."""
+        e57_path = self.root
+        if e57_path.is_dir():
+            candidates = sorted(e57_path.glob('*.e57'))
+            if not candidates:
+                raise FileNotFoundError(f'No .e57 file found in {e57_path}')
+            e57_path = candidates[0]
+        self._e57_path = e57_path
+        self._e57_pcd_cache: tuple | None = None   # (xyz, colors_or_None) lazy cache
+
+        self._meta = {'dataset': {'name': e57_path.stem, 'dataset_id': e57_path.stem}}
+        self._cameras = []
+        self._poses   = []
+
+        try:
+            import pye57
+            e57 = pye57.E57(str(e57_path))
+            for i in range(e57.scan_count):
+                header = e57.get_header(i)
+                try:
+                    R = np.array(header.rotation_matrix, dtype=np.float64)
+                    t = np.array(header.translation,     dtype=np.float64)
+                except Exception:
+                    R, t = np.eye(3), np.zeros(3)
+                qw, qx, qy, qz = self._rot_to_quat(R)
+                pos = t.tolist()
+                self._poses.append({
+                    'cam_head':  {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                    'footprint': {'position': pos, 'quaternion': [qw, qx, qy, qz]},
+                    'timestamp': 0.0, 'valid': 'true', 'capture_mode': 'E57',
+                    '_image_path': '', '_sensor_id': str(i),
+                    '_reference': {},
+                    '_transform_matrix': np.block([[R, t[:,None]],[np.zeros((1,3)),np.ones((1,1))]]).tolist(),
+                    '_utm': tuple(t.tolist()),
+                })
+        except ImportError:
+            # pye57 not installed — create a single dummy pose so num_frames > 0
+            self._poses.append({
+                'cam_head': {'position': [0,0,0], 'quaternion': [1,0,0,0]},
+                'footprint': {'position': [0,0,0], 'quaternion': [1,0,0,0]},
+                'timestamp': 0.0, 'valid': 'true', 'capture_mode': 'E57',
+                '_image_path': '', '_sensor_id': '0', '_reference': {},
+                '_transform_matrix': np.eye(4).tolist(), '_utm': (0.0, 0.0, 0.0),
+            })
+
+    def has_training_images(self) -> bool:
+        """Return True when the dataset has calibrated images suitable for 3DGS training."""
+        if self.platform == 'e57':
+            return len(self.cameras) > 0 and any(
+                p.get('_image_path', '') for p in (self._poses or [])
+            )
+        return len(self.valid_frame_indices()) > 0
+
+    def e57_point_cloud(self) -> tuple[np.ndarray, 'np.ndarray | None']:
+        """Read and return (xyz_float32, colors_float32_or_None) from the E57 file.
+
+        Result is cached after the first call.
+        """
+        if not hasattr(self, '_e57_path'):
+            raise RuntimeError('e57_point_cloud() called on non-E57 dataset')
+        if self._e57_pcd_cache is not None:
+            return self._e57_pcd_cache
+
+        try:
+            import pye57
+            e57   = pye57.E57(str(self._e57_path))
+            xyzs, rgbs = [], []
+            for i in range(e57.scan_count):
+                header = e57.get_header(i)
+                data   = e57.read_scan(i, ignore_missing_fields=True)
+                x = np.array(data.get('cartesianX', []), dtype=np.float64)
+                y = np.array(data.get('cartesianY', []), dtype=np.float64)
+                z = np.array(data.get('cartesianZ', []), dtype=np.float64)
+                if len(x) == 0:
+                    continue
+                pts = np.stack([x, y, z], axis=-1)
+                # Apply scanner pose to bring into world frame
+                try:
+                    R = np.array(header.rotation_matrix, dtype=np.float64)
+                    t = np.array(header.translation,     dtype=np.float64)
+                    pts = pts @ R.T + t
+                except Exception:
+                    pass
+                xyzs.append(pts.astype(np.float32))
+                r = data.get('colorRed')
+                g = data.get('colorGreen')
+                b = data.get('colorBlue')
+                if r is not None and g is not None and b is not None:
+                    maxv = 255.0 if np.max(r) > 1.0 else 1.0
+                    rgbs.append(np.stack([
+                        np.array(r, dtype=np.float32) / maxv,
+                        np.array(g, dtype=np.float32) / maxv,
+                        np.array(b, dtype=np.float32) / maxv,
+                    ], axis=-1))
+                else:
+                    rgbs.append(None)
+
+            if not xyzs:
+                raise RuntimeError('No valid scan data in E57 file')
+            xyz_all = np.concatenate(xyzs, axis=0)
+            colors_all = (
+                np.concatenate([c for c in rgbs if c is not None], axis=0)
+                if all(c is not None for c in rgbs) else None
+            )
+            self._e57_pcd_cache = (xyz_all, colors_all)
+            log.info('E57: %d points%s', len(xyz_all),
+                     ' with RGB' if colors_all is not None else ' (no color)')
+            return self._e57_pcd_cache
+
+        except ImportError:
+            # Fall back to Open3D
+            try:
+                import open3d as o3d
+                pcd = o3d.io.read_point_cloud(str(self._e57_path))
+                xyz = np.asarray(pcd.points, dtype=np.float32)
+                colors = np.asarray(pcd.colors, dtype=np.float32) if pcd.has_colors() else None
+                self._e57_pcd_cache = (xyz, colors)
+                return self._e57_pcd_cache
+            except ImportError:
+                raise RuntimeError(
+                    'pye57 or open3d is required to read E57 files.\n'
+                    '  pip install pye57   (recommended)\n'
+                    '  pip install open3d  (fallback)'
+                )
+
+    # ------------------------------------------------------------------
+
+    def _read_anchor_names(self) -> list[str]:
+        """Parse anchor names from anchors.txt."""
+        path = self.root / 'anchors' / 'anchors.txt'
+        if not path.exists():
+            return []
+        names = []
+        in_data = False
+        for line in path.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+            if not in_data:
+                in_data = True   # first non-comment line is version number
+                continue
+            parts = stripped.split()
+            if len(parts) >= 2:
+                name = parts[1].strip('"')
+                if name not in names:
+                    names.append(name)
+        return names

--- a/rawkee/tools/lidar/export.py
+++ b/rawkee/tools/lidar/export.py
@@ -1,0 +1,635 @@
+"""Export functions for scan mesh and Gaussian splat pipelines.
+
+Mesh formats  : x3d (default) | x3dv | x3dj | obj | glb
+Splat formats : x3d (default) | x3dv | x3dj | ply | splat | glb
+"""
+from __future__ import annotations
+import json
+import struct as _s
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def export_mesh(
+    mesh,
+    atlas: np.ndarray,
+    spec_cubemap_paths: dict[str, Path],
+    diff_cubemap_paths: dict[str, Path],
+    output_dir: Path,
+    stem: str,
+    fmt: str = 'x3d',
+    equirect_spec_path: Optional[Path] = None,
+    equirect_diff_path: Optional[Path] = None,
+    geo_origin: Optional[tuple] = None,
+) -> Path:
+    """Export a textured polygon mesh in the requested format.
+
+    Parameters
+    ----------
+    geo_origin: (easting, northing, height, epsg) from ScanDataset.geo_origin(), or None.
+    """
+    fmt = fmt.lower().lstrip('.')
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if fmt in ('x3d', 'x3dv', 'x3dj'):
+        return _export_mesh_x3d(
+            mesh, atlas, spec_cubemap_paths, diff_cubemap_paths,
+            equirect_spec_path, equirect_diff_path,
+            output_dir, stem, fmt, geo_origin,
+        )
+    elif fmt == 'obj':
+        return _export_mesh_obj(mesh, atlas, output_dir, stem)
+    elif fmt == 'glb':
+        return _export_mesh_glb(mesh, atlas, output_dir, stem)
+    else:
+        raise ValueError(f'Unknown mesh export format: {fmt!r}')
+
+
+def export_splat(
+    gaussians: dict[str, 'torch.Tensor'],
+    output_dir: Path,
+    stem: str,
+    fmt: str = 'x3d',
+    sh_degree: int = 3,
+    geo_origin: Optional[tuple] = None,
+) -> Path:
+    """Export trained Gaussian splat parameters in the requested format.
+
+    Parameters
+    ----------
+    geo_origin: (easting, northing, height, epsg) from ScanDataset.geo_origin(), or None.
+    """
+    fmt = fmt.lower().lstrip('.')
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Convert tensors to numpy once
+    params = {k: v.cpu().numpy() for k, v in gaussians.items()}
+    means      = params['means']                        # (N, 3)
+    scales     = np.exp(params['log_scales'])           # (N, 3)
+    quats_wxyz = params['quats']                        # (N, 4) w,x,y,z
+    sh_coeffs  = params['sh_coeffs']                   # (N, n_sh, 3)
+    opacities  = 1.0 / (1.0 + np.exp(-params['opacities']))  # (N,) sigmoid
+
+    if fmt in ('x3d', 'x3dv', 'x3dj'):
+        return _export_splat_x3d(
+            means, scales, quats_wxyz, sh_coeffs, opacities,
+            output_dir, stem, fmt, sh_degree, geo_origin,
+        )
+    elif fmt == 'ply':
+        return _export_splat_ply(
+            means, scales, quats_wxyz, sh_coeffs, params['opacities'],
+            params['log_scales'], output_dir, stem,
+        )
+    elif fmt == 'splat':
+        return _export_splat_binary(
+            means, scales, quats_wxyz, sh_coeffs, opacities,
+            output_dir, stem,
+        )
+    elif fmt == 'glb':
+        return _export_splat_glb(
+            means, scales, quats_wxyz, sh_coeffs, opacities,
+            output_dir, stem, sh_degree,
+        )
+    else:
+        raise ValueError(f'Unknown splat export format: {fmt!r}')
+
+
+# ---------------------------------------------------------------------------
+# Geospatial helpers
+# ---------------------------------------------------------------------------
+
+def _epsg_to_geo_system(epsg: int) -> list[str]:
+    """Return X3D geoSystem MFString for a UTM EPSG code."""
+    if 32601 <= epsg <= 32660:
+        return ['UTM', f'Z{epsg - 32600}', 'N']
+    if 32701 <= epsg <= 32760:
+        return ['UTM', f'Z{epsg - 32700}', 'S']
+    return ['GD', 'WE']   # fall back to geodetic for non-UTM EPSG
+
+
+# ---------------------------------------------------------------------------
+# Mesh — X3D / X3DV / X3DJ
+# ---------------------------------------------------------------------------
+
+def _make_env_ktx2(equirect_path: Optional[Path], face_paths: dict[str, Path],
+                   out_dir: Path, label: str) -> Optional[Path]:
+    """Convert equirectangular HDR to KTX2 for ImageCubeMapTexture.
+
+    Falls back to listing the first face HDR path when conversion is unavailable.
+    """
+    ktx2_path = out_dir / f'{label}.ktx2'
+    if ktx2_path.exists():
+        return ktx2_path
+    if equirect_path and equirect_path.exists():
+        try:
+            from rawkee.tools.RKTools import RKTools
+            RKTools.hdri2ktx2(str(equirect_path), str(ktx2_path))
+            log.info('KTX2 cubemap → %s', ktx2_path)
+            return ktx2_path
+        except Exception as exc:
+            log.warning('KTX2 conversion failed (%s) — falling back to HDR', exc)
+    # Fall back: return the px (positive-x) face; ImageCubeMapTexture will
+    # only get one face but is still valid X3D.
+    return face_paths.get('px') or next(iter(face_paths.values()), None)
+
+
+def _export_mesh_x3d(
+    mesh, atlas: np.ndarray,
+    spec_paths: dict[str, Path],
+    diff_paths: dict[str, Path],
+    equirect_spec: Optional[Path],
+    equirect_diff: Optional[Path],
+    output_dir: Path, stem: str, fmt: str,
+    geo_origin: Optional[tuple] = None,
+) -> Path:
+    try:
+        import open3d as o3d
+    except ImportError:
+        raise RuntimeError('open3d required: pip install open3d')
+    try:
+        import imageio.v3 as iio
+    except ImportError:
+        raise RuntimeError('imageio required: pip install imageio')
+
+    from rawkee.io.RKx3d import (
+        X3D, Scene, Shape, Appearance, PhysicalMaterial,
+        ImageTexture, IndexedTriangleSet, Coordinate, TextureCoordinate,
+        EnvironmentLight, ImageCubeMapTexture, GeoLocation,
+    )
+    from rawkee.io.RKSceneTraversal import RKSceneTraversal
+
+    # --- Save atlas PNG ---
+    atlas_uint8 = (np.clip(atlas, 0, 1) * 255).astype(np.uint8)
+    atlas_path = output_dir / f'{stem}_atlas.png'
+    iio.imwrite(str(atlas_path), atlas_uint8)
+    log.info('Atlas → %s', atlas_path)
+
+    # --- Prepare KTX2 / HDR env maps ---
+    spec_env_path = _make_env_ktx2(equirect_spec, spec_paths, output_dir, f'{stem}_envmap_spec')
+    diff_env_path = _make_env_ktx2(equirect_diff, diff_paths, output_dir, f'{stem}_envmap_diff')
+
+    # --- Mesh geometry ---
+    verts = np.asarray(mesh.vertices)           # (V, 3)
+    tris  = np.asarray(mesh.triangles)          # (T, 3) int
+
+    # UVs from triangle_uvs if present, else planar
+    if mesh.has_triangle_uvs():
+        uvs = np.asarray(mesh.triangle_uvs)     # (T*3, 2)
+    else:
+        uvs = np.zeros((len(tris) * 3, 2), dtype=np.float32)
+
+    # Flatten index list: each row of tris → 3 consecutive indices
+    idx_flat = tris.ravel().tolist()
+
+    # --- Build X3D scene ---
+    trv = RKSceneTraversal()
+    x3d_doc   = trv.getX3DObject()
+    x3d_scene = trv.getSceneObject()
+    x3d_doc.Scene = x3d_scene
+
+    # EnvironmentLight
+    spec_url = [str(spec_env_path.name)] if spec_env_path else []
+    diff_url = [str(diff_env_path.name)] if diff_env_path else []
+    env_light = EnvironmentLight(
+        intensity=1.0,
+        specularTexture=ImageCubeMapTexture(url=spec_url, DEF='EnvSpec') if spec_url else None,
+        diffuseTexture =ImageCubeMapTexture(url=diff_url, DEF='EnvDiff') if diff_url else None,
+        global_=True,
+        DEF='EnvLight',
+    )
+    x3d_scene.children.append(env_light)
+
+    # PhysicalMaterial with baked texture
+    mat = PhysicalMaterial(
+        baseColor=(1.0, 1.0, 1.0),
+        metallic=0.0,
+        roughness=0.6,
+        baseTexture=ImageTexture(url=[str(atlas_path.name)], DEF='AtlasTex'),
+        DEF='ScanMat',
+    )
+    appearance = Appearance(material=mat, DEF='ScanApp')
+
+    # Geometry
+    coord     = Coordinate(point=verts.tolist(), DEF='MeshCoord')
+    tex_coord = TextureCoordinate(point=uvs.tolist(), DEF='MeshUV')
+    geom = IndexedTriangleSet(
+        index=idx_flat,
+        coord=coord,
+        texCoord=tex_coord,
+        solid=False,
+        DEF='MeshGeom',
+    )
+
+    shape = Shape(appearance=appearance, geometry=geom, DEF='ScanShape')
+
+    # Wrap in GeoLocation when georeferenced anchor data is available
+    if geo_origin is not None:
+        e, n, h, epsg = geo_origin
+        geo_node = GeoLocation(
+            geoCoords=(e, n, h),
+            geoSystem=_epsg_to_geo_system(epsg),
+            children=[shape],
+            DEF='GeoScanLocation',
+        )
+        x3d_scene.children.append(geo_node)
+    else:
+        x3d_scene.children.append(shape)
+
+    # Write
+    out_path = output_dir / f'{stem}.{fmt}'
+    trv.x3d2disk(x3d_doc, str(out_path), fmt)
+    log.info('Mesh X3D → %s', out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Mesh — OBJ
+# ---------------------------------------------------------------------------
+
+def _export_mesh_obj(mesh, atlas: np.ndarray, output_dir: Path, stem: str) -> Path:
+    try:
+        import open3d as o3d
+        import imageio.v3 as iio
+    except ImportError:
+        raise RuntimeError('open3d and imageio required')
+
+    atlas_uint8 = (np.clip(atlas, 0, 1) * 255).astype(np.uint8)
+    atlas_path = output_dir / f'{stem}_atlas.png'
+    iio.imwrite(str(atlas_path), atlas_uint8)
+
+    # Write MTL
+    mtl_path = output_dir / f'{stem}.mtl'
+    mtl_path.write_text(
+        f'newmtl ScanMaterial\n'
+        f'map_Kd {atlas_path.name}\n'
+        f'Ns 10.0\nKa 0.1 0.1 0.1\nKd 0.9 0.9 0.9\nKs 0.0 0.0 0.0\nd 1.0\n'
+    )
+
+    out_path = output_dir / f'{stem}.obj'
+    o3d.io.write_triangle_mesh(
+        str(out_path), mesh,
+        write_ascii=True, write_vertex_normals=True, write_vertex_colors=False,
+    )
+    # Inject mtllib reference
+    obj_text = out_path.read_text()
+    if 'mtllib' not in obj_text:
+        out_path.write_text(f'mtllib {mtl_path.name}\n' + obj_text)
+    log.info('Mesh OBJ → %s', out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Mesh — GLB
+# ---------------------------------------------------------------------------
+
+def _export_mesh_glb(mesh, atlas: np.ndarray, output_dir: Path, stem: str) -> Path:
+    try:
+        import open3d as o3d
+        import imageio.v3 as iio
+    except ImportError:
+        raise RuntimeError('open3d and imageio required')
+
+    atlas_uint8 = (np.clip(atlas, 0, 1) * 255).astype(np.uint8)
+    atlas_path = output_dir / f'{stem}_atlas.png'
+    iio.imwrite(str(atlas_path), atlas_uint8)
+
+    out_path = output_dir / f'{stem}.glb'
+    o3d.io.write_triangle_mesh(str(out_path), mesh)
+    log.info('Mesh GLB → %s', out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Splat — X3D / X3DV / X3DJ
+# ---------------------------------------------------------------------------
+
+def _sh_flat(sh_coeffs: np.ndarray, degree: int, coef_idx: int) -> list:
+    """Extract one SH coefficient vector (N, 3) and return as flat list of (x,y,z)."""
+    n_sh = (degree + 1) ** 2
+    if coef_idx >= sh_coeffs.shape[1]:
+        return []
+    v = sh_coeffs[:, coef_idx, :]      # (N, 3)
+    return [tuple(row.tolist()) for row in v]
+
+
+def _export_splat_x3d(
+    means: np.ndarray, scales: np.ndarray,
+    quats_wxyz: np.ndarray, sh_coeffs: np.ndarray, opacities: np.ndarray,
+    output_dir: Path, stem: str, fmt: str, sh_degree: int,
+    geo_origin: Optional[tuple] = None,
+) -> Path:
+    from rawkee.io.RKx3d import X3D, Scene, GaussianSplats, GeoTransform
+    from rawkee.io.RKSceneTraversal import RKSceneTraversal
+
+    N = len(means)
+    log.info('Building X3D GaussianSplats node  N=%d  sh_degree=%d', N, sh_degree)
+
+    # Quaternion order: training stores (w,x,y,z); X3D spec says (x,y,z,w)
+    quats_xyzw = np.roll(quats_wxyz, -1, axis=1)   # (N,4) x,y,z,w
+
+    def _mf3(arr):
+        return [tuple(r.tolist()) for r in arr]
+
+    def _sh(ci):
+        return _sh_flat(sh_coeffs, sh_degree, ci)
+
+    gs_kwargs: dict = dict(
+        positions   = _mf3(means),
+        orientations= [tuple(r.tolist()) for r in quats_xyzw],
+        scales      = _mf3(scales),
+        opacities   = opacities.tolist(),
+        sphericalHarmonicsDegree0Coef0 = _sh(0),
+        DEF='ScanSplats',
+    )
+    if sh_degree >= 1:
+        gs_kwargs.update(
+            sphericalHarmonicsDegree1Coef0=_sh(1),
+            sphericalHarmonicsDegree1Coef1=_sh(2),
+            sphericalHarmonicsDegree1Coef2=_sh(3),
+        )
+    if sh_degree >= 2:
+        gs_kwargs.update(
+            sphericalHarmonicsDegree2Coef0=_sh(4),
+            sphericalHarmonicsDegree2Coef1=_sh(5),
+            sphericalHarmonicsDegree2Coef2=_sh(6),
+            sphericalHarmonicsDegree2Coef3=_sh(7),
+            sphericalHarmonicsDegree2Coef4=_sh(8),
+        )
+    if sh_degree >= 3:
+        gs_kwargs.update(
+            sphericalHarmonicsDegree3Coef0=_sh(9),
+            sphericalHarmonicsDegree3Coef1=_sh(10),
+            sphericalHarmonicsDegree3Coef2=_sh(11),
+            sphericalHarmonicsDegree3Coef3=_sh(12),
+            sphericalHarmonicsDegree3Coef4=_sh(13),
+            sphericalHarmonicsDegree3Coef5=_sh(14),
+            sphericalHarmonicsDegree3Coef6=_sh(15),
+        )
+
+    gs_node = GaussianSplats(**gs_kwargs)
+
+    trv = RKSceneTraversal()
+    x3d_doc   = trv.getX3DObject()
+    x3d_scene = trv.getSceneObject()
+    x3d_doc.Scene = x3d_scene
+
+    # Wrap in GeoTransform when georeferenced anchor data is available
+    if geo_origin is not None:
+        e, n, h, epsg = geo_origin
+        geo_node = GeoTransform(
+            geoCenter=(e, n, h),
+            geoSystem=_epsg_to_geo_system(epsg),
+            children=[gs_node],
+            DEF='GeoSplatTransform',
+        )
+        x3d_scene.children.append(geo_node)
+    else:
+        x3d_scene.children.append(gs_node)
+
+    out_path = output_dir / f'{stem}.{fmt}'
+    trv.x3d2disk(x3d_doc, str(out_path), fmt)
+    log.info('Splat X3D → %s', out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Splat — PLY (3DGS standard format)
+# ---------------------------------------------------------------------------
+
+def _export_splat_ply(
+    means: np.ndarray, scales: np.ndarray,
+    quats_wxyz: np.ndarray, sh_coeffs: np.ndarray,
+    raw_opacities: np.ndarray, log_scales: np.ndarray,
+    output_dir: Path, stem: str,
+) -> Path:
+    """Write a 3DGS-compatible PLY file with pre-activation (raw) parameter values."""
+    N = len(means)
+    n_sh = sh_coeffs.shape[1]     # number of SH coefficients per channel
+    n_rest = max(0, n_sh - 1)     # DC is f_dc_*, rest are f_rest_*
+
+    # Build per-vertex property arrays (pre-activation, matching 3DGS convention)
+    dc    = sh_coeffs[:, 0, :]                                        # (N, 3)
+    rest  = sh_coeffs[:, 1:, :].reshape(N, -1)                       # (N, n_rest*3)
+
+    out_path = output_dir / f'{stem}.ply'
+    with open(out_path, 'wb') as f:
+        # --- PLY header ---
+        props = (
+            ['x', 'y', 'z', 'nx', 'ny', 'nz']
+            + [f'f_dc_{i}'   for i in range(3)]
+            + [f'f_rest_{i}' for i in range(n_rest * 3)]
+            + ['opacity']
+            + [f'scale_{i}'  for i in range(3)]
+            + ['rot_0', 'rot_1', 'rot_2', 'rot_3']   # w,x,y,z
+        )
+        header = (
+            'ply\nformat binary_little_endian 1.0\n'
+            f'element vertex {N}\n'
+        )
+        for p in props:
+            header += f'property float {p}\n'
+        header += 'end_header\n'
+        f.write(header.encode())
+
+        # --- Vertex data (all float32) ---
+        normals = np.zeros((N, 3), dtype=np.float32)
+        row = np.concatenate([
+            means.astype(np.float32),
+            normals,
+            dc.astype(np.float32),
+            rest.astype(np.float32),
+            raw_opacities.astype(np.float32).reshape(N, 1),
+            log_scales.astype(np.float32),
+            quats_wxyz.astype(np.float32),              # w,x,y,z per 3DGS convention
+        ], axis=1)
+        f.write(row.tobytes())
+
+    log.info('Splat PLY → %s  (%d Gaussians, %d SH coeffs)', out_path, N, n_sh)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Splat — binary .splat (Luma AI / web viewer format)
+# ---------------------------------------------------------------------------
+
+def _export_splat_binary(
+    means: np.ndarray, scales: np.ndarray,
+    quats_wxyz: np.ndarray, sh_coeffs: np.ndarray, opacities: np.ndarray,
+    output_dir: Path, stem: str,
+) -> Path:
+    """Write the packed 32-byte-per-splat binary .splat format.
+
+    Layout per splat:
+      bytes  0–11 : x, y, z  (float32 × 3)
+      bytes 12–23 : sx, sy, sz (float32 × 3, linear scale)
+      bytes 24–27 : r, g, b, alpha (uint8; colour from DC SH, opacity → sigmoid)
+      bytes 28–31 : qx, qy, qz, qw (uint8; normalised quaternion → [0,255])
+    """
+    N = len(means)
+
+    # Colour from DC SH coefficient (SH DC → linear RGB via the standard SH basis)
+    sh0 = 0.28209479177387814   # 1 / (2 * sqrt(pi))
+    dc  = sh_coeffs[:, 0, :]                            # (N, 3)
+    rgb_lin = (dc * sh0 + 0.5).clip(0.0, 1.0)          # (N, 3)
+    r = (rgb_lin[:, 0] * 255).astype(np.uint8)
+    g = (rgb_lin[:, 1] * 255).astype(np.uint8)
+    b = (rgb_lin[:, 2] * 255).astype(np.uint8)
+    a = (opacities * 255).astype(np.uint8)
+
+    # Quaternion (w,x,y,z) → uint8 in range [0,255]
+    # Normalise then map [-1,1] → [0,255]
+    q = quats_wxyz.astype(np.float32)
+    norms = np.linalg.norm(q, axis=1, keepdims=True).clip(min=1e-8)
+    q /= norms
+    # Pack as x,y,z,w
+    qx = ((q[:, 1] * 0.5 + 0.5) * 255).clip(0, 255).astype(np.uint8)
+    qy = ((q[:, 2] * 0.5 + 0.5) * 255).clip(0, 255).astype(np.uint8)
+    qz = ((q[:, 3] * 0.5 + 0.5) * 255).clip(0, 255).astype(np.uint8)
+    qw = ((q[:, 0] * 0.5 + 0.5) * 255).clip(0, 255).astype(np.uint8)
+
+    # Sort by distance from scene centroid (improves web renderer alpha blending)
+    centroid = means.mean(axis=0)
+    order = np.argsort(-np.linalg.norm(means - centroid, axis=1))
+
+    # Vectorized write using a numpy structured record array
+    rec_dtype = np.dtype([
+        ('pos',   '<f4', (3,)),
+        ('scale', '<f4', (3,)),
+        ('rgba',  'u1',  (4,)),
+        ('rot',   'u1',  (4,)),
+    ])
+    records = np.empty(N, dtype=rec_dtype)
+    records['pos']   = means[order].astype('<f4')
+    records['scale'] = scales[order].astype('<f4')
+    records['rgba']  = np.stack([r[order], g[order], b[order], a[order]], axis=1)
+    records['rot']   = np.stack([qx[order], qy[order], qz[order], qw[order]], axis=1)
+
+    out_path = output_dir / f'{stem}.splat'
+    out_path.write_bytes(records.tobytes())
+
+    log.info('Splat binary → %s  (%d Gaussians)', out_path, N)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Splat — GLB (KHR_gaussian_splatting extension)
+# ---------------------------------------------------------------------------
+
+def _export_splat_glb(
+    means: np.ndarray, scales: np.ndarray,
+    quats_wxyz: np.ndarray, sh_coeffs: np.ndarray, opacities: np.ndarray,
+    output_dir: Path, stem: str, sh_degree: int,
+) -> Path:
+    """Write a GLB using the KHR_gaussian_splatting glTF extension.
+
+    The extension stores splats as a point-cloud mesh primitive with custom
+    accessor attributes following the KHR_gaussian_splatting draft spec.
+    """
+    N = len(means)
+
+    # --- Build binary buffer ---
+    # POSITION (vec3 float32)
+    pos_bytes  = means.astype('<f4').tobytes()
+    # ROTATION (vec4 float32, x,y,z,w)
+    rot_xyzw   = np.roll(quats_wxyz, -1, axis=1).astype('<f4')
+    rot_bytes  = rot_xyzw.tobytes()
+    # SCALE (vec3 float32)
+    scale_bytes = scales.astype('<f4').tobytes()
+    # OPACITY (scalar float32)
+    op_bytes   = opacities.astype('<f4').tobytes()
+    # COLOR (DC SH → linear RGB, vec3 float32)
+    sh0        = 0.28209479177387814
+    dc_rgb     = (sh_coeffs[:, 0, :] * sh0 + 0.5).clip(0, 1).astype('<f4')
+    col_bytes  = dc_rgb.tobytes()
+
+    buffer_data = pos_bytes + rot_bytes + scale_bytes + op_bytes + col_bytes
+    buf_len  = len(buffer_data)
+
+    def _bv(offset, length, target=None):
+        bv = {'buffer': 0, 'byteOffset': offset, 'byteLength': length}
+        if target is not None:
+            bv['target'] = target
+        return bv
+
+    def _acc(bv_idx, count, comp_type, acc_type, min_v=None, max_v=None):
+        a = {'bufferView': bv_idx, 'componentType': comp_type,
+             'count': count, 'type': acc_type}
+        if min_v is not None:
+            a['min'] = min_v
+            a['max'] = max_v
+        return a
+
+    FLOAT = 5126  # GL_FLOAT
+
+    off = 0
+    bvs, accs = [], []
+    attr = {}
+
+    for name, raw, atype in [
+        ('POSITION',  pos_bytes,   'VEC3'),
+        ('_ROTATION', rot_bytes,   'VEC4'),
+        ('_SCALE',    scale_bytes, 'VEC3'),
+        ('_OPACITY',  op_bytes,    'SCALAR'),
+        ('_COLOR',    col_bytes,   'VEC3'),
+    ]:
+        bvs.append(_bv(off, len(raw)))
+        mn, mx = None, None
+        if name == 'POSITION':
+            mn = means.min(axis=0).tolist()
+            mx = means.max(axis=0).tolist()
+        elif name == '_OPACITY':
+            mn = [float(opacities.min())]
+            mx = [float(opacities.max())]
+        accs.append(_acc(len(bvs) - 1, N, FLOAT, atype, mn, mx))
+        attr[name] = len(accs) - 1
+        off += len(raw)
+
+    gltf = {
+        'asset': {'version': '2.0', 'generator': 'rawkee NavVis splat pipeline'},
+        'extensionsUsed': ['KHR_gaussian_splatting'],
+        'extensionsRequired': ['KHR_gaussian_splatting'],
+        'scene': 0,
+        'scenes': [{'nodes': [0]}],
+        'nodes': [{'mesh': 0}],
+        'meshes': [{
+            'name': stem,
+            'primitives': [{
+                'attributes': attr,
+                'mode': 0,   # POINTS
+                'extensions': {'KHR_gaussian_splatting': {}},
+            }],
+        }],
+        'accessors': accs,
+        'bufferViews': bvs,
+        'buffers': [{'byteLength': buf_len}],
+    }
+
+    json_bytes = json.dumps(gltf, separators=(',', ':')).encode('utf-8')
+    # Pad to 4-byte boundary
+    if len(json_bytes) % 4:
+        json_bytes += b' ' * (4 - len(json_bytes) % 4)
+    if len(buffer_data) % 4:
+        buffer_data += b'\x00' * (4 - len(buffer_data) % 4)
+
+    glb_len = 12 + 8 + len(json_bytes) + 8 + len(buffer_data)
+    out_path = output_dir / f'{stem}.glb'
+    with open(out_path, 'wb') as f:
+        f.write(_s.pack('<III', 0x46546C67, 2, glb_len))          # GLB header
+        f.write(_s.pack('<II', len(json_bytes), 0x4E4F534A))       # JSON chunk header
+        f.write(json_bytes)
+        f.write(_s.pack('<II', len(buffer_data), 0x004E4942))      # BIN chunk header
+        f.write(buffer_data)
+
+    log.info('Splat GLB → %s  (%d Gaussians)', out_path, N)
+    return out_path

--- a/rawkee/tools/lidar/hdri.py
+++ b/rawkee/tools/lidar/hdri.py
@@ -1,0 +1,355 @@
+"""GPU-accelerated HDRI panorama generator from fisheye scan cameras.
+
+Pipeline
+--------
+1. Load 4 DNG images as linear float32 HDR arrays (rawpy, CPU).
+2. Build equirectangular ray grid on GPU (PyTorch).
+3. Rotate rays to each camera frame using the frame pose + per-camera extrinsics.
+4. Project rays via OCamModel on GPU (polynomial + affine, fully vectorised).
+5. Bilinear sample each camera image on GPU (F.grid_sample).
+6. Blend: weight by cosine of angle from optical axis; fill uncovered pixels with
+   a neutral sky/floor gradient.
+7. Optionally convolve a downsampled copy for the diffuse irradiance map.
+8. Save equirectangular .hdr and cubemap faces for X3D ImageCubeMapTexture.
+"""
+from __future__ import annotations
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+try:
+    import rawpy
+    _RAWPY = True
+except ImportError:
+    _RAWPY = False
+
+try:
+    import imageio.v3 as iio
+    _IMAGEIO = True
+except ImportError:
+    _IMAGEIO = False
+
+try:
+    import torch
+    import torch.nn.functional as F
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+from .dataset import ScanDataset, CameraModel
+
+log = logging.getLogger(__name__)
+
+
+def _warn_no_gpu(require: bool = False) -> None:
+    """Print actionable GPU diagnostic and optionally raise."""
+    lines = ['', 'WARNING: No CUDA GPU is available for the HDRI generator.']
+    if _TORCH:
+        lines.append(f'  PyTorch version : {torch.__version__}')
+        lines.append(f'  PyTorch CUDA    : {torch.version.cuda or "not compiled"}')
+    else:
+        lines.append('  PyTorch is not installed.')
+    lines += [
+        '  Suggested fixes:',
+        '    1. Ensure your NVIDIA driver is installed (>=525 for CUDA 12.x).',
+        '    2. Reinstall PyTorch for your CUDA version:',
+        '         pip install torch --index-url https://download.pytorch.org/whl/cu124',
+        '    3. For Grace/Hopper or DGX Spark use the NGC PyTorch container.',
+        '    4. Quick check: python -c "import torch; print(torch.cuda.is_available())"',
+        '  Continuing on CPU — HDRI generation will be slow.',
+        '',
+    ]
+    print('\n'.join(lines), flush=True)
+    if require:
+        raise RuntimeError('A CUDA GPU is required but none is available.')
+
+# Neutral fill: warm grey for the floor hemisphere, cool grey for the sky
+_FLOOR_RGB = np.array([0.18, 0.16, 0.14], dtype=np.float32)
+_SKY_RGB   = np.array([0.20, 0.22, 0.26], dtype=np.float32)
+
+CUBEMAP_FACES = ['px', 'nx', 'py', 'ny', 'pz', 'nz']
+_FACE_FORWARD = {
+    'px': np.array([ 1,  0,  0]),
+    'nx': np.array([-1,  0,  0]),
+    'py': np.array([ 0,  1,  0]),
+    'ny': np.array([ 0, -1,  0]),
+    'pz': np.array([ 0,  0,  1]),
+    'nz': np.array([ 0,  0, -1]),
+}
+_FACE_UP = {
+    'px': np.array([0, -1, 0]),
+    'nx': np.array([0, -1, 0]),
+    'py': np.array([0,  0, 1]),
+    'ny': np.array([0,  0,-1]),
+    'pz': np.array([0, -1, 0]),
+    'nz': np.array([0, -1, 0]),
+}
+
+
+def _get_device(prefer_cuda: bool = True) -> 'torch.device':
+    if _TORCH and prefer_cuda and torch.cuda.is_available():
+        dev = torch.device('cuda')
+        p = torch.cuda.get_device_properties(0)
+        log.info('GPU: %s  %d GB  sm_%d%d', p.name, p.total_memory >> 30, p.major, p.minor)
+        if p.major >= 9:
+            torch.cuda.set_per_process_memory_fraction(0.90)
+            log.info('Unified-memory architecture detected — memory fraction set to 90%%')
+        return dev
+    _warn_no_gpu(require=False)
+    return torch.device('cpu')
+
+
+def _load_image_hdr(path: Path) -> np.ndarray:
+    """Load any image format as linear float32 HDR (H, W, 3).
+
+    DNG/RAW: decoded via rawpy (16-bit, no gamma).
+    JPEG/TIFF/PNG: decoded via imageio, then sRGB inverse-gamma applied.
+    """
+    if path.suffix.lower() in ('.dng', '.nef', '.cr2', '.arw', '.raw', '.rw2'):
+        if not _RAWPY:
+            raise RuntimeError('rawpy is required for raw images: pip install rawpy')
+        with rawpy.imread(str(path)) as raw:
+            rgb = raw.postprocess(
+                output_bps=16, no_auto_bright=True,
+                use_camera_wb=True, gamma=(1, 1),
+                output_color=rawpy.ColorSpace.sRGB,
+            )
+        return rgb.astype(np.float32) / 65535.0
+    else:
+        if not _IMAGEIO:
+            raise RuntimeError('imageio is required: pip install imageio')
+        img = iio.imread(str(path))
+        if img.ndim == 2:
+            img = np.stack([img, img, img], axis=-1)
+        elif img.shape[2] == 4:
+            img = img[:, :, :3]
+        f = img.astype(np.float32) / 255.0
+        # sRGB → linear
+        return np.where(f <= 0.04045, f / 12.92, ((f + 0.055) / 1.055) ** 2.4)
+
+
+# Keep legacy name as alias
+_load_dng_hdr = _load_image_hdr
+
+
+def _build_equirect_rays(width: int, height: int, device: 'torch.device') -> 'torch.Tensor':
+    """Return (H, W, 3) unit directions for an equirectangular grid.
+
+    Convention: X=East (right), Y=North (forward), Z=Up.
+    Longitude ∈ [-π, π], Latitude ∈ [π/2, -π/2] (top row = zenith).
+    """
+    lon = torch.linspace(-math.pi, math.pi,  width,  device=device)
+    lat = torch.linspace(math.pi / 2, -math.pi / 2, height, device=device)
+    lat_g, lon_g = torch.meshgrid(lat, lon, indexing='ij')  # (H, W)
+    cos_lat = torch.cos(lat_g)
+    x = cos_lat * torch.cos(lon_g)
+    y = cos_lat * torch.sin(lon_g)
+    z = torch.sin(lat_g)
+    return torch.stack([x, y, z], dim=-1)   # (H, W, 3)
+
+
+def _neutral_fill(height: int, width: int) -> np.ndarray:
+    """Generate a neutral sky-to-floor gradient as fallback for uncovered pixels."""
+    t    = np.linspace(0.0, 1.0, height, dtype=np.float32)[:, None, None]
+    fill = (1.0 - t) * np.array(_SKY_RGB,   dtype=np.float32) \
+               + t   * np.array(_FLOOR_RGB, dtype=np.float32)
+    return np.broadcast_to(fill, (height, width, 3)).copy()
+
+
+def _equirect_to_cubemap_face(
+    equirect: np.ndarray, face: str, face_size: int
+) -> np.ndarray:
+    """Sample equirectangular image into a single cubemap face."""
+    H, W = equirect.shape[:2]
+    fwd = _FACE_FORWARD[face].astype(np.float64)
+    up  = _FACE_UP[face].astype(np.float64)
+    right = np.cross(fwd, up)
+
+    lin = np.linspace(-1, 1, face_size)
+    gx, gy = np.meshgrid(lin, lin)              # (F, F)
+    # Ray direction for each pixel on this face
+    dirs = (fwd[None, None, :]
+            + right[None, None, :] * gx[:, :, None]
+            + up[None, None, :]    * gy[:, :, None])
+    norms = np.linalg.norm(dirs, axis=-1, keepdims=True)
+    dirs /= np.maximum(norms, 1e-8)
+
+    lon = np.arctan2(dirs[..., 1], dirs[..., 0])           # [-π, π]
+    lat = np.arcsin(np.clip(dirs[..., 2], -1, 1))           # [-π/2, π/2]
+    u = ((lon / math.pi + 1.0) / 2.0 * (W - 1)).astype(np.float32)
+    v = ((1.0 - (lat / (math.pi / 2) + 1.0) / 2.0) * (H - 1)).astype(np.float32)
+
+    # Bilinear sampling
+    u0 = np.clip(np.floor(u).astype(int), 0, W - 2)
+    v0 = np.clip(np.floor(v).astype(int), 0, H - 2)
+    fu = (u - u0)[..., None]
+    fv = (v - v0)[..., None]
+    face_img = (
+        equirect[v0,     u0    ] * (1 - fu) * (1 - fv) +
+        equirect[v0,     u0 + 1] *      fu  * (1 - fv) +
+        equirect[v0 + 1, u0    ] * (1 - fu) *      fv  +
+        equirect[v0 + 1, u0 + 1] *      fu  *      fv
+    )
+    return face_img.astype(np.float32)
+
+
+class HDRIGenerator:
+    """Generate georeferenced equirectangular HDRI from a NavVis capture frame."""
+
+    def __init__(
+        self,
+        envmap_width: int = 4096,
+        envmap_height: int = 2048,
+        cubemap_size: int = 1024,
+        diffuse_blur_passes: int = 4,
+        prefer_cuda: bool = True,
+    ) -> None:
+        self.envmap_width  = envmap_width
+        self.envmap_height = envmap_height
+        self.cubemap_size  = cubemap_size
+        self.diffuse_blur_passes = diffuse_blur_passes
+        self.device = _get_device(prefer_cuda)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate(
+        self,
+        dataset: ScanDataset,
+        frame_idx: Optional[int] = None,
+    ) -> np.ndarray:
+        """Return an equirectangular HDR float32 image (H, W, 3).
+
+        Uses the fisheye cameras at `frame_idx` (defaults to the dataset's
+        central valid frame) to fill the sphere. Missing sectors are blended
+        with a neutral sky/floor gradient.
+        """
+        if frame_idx is None:
+            frame_idx = dataset.select_reference_frame()
+
+        log.info('Generating HDRI from frame %d / %d', frame_idx, dataset.num_frames)
+
+        head_pos, R_head = dataset.frame_transform(frame_idx)
+
+        # Load DNG images as HDR float32 tensors on GPU
+        images_gpu = []
+        for ci, cam in enumerate(dataset.cameras):
+            p = dataset.dng_path(frame_idx, ci)
+            if not p.exists():
+                p = dataset.image_path(frame_idx, ci)
+            if not p.exists():
+                log.warning('Missing DNG %s — camera %d skipped', p.name, ci)
+                images_gpu.append(None)
+                continue
+            img_np = _load_image_hdr(p)
+            # grid_sample expects (1, C, H, W)
+            t = torch.from_numpy(img_np).to(self.device).permute(2, 0, 1).unsqueeze(0)
+            images_gpu.append(t)
+            log.debug('Loaded cam%d  %s', ci, p.name)
+
+        # Build equirectangular ray grid
+        rays = _build_equirect_rays(
+            self.envmap_width, self.envmap_height, self.device
+        )  # (H, W, 3)
+
+        # Rotate world rays into camera-head frame (R_head^T maps world → head)
+        R_head_t = torch.tensor(R_head.T, device=self.device, dtype=torch.float32)
+        rays_head = rays @ R_head_t  # (H, W, 3)
+
+        accum  = torch.zeros(self.envmap_height, self.envmap_width, 3, device=self.device)
+        weight = torch.zeros(self.envmap_height, self.envmap_width,    device=self.device)
+
+        for ci, cam in enumerate(dataset.cameras):
+            if images_gpu[ci] is None:
+                continue
+            # Rotate from head frame to this camera's frame (R_cam.T maps head → cam)
+            R_cam_t = torch.tensor(cam.R.T, device=self.device, dtype=torch.float32)
+            rays_cam = (rays_head - torch.tensor(cam.position, device=self.device, dtype=torch.float32)) @ R_cam_t
+            # (We only rotate direction for unprojection; position offset is negligible vs scene scale)
+            rays_cam_dir = rays_head @ R_cam_t   # (H, W, 3)
+
+            uvs, mask = cam.ocam.project_gpu(rays_cam_dir, self.device)  # (H,W,2), (H,W)
+
+            # Cosine weight: prefer rays closer to optical axis (z < 0, negate for cos)
+            cos_w = (-rays_cam_dir[..., 2]).clamp(min=0.0)   # (H, W)
+
+            # grid_sample: input (1,C,H_img,W_img), grid (1,H,W,2)
+            grid = uvs.unsqueeze(0)   # (1, H, W, 2)
+            sampled = F.grid_sample(
+                images_gpu[ci], grid, mode='bilinear',
+                padding_mode='border', align_corners=True
+            ).squeeze(0).permute(1, 2, 0)   # (H, W, 3)
+
+            w = cos_w * mask.float()
+            accum  += sampled * w.unsqueeze(-1)
+            weight += w
+
+        # Normalise blended pixels
+        covered = weight > 1e-6
+        result = torch.where(
+            covered.unsqueeze(-1),
+            accum / weight.unsqueeze(-1).clamp(min=1e-8),
+            torch.zeros_like(accum),
+        )
+
+        # Fill uncovered pixels with neutral gradient
+        fill_np = _neutral_fill(self.envmap_height, self.envmap_width)
+        fill_t  = torch.from_numpy(fill_np).to(self.device)
+        result = torch.where(covered.unsqueeze(-1), result, fill_t)
+
+        equirect = result.cpu().numpy().astype(np.float32)
+        log.info('HDRI generation complete  coverage=%.1f%%',
+                 covered.float().mean().item() * 100)
+        return equirect
+
+    def to_cubemap(self, equirect: np.ndarray) -> dict[str, np.ndarray]:
+        """Convert equirectangular HDR to a dict of 6 cubemap faces."""
+        return {
+            face: _equirect_to_cubemap_face(equirect, face, self.cubemap_size)
+            for face in CUBEMAP_FACES
+        }
+
+    def generate_diffuse(self, equirect: np.ndarray) -> np.ndarray:
+        """Return a blurred equirectangular map suitable for diffuse IBL."""
+        if not _TORCH:
+            return equirect
+        t = torch.from_numpy(equirect).to(self.device).permute(2, 0, 1).unsqueeze(0)
+        # Repeated box blur with large kernel approximates Lambertian convolution
+        k = max(equirect.shape[1] // 32, 3) | 1   # odd kernel
+        for _ in range(self.diffuse_blur_passes):
+            t = F.avg_pool2d(
+                F.pad(t, [k // 2] * 4, mode='circular'),
+                kernel_size=k, stride=1, padding=0,
+            )
+        return t.squeeze(0).permute(1, 2, 0).cpu().numpy().astype(np.float32)
+
+    # ------------------------------------------------------------------
+    # Save helpers
+    # ------------------------------------------------------------------
+
+    def save_equirect_hdr(self, equirect: np.ndarray, path: Path) -> None:
+        if not _IMAGEIO:
+            raise RuntimeError('imageio is required: pip install imageio[freeimage]')
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        iio.imwrite(str(path), equirect, extension='.hdr')
+        log.info('Saved equirectangular HDR → %s', path)
+
+    def save_cubemap_hdr(
+        self, cubemap: dict[str, np.ndarray], output_dir: Path, stem: str
+    ) -> dict[str, Path]:
+        if not _IMAGEIO:
+            raise RuntimeError('imageio is required: pip install imageio[freeimage]')
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = {}
+        for face, img in cubemap.items():
+            p = output_dir / f'{stem}_{face}.hdr'
+            iio.imwrite(str(p), img, extension='.hdr')
+            paths[face] = p
+        log.info('Saved cubemap faces → %s/%s_*.hdr', output_dir, stem)
+        return paths

--- a/rawkee/tools/lidar/hpc_preflight_check.py
+++ b/rawkee/tools/lidar/hpc_preflight_check.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+hpc_preflight_check.py
+======================
+Run this script on a compute node BEFORE submitting rawkee scan pipeline jobs.
+It checks every required Python dependency, validates CUDA/PyTorch compatibility,
+and prints fix commands for anything that is missing or mismatched.
+
+Usage:
+    python hpc_preflight_check.py
+    python hpc_preflight_check.py --json   # machine-readable output
+    python hpc_preflight_check.py --strict # exit 1 if any warning/error found
+"""
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CheckResult:
+    name:     str
+    status:   str           # OK | WARN | ERROR | SKIP
+    version:  Optional[str] = None
+    message:  str = ''
+    fix:      str = ''
+
+
+results: list[CheckResult] = []
+
+
+def ok(name, version=None, msg=''):
+    results.append(CheckResult(name, 'OK', version, msg))
+
+def warn(name, msg, fix='', version=None):
+    results.append(CheckResult(name, 'WARN', version, msg, fix))
+
+def error(name, msg, fix='', version=None):
+    results.append(CheckResult(name, 'ERROR', version, msg, fix))
+
+def skip(name, msg=''):
+    results.append(CheckResult(name, 'SKIP', message=msg))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _try_import(mod: str):
+    try:
+        return importlib.import_module(mod)
+    except ImportError:
+        return None
+
+def _pkg_version(mod_name: str, attr: str = '__version__') -> Optional[str]:
+    m = _try_import(mod_name)
+    if m is None:
+        return None
+    return getattr(m, attr, 'unknown')
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        return r.returncode, (r.stdout + r.stderr).strip()
+    except Exception:
+        return -1, ''
+
+
+# ---------------------------------------------------------------------------
+# Check sections
+# ---------------------------------------------------------------------------
+
+def check_python():
+    v = sys.version_info
+    ver = f'{v.major}.{v.minor}.{v.micro}'
+    if v < (3, 10):
+        error('Python', f'Version {ver} is too old. rawkee requires Python ≥ 3.10.',
+              fix='module load python/3.11  # or use a virtualenv with Python 3.11+',
+              version=ver)
+    else:
+        ok('Python', version=ver)
+
+
+
+def check_numpy():
+    np = _try_import('numpy')
+    if np is None:
+        error('numpy', 'Not installed.',
+              fix='pip install "numpy>=1.24"')
+        return
+    v = np.__version__
+    major = int(v.split('.')[0])
+    if major < 1 or (major == 1 and int(v.split('.')[1]) < 24):
+        warn('numpy', f'Version {v} is old; recommend ≥ 1.24.',
+             fix='pip install --upgrade "numpy>=1.24"', version=v)
+    else:
+        ok('numpy', version=v)
+
+
+def check_torch():
+    torch = _try_import('torch')
+    if torch is None:
+        error('torch (PyTorch)', 'Not installed.',
+              fix=(
+                  'pip install torch --index-url https://download.pytorch.org/whl/cu124\n'
+                  '  For Grace/Hopper use cu124; for Blackwell/DGX Spark use NGC container:\n'
+                  '  nvcr.io/nvidia/pytorch:26.05-py3'
+              ))
+        return
+
+    tv = torch.__version__
+    cuda_ver = getattr(torch.version, 'cuda', None) or 'not compiled with CUDA'
+    ok('torch (PyTorch)', version=f'{tv}  (CUDA build: {cuda_ver})')
+
+    # Check CUDA availability
+    if not torch.cuda.is_available():
+        error('CUDA', 'torch.cuda.is_available() returned False.',
+              fix=(
+                  '1. Check driver: nvidia-smi\n'
+                  '  2. Match PyTorch CUDA build to driver:\n'
+                  '     driver ≥ 525  →  pip install torch --index-url https://download.pytorch.org/whl/cu121\n'
+                  '     driver ≥ 545  →  pip install torch --index-url https://download.pytorch.org/whl/cu124\n'
+                  '     Blackwell     →  use NGC container nvcr.io/nvidia/pytorch:26.05-py3'
+              ))
+        return
+
+    # GPU info
+    n = torch.cuda.device_count()
+    for i in range(n):
+        p     = torch.cuda.get_device_properties(i)
+        sm    = f'sm_{p.major}{p.minor}'
+        vram  = p.total_memory >> 30
+        label = f'GPU {i}: {p.name}  {vram} GB  {sm}'
+
+        if p.major < 6:
+            error(f'GPU {i}', f'{p.name} ({sm}) is below sm_60. Training will fail.',
+                  fix='Upgrade to an NVIDIA GPU with compute capability ≥ 6.0 (Pascal or newer).',
+                  version=sm)
+        elif p.major < 7:
+            warn(f'GPU {i}', f'{p.name} ({sm}) is Pascal-era. gsplat training may be slow.',
+                 fix='Recommend Volta (sm_70) or newer for efficient training.',
+                 version=sm)
+        else:
+            ok(f'GPU {i}', version=sm, msg=label)
+
+        # Blackwell (sm_100) requires NGC container or nightly PyTorch
+        if p.major >= 10:
+            cuda_b = torch.version.cuda or ''
+            if not cuda_b.startswith('12.8') and 'nightly' not in tv:
+                warn(f'GPU {i} (Blackwell)', 
+                     f'{p.name} requires CUDA ≥ 12.8 or NGC container; detected torch CUDA {cuda_b}.',
+                     fix=(
+                         'Use NVIDIA NGC container: nvcr.io/nvidia/pytorch:26.05-py3\n'
+                         '  or: pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cu128'
+                     ), version=sm)
+
+    # NCCL for DDP
+    try:
+        nccl = torch.cuda.nccl.version()
+        ok('NCCL', version='.'.join(str(x) for x in nccl))
+    except Exception:
+        warn('NCCL', 'NCCL version not detectable. DDP multi-node training may fail.',
+             fix='Ensure torch was built with NCCL support (standard CUDA wheels include it).')
+
+
+def check_gsplat():
+    m = _try_import('gsplat')
+    if m is None:
+        error('gsplat', 'Not installed. Required for Gaussian splat training.',
+              fix='pip install gsplat  # requires CUDA toolkit and a compiled wheel')
+        return
+    ok('gsplat', version=_pkg_version('gsplat'))
+
+
+def check_open3d():
+    m = _try_import('open3d')
+    if m is None:
+        error('open3d', 'Not installed. Required for Poisson mesh reconstruction and E57 fallback.',
+              fix='pip install open3d')
+        return
+    ok('open3d', version=_pkg_version('open3d'))
+
+
+def check_scipy():
+    m = _try_import('scipy')
+    if m is None:
+        error('scipy', 'Not installed. Required for KDTree in texture baking and UTM projection.',
+              fix='pip install scipy')
+        return
+    ok('scipy', version=_pkg_version('scipy'))
+
+
+def check_imageio():
+    m = _try_import('imageio')
+    if m is None:
+        error('imageio', 'Not installed. Required for HDR/PNG image saving.',
+              fix='pip install "imageio[freeimage]"')
+        return
+    iio_ver = _pkg_version('imageio')
+    # Verify the FreeImage binary actually loads (not just the plugin module)
+    fi_ok = False
+    try:
+        import imageio.plugins.freeimage as _fi
+        _fi.load_lib()
+        fi_ok = True
+    except Exception:
+        pass
+    if fi_ok:
+        ok('imageio', version=iio_ver, msg='FreeImage binary confirmed')
+    else:
+        warn('imageio', 'FreeImage binary not loadable. HDR (.hdr) output will fail.',
+             fix='pip install "imageio[freeimage]"',
+             version=iio_ver)
+
+
+def check_rawpy():
+    m = _try_import('rawpy')
+    if m is None:
+        warn('rawpy', 'Not installed. DNG/RAW image loading will be unavailable (JPEG/TIFF still works).',
+             fix='pip install rawpy')
+        return
+    ok('rawpy', version=_pkg_version('rawpy'))
+
+
+def check_pil():
+    m = _try_import('PIL')
+    if m is None:
+        error('Pillow (PIL)', 'Not installed. Required for image resizing in splat training.',
+              fix='pip install Pillow')
+        return
+    try:
+        version = importlib.metadata.version('Pillow')
+    except importlib.metadata.PackageNotFoundError:
+        version = getattr(m, '__version__', 'unknown')
+    ok('Pillow (PIL)', version=version)
+
+
+def check_rosbags():
+    m = _try_import('rosbags')
+    if m is None:
+        warn('rosbags', 'Not installed. LiDAR extraction from NavVis ROS bags will be unavailable.',
+             fix='pip install rosbags')
+        return
+    ok('rosbags', version=_pkg_version('rosbags'))
+
+
+def check_pye57():
+    m = _try_import('pye57')
+    if m is None:
+        warn('pye57', 'Not installed. E57 point cloud reading will fall back to open3d.',
+             fix='pip install pye57')
+        return
+    ok('pye57', version=_pkg_version('pye57'))
+
+
+def check_pyproj():
+    m = _try_import('pyproj')
+    if m is None:
+        warn('pyproj', 'Not installed. Georeferencing will use built-in Helmert UTM formula (< 1 mm error within a zone).',
+             fix='pip install pyproj')
+        return
+    ok('pyproj', version=_pkg_version('pyproj'))
+
+
+def check_transformers():
+    m = _try_import('transformers')
+    if m is None:
+        warn('transformers', 'Not installed. Depth Anything V2 fallback will be unavailable when no LiDAR bag is present.',
+             fix='pip install transformers')
+        return
+    ok('transformers', version=_pkg_version('transformers'))
+
+
+def check_pyside6():
+    m = _try_import('PySide6')
+    if m is None:
+        warn('PySide6', 'Not installed. The desktop GUI (scan_gui.py) will be unavailable.',
+             fix='pip install PySide6  # not required for CLI / SLURM usage')
+        return
+    ok('PySide6', version=_pkg_version('PySide6'))
+
+
+def check_rawkee():
+    m = _try_import('rawkee.tools.lidar')
+    if m is None:
+        error('rawkee.tools.lidar', 'rawkee package is not on PYTHONPATH.',
+              fix=(
+                  'cd /path/to/rawkee\n'
+                  '  pip install -e .   # editable install\n'
+                  '  # or: export PYTHONPATH=/path/to/rawkee:$PYTHONPATH'
+              ))
+        return
+    ok('rawkee.tools.lidar', msg='Package importable')
+
+
+def check_nvidia_smi():
+    rc, out = _run(['nvidia-smi', '--query-gpu=name,driver_version,memory.total',
+                    '--format=csv,noheader'])
+    if rc != 0:
+        warn('nvidia-smi', 'nvidia-smi not available or no GPU detected.',
+             fix='Ensure NVIDIA drivers are installed: module load cuda')
+        return
+    for line in out.strip().splitlines():
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) >= 3:
+            name, drv, mem = parts[0], parts[1], parts[2]
+            drv_major = int(drv.split('.')[0]) if drv.split('.')[0].isdigit() else 0
+            msg = f'{name}  driver {drv}  {mem}'
+            if drv_major < 525:
+                warn('nvidia-smi', f'Driver {drv} is below 525; CUDA 12.x requires ≥ 525.',
+                     fix='Update NVIDIA driver: contact your HPC sysadmin or use "module load cuda/12.x"',
+                     version=drv)
+            else:
+                ok('nvidia-smi', version=drv, msg=msg)
+
+
+def check_cuda_toolkit():
+    rc, out = _run(['nvcc', '--version'])
+    if rc != 0:
+        warn('nvcc (CUDA toolkit)', 'nvcc not found. Compilation of custom CUDA extensions (gsplat) may fail.',
+             fix='module load cuda/12.4   # or whichever version matches your PyTorch build')
+        return
+    import re
+    m = re.search(r'release (\S+),', out)
+    ver = m.group(1).rstrip(',') if m else 'unknown'
+    ok('nvcc (CUDA toolkit)', version=ver)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+CHECKS = [
+    check_python,
+    check_numpy,
+    check_torch,
+    check_gsplat,
+    check_open3d,
+    check_scipy,
+    check_imageio,
+    check_rawpy,
+    check_pil,
+    check_rosbags,
+    check_pye57,
+    check_pyproj,
+    check_transformers,
+    check_pyside6,
+    check_rawkee,
+    check_nvidia_smi,
+    check_cuda_toolkit,
+]
+
+STATUS_ICON  = {'OK': '[+]', 'WARN': '[!]', 'ERROR': '[X]', 'SKIP': '[-]'}
+STATUS_LABEL = {'OK': 'OK   ', 'WARN': 'WARN ', 'ERROR': 'ERROR', 'SKIP': 'SKIP '}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='rawkee HPC environment preflight check')
+    parser.add_argument('--json',   action='store_true', help='Output machine-readable JSON')
+    parser.add_argument('--strict', action='store_true', help='Exit 1 if any WARN or ERROR')
+    args = parser.parse_args()
+
+    print('=' * 70)
+    print('rawkee scan pipeline — HPC environment preflight check')
+    print(f'Host    : {platform.node()}')
+    print(f'OS      : {platform.system()} {platform.release()}  {platform.machine()}')
+    print(f'Python  : {sys.executable}')
+    print(f'Env     : {os.environ.get("VIRTUAL_ENV") or os.environ.get("CONDA_DEFAULT_ENV") or "(none)"}')
+    print('=' * 70)
+
+    for check in CHECKS:
+        check()
+
+    errors  = [r for r in results if r.status == 'ERROR']
+    warns   = [r for r in results if r.status == 'WARN']
+
+    if args.json:
+        print(json.dumps([vars(r) for r in results], indent=2))
+        sys.exit(1 if (errors or (args.strict and warns)) else 0)
+
+    # Pretty-print results
+    print()
+    for r in results:
+        icon  = STATUS_ICON[r.status]
+        label = STATUS_LABEL[r.status]
+        ver   = f'  [{r.version}]' if r.version else ''
+        msg   = f'  {r.message}' if r.message else ''
+        print(f'  {icon} {label}  {r.name}{ver}{msg}')
+
+    # Fix section
+    fixable = [r for r in results if r.fix and r.status in ('ERROR', 'WARN')]
+    if fixable:
+        print()
+        print('─' * 70)
+        print('SUGGESTED FIXES')
+        print('─' * 70)
+        for r in fixable:
+            tag = '[ ERROR ]' if r.status == 'ERROR' else '[ WARN  ]'
+            print(f'\n{tag} {r.name}')
+            for line in r.fix.splitlines():
+                print(f'  {line}')
+
+    # Summary
+    print()
+    print('─' * 70)
+    n_ok   = sum(1 for r in results if r.status == 'OK')
+    n_warn = len(warns)
+    n_err  = len(errors)
+    print(f'  {STATUS_ICON["OK"]} {n_ok} OK    '
+          f'{STATUS_ICON["WARN"]} {n_warn} warnings    '
+          f'{STATUS_ICON["ERROR"]} {n_err} errors')
+
+    if n_err == 0 and n_warn == 0:
+        print('\n  Environment is fully ready.')
+    elif n_err == 0:
+        print('\n  Environment is functional. Address warnings for full capability.')
+    else:
+        print('\n  Environment has critical issues. Fix errors before submitting jobs.')
+
+    print('=' * 70)
+
+    should_fail = bool(errors) or (args.strict and bool(warns))
+    sys.exit(1 if should_fail else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/rawkee/tools/lidar/install_workstation_deps.py
+++ b/rawkee/tools/lidar/install_workstation_deps.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""
+install_workstation_deps.py
+============================
+Run this script once on a workstation to install all Python packages required
+to launch the rawkee scan GUI and run the mesh / Gaussian splat pipelines.
+
+The script:
+  1. Installs required and optional packages via pip.
+  2. Auto-detects your CUDA driver and installs the matching PyTorch wheel.
+  3. Reports any CUDA/PyTorch mismatches it cannot fix automatically.
+  4. Verifies every install succeeded before reporting done.
+
+Usage:
+    python install_workstation_deps.py           # interactive
+    python install_workstation_deps.py --yes     # non-interactive (skip prompts)
+    python install_workstation_deps.py --dry-run # show what would be installed
+"""
+
+import argparse
+import importlib
+import importlib.metadata
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Colour helpers (graceful fallback on Windows without ANSI support)
+# ---------------------------------------------------------------------------
+
+try:
+    if sys.platform == 'win32':
+        import ctypes
+        ctypes.windll.kernel32.SetConsoleMode(
+            ctypes.windll.kernel32.GetStdHandle(-11), 7)
+    _ANSI = True
+except Exception:
+    _ANSI = False
+
+def _c(text: str, code: str) -> str:
+    return f'\033[{code}m{text}\033[0m' if _ANSI else text
+
+def green(t):  return _c(t, '32')
+def yellow(t): return _c(t, '33')
+def red(t):    return _c(t, '31')
+def bold(t):   return _c(t, '1')
+def cyan(t):   return _c(t, '36')
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DRY_RUN = False
+FAILURES: list[str] = []
+WARNINGS: list[str] = []
+
+
+def _run(cmd: list[str], capture: bool = True) -> tuple[int, str]:
+    try:
+        r = subprocess.run(
+            cmd, capture_output=capture, text=True, timeout=300,
+        )
+        return r.returncode, (r.stdout + r.stderr).strip()
+    except FileNotFoundError:
+        return -1, 'command not found'
+    except Exception as e:
+        return -1, str(e)
+
+
+def _is_installed(pkg_import: str) -> bool:
+    try:
+        importlib.import_module(pkg_import)
+        return True
+    except ImportError:
+        return False
+
+
+def _installed_version(dist_name: str) -> Optional[str]:
+    try:
+        return importlib.metadata.version(dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def pip_install(packages: list[str], index_url: str = '', label: str = '') -> bool:
+    """Install one or more packages; return True on success."""
+    if DRY_RUN:
+        print(f'  {cyan("[dry-run]")} pip install {" ".join(packages)}')
+        return True
+
+    cmd = [sys.executable, '-m', 'pip', 'install', '--quiet', '--upgrade'] + packages
+    if index_url:
+        cmd += ['--index-url', index_url]
+
+    desc = label or ' '.join(packages)
+    print(f'  Installing {bold(desc)} … ', end='', flush=True)
+    rc, out = _run(cmd, capture=True)
+    if rc == 0:
+        print(green('OK'))
+        return True
+    else:
+        print(red('FAILED'))
+        FAILURES.append(f'{desc}: {out[:200]}')
+        return False
+
+
+def section(title: str):
+    print(f'\n{bold(cyan(title))}')
+    print('─' * 60)
+
+
+# ---------------------------------------------------------------------------
+# CUDA auto-detection
+# ---------------------------------------------------------------------------
+
+def _detect_cuda_driver_version() -> Optional[int]:
+    """Return NVIDIA driver major version, or None if no GPU."""
+    rc, out = _run(['nvidia-smi', '--query-gpu=driver_version', '--format=csv,noheader'])
+    if rc != 0:
+        return None
+    first = out.strip().splitlines()[0].strip()
+    m = re.match(r'^(\d+)', first)
+    return int(m.group(1)) if m else None
+
+
+def _cuda_wheel_for_driver(driver_major: int) -> tuple[str, str]:
+    """Return (cuda_label, torch_index_url) appropriate for this driver."""
+    if driver_major >= 570:
+        return 'cu128', 'https://download.pytorch.org/whl/cu128'
+    if driver_major >= 545:
+        return 'cu124', 'https://download.pytorch.org/whl/cu124'
+    if driver_major >= 528:
+        return 'cu121', 'https://download.pytorch.org/whl/cu121'
+    # Very old driver: CPU-only torch but warn
+    return 'cpu', 'https://download.pytorch.org/whl/cpu'
+
+
+def _check_torch_cuda_mismatch() -> list[str]:
+    """Return list of mismatch messages after torch is installed."""
+    issues = []
+    try:
+        import torch
+        cuda_build = getattr(torch.version, 'cuda', None)
+        if not cuda_build:
+            issues.append(
+                f'PyTorch {torch.__version__} was not compiled with CUDA support.\n'
+                '  Gaussian splat training will be unavailable.\n'
+                '  Fix: pip install torch --index-url https://download.pytorch.org/whl/cu124'
+            )
+            return issues
+
+        if not torch.cuda.is_available():
+            issues.append(
+                f'PyTorch CUDA build ({cuda_build}) installed but torch.cuda.is_available() is False.\n'
+                '  This usually means the NVIDIA driver is too old for the CUDA version.\n'
+                '  Fix: update your NVIDIA driver or install PyTorch for a lower CUDA version.\n'
+                f'  Your driver supports up to CUDA {_cuda_from_driver()} — reinstall with:\n'
+                '    python install_workstation_deps.py --reinstall-torch'
+            )
+            return issues
+
+        for i in range(torch.cuda.device_count()):
+            p = torch.cuda.get_device_properties(i)
+            if p.major < 6:
+                issues.append(
+                    f'GPU {i} ({p.name}, sm_{p.major}{p.minor}) is below sm_60.\n'
+                    '  Gaussian splat training requires Pascal (sm_60) or newer.'
+                )
+            elif p.major >= 10:
+                if not (cuda_build or '').startswith('12.8'):
+                    issues.append(
+                        f'GPU {i} ({p.name}) is Blackwell (sm_{p.major}{p.minor}) and requires CUDA 12.8.\n'
+                        f'  Detected PyTorch CUDA build: {cuda_build}.\n'
+                        '  Fix: use the NGC container nvcr.io/nvidia/pytorch:26.05-py3'
+                    )
+    except ImportError:
+        pass
+    return issues
+
+
+def _cuda_from_driver() -> str:
+    drv = _detect_cuda_driver_version()
+    if drv is None:
+        return 'unknown'
+    label, _ = _cuda_wheel_for_driver(drv)
+    return label.replace('cu', '').replace('cpu', 'none')
+
+
+# ---------------------------------------------------------------------------
+# Installation steps
+# ---------------------------------------------------------------------------
+
+def step_pip_upgrade():
+    section('1 / 7  Upgrading pip')
+    pip_install(['pip'], label='pip (upgrade)')
+
+
+def step_core_gui():
+    section('2 / 7  Core GUI and numeric packages')
+    pkgs = [
+        ('numpy>=1.24',         'numpy',    'numpy'),
+        ('Pillow',              'PIL',      'Pillow'),
+        ('scipy',               'scipy',    'scipy'),
+        ('PySide6',             'PySide6',  'PySide6'),
+    ]
+    for dist, imp, label in pkgs:
+        if _is_installed(imp):
+            ver = _installed_version(dist.split('>=')[0].split('[')[0])
+            print(f'  {green("[+]")} {label} already installed  [{ver}]')
+        else:
+            pip_install([dist], label=label)
+
+
+def step_imageio():
+    section('3 / 7  imageio (HDR export)')
+    imp = 'imageio'
+    if not _is_installed(imp):
+        pip_install(['imageio[freeimage]'], label='imageio + FreeImage')
+    else:
+        # Check if FreeImage binary is loadable
+        fi_ok = False
+        try:
+            import imageio.plugins.freeimage as _fi
+            _fi.load_lib()
+            fi_ok = True
+        except Exception:
+            pass
+
+        if fi_ok:
+            ver = _installed_version('imageio')
+            print(f'  {green("[+]")} imageio already installed [{ver}] with FreeImage')
+        else:
+            ver = _installed_version('imageio')
+            print(f'  {yellow("[!]")} imageio [{ver}] present but FreeImage binary missing — reinstalling')
+            pip_install(['imageio[freeimage]'], label='imageio[freeimage] (FreeImage binary)')
+
+
+def step_torch():
+    section('4 / 7  PyTorch (GPU-accelerated pipelines)')
+    existing = _installed_version('torch')
+
+    if existing:
+        print(f'  {green("[+]")} PyTorch {existing} already installed — checking CUDA compatibility …')
+        issues = _check_torch_cuda_mismatch()
+        for issue in issues:
+            print(f'\n  {yellow("[!]")} {issue}\n')
+            WARNINGS.append(issue)
+        if not issues:
+            import torch
+            cuda_avail = torch.cuda.is_available()
+            print(f'  {green("[+]")} CUDA available: {cuda_avail}  '
+                  f'({torch.cuda.device_count()} GPU(s))')
+        return
+
+    drv = _detect_cuda_driver_version()
+    if drv is None:
+        print(f'  {yellow("[!]")} No NVIDIA GPU detected — installing CPU-only PyTorch.')
+        print( '       GPU-based pipelines (splat training) will be unavailable.')
+        WARNINGS.append(
+            'No NVIDIA GPU found. Installing CPU-only PyTorch.\n'
+            '  Gaussian splat training requires a CUDA GPU.'
+        )
+        pip_install(['torch'], index_url='https://download.pytorch.org/whl/cpu',
+                    label='torch (CPU-only)')
+        return
+
+    label, index_url = _cuda_wheel_for_driver(drv)
+    print(f'  Detected driver v{drv} → installing PyTorch for {label} …')
+    if label == 'cpu':
+        WARNINGS.append(
+            f'NVIDIA driver v{drv} is too old for CUDA 12.x.\n'
+            '  Installed CPU-only PyTorch. Update driver to ≥ 528 for GPU support.'
+        )
+    ok = pip_install(['torch'], index_url=index_url, label=f'torch ({label})')
+    if ok:
+        issues = _check_torch_cuda_mismatch()
+        for issue in issues:
+            print(f'\n  {yellow("[!]")} {issue}\n')
+            WARNINGS.append(issue)
+
+
+def step_open3d():
+    section('5 / 7  open3d (mesh reconstruction + E57 fallback)')
+    if _is_installed('open3d'):
+        ver = _installed_version('open3d')
+        print(f'  {green("[+]")} open3d already installed  [{ver}]')
+    else:
+        pip_install(['open3d'], label='open3d')
+
+
+def step_pipeline_extras():
+    section('6 / 7  Optional pipeline packages')
+    optional = [
+        ('rawpy',        'rawpy',        'rawpy  (DNG/RAW camera images)'),
+        ('rosbags',      'rosbags',      'rosbags  (NavVis LiDAR bag reading)'),
+        ('pye57',        'pye57',        'pye57  (E57 point cloud reading)'),
+        ('pyproj',       'pyproj',       'pyproj  (precise UTM georeferencing)'),
+        ('transformers', 'transformers', 'transformers  (Depth Anything V2 fallback)'),
+    ]
+    for dist, imp, label in optional:
+        if _is_installed(imp):
+            ver = _installed_version(dist)
+            print(f'  {green("[+]")} {label}  already installed  [{ver}]')
+        else:
+            pip_install([dist], label=label)
+
+    # gsplat: requires CUDA toolkit — attempt but don't fail hard
+    if _is_installed('gsplat'):
+        ver = _installed_version('gsplat')
+        print(f'  {green("[+]")} gsplat already installed  [{ver}]')
+    else:
+        rc, _ = _run(['nvcc', '--version'])
+        if rc == 0:
+            if not DRY_RUN:
+                print(f'  Installing {bold("gsplat")} (requires CUDA toolkit — may take several minutes) … ',
+                      end='', flush=True)
+                rc2, out2 = _run([sys.executable, '-m', 'pip', 'install', 'gsplat'])
+                if rc2 == 0:
+                    print(green('OK'))
+                else:
+                    print(red('FAILED'))
+                    WARNINGS.append(
+                        f'gsplat install failed. Gaussian splat training will be unavailable.\n'
+                        '  Try manually: pip install gsplat\n'
+                        f'  Detail: {out2[:300]}'
+                    )
+            else:
+                print(f'  {cyan("[dry-run]")} pip install gsplat')
+        else:
+            WARNINGS.append(
+                'gsplat not installed: nvcc (CUDA toolkit) not found.\n'
+                '  Install the CUDA toolkit matching your driver, then: pip install gsplat'
+            )
+            print(f'  {yellow("[!]")} gsplat skipped — nvcc not found '
+                  f'(CUDA toolkit required for compilation)')
+
+
+def step_verify() -> bool:
+    section('7 / 7  Verifying installs')
+    if DRY_RUN:
+        print(f'  {cyan("[dry-run]")} skipping verification (nothing was installed)')
+        return True
+    checks = [
+        ('numpy',      'numpy',     True),
+        ('PIL',        'Pillow',    True),
+        ('scipy',      'scipy',     True),
+        ('PySide6',    'PySide6',   True),
+        ('imageio',    'imageio',   True),
+        ('open3d',     'open3d',    True),
+        ('torch',      'torch',     True),
+        ('rawpy',      'rawpy',     False),
+        ('rosbags',    'rosbags',   False),
+        ('pye57',      'pye57',     False),
+        ('pyproj',     'pyproj',    False),
+        ('gsplat',     'gsplat',    False),
+    ]
+    all_required_ok = True
+    for imp, dist, required in checks:
+        ok_flag = _is_installed(imp)
+        ver = _installed_version(dist) or '—'
+        tag = 'required' if required else 'optional'
+        if ok_flag:
+            print(f'  {green("[+]")} {imp:<20} [{ver}]')
+        elif required:
+            print(f'  {red("[X]")} {imp:<20} MISSING  ({tag})')
+            all_required_ok = False
+        else:
+            print(f'  {yellow("[-]")} {imp:<20} not installed  ({tag})')
+    return all_required_ok
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    global DRY_RUN
+    parser = argparse.ArgumentParser(
+        description='rawkee workstation dependency installer'
+    )
+    parser.add_argument('--yes',            action='store_true',
+                        help='Skip confirmation prompts')
+    parser.add_argument('--dry-run',        action='store_true',
+                        help='Show what would be installed without installing')
+    parser.add_argument('--reinstall-torch', action='store_true',
+                        help='Force reinstall PyTorch (useful after driver update)')
+    args = parser.parse_args()
+    DRY_RUN = args.dry_run
+
+    print('=' * 60)
+    print(bold('rawkee scan pipeline — workstation dependency installer'))
+    print(f'Python: {sys.executable}  ({sys.version.split()[0]})')
+    if DRY_RUN:
+        print(yellow('DRY-RUN mode — nothing will be installed'))
+    print('=' * 60)
+
+    if sys.version_info < (3, 10):
+        print(red(f'\n[X] Python {sys.version_info.major}.{sys.version_info.minor} is too old.'
+                  ' rawkee requires Python >= 3.10.\n'))
+        sys.exit(1)
+
+    if not args.yes and not DRY_RUN:
+        print('\nThis will install/upgrade packages into:')
+        print(f'  {sys.executable}')
+        env = os.environ.get('VIRTUAL_ENV') or os.environ.get('CONDA_DEFAULT_ENV') or '(system)'
+        print(f'  Environment: {env}')
+        answer = input('\nProceed? [Y/n] ').strip().lower()
+        if answer and answer != 'y':
+            print('Aborted.')
+            sys.exit(0)
+
+    if args.reinstall_torch and not DRY_RUN:
+        print('\nRemoving existing torch installation …')
+        _run([sys.executable, '-m', 'pip', 'uninstall', '-y', 'torch'])
+
+    step_pip_upgrade()
+    step_core_gui()
+    step_imageio()
+    step_torch()
+    step_open3d()
+    step_pipeline_extras()
+    all_ok = step_verify()
+
+    # Summary
+    print(f'\n{"=" * 60}')
+    print(bold('Summary'))
+    print('─' * 60)
+
+    if FAILURES:
+        print(f'\n{red("[X] Installation failures:")}')
+        for f in FAILURES:
+            print(f'    • {f}')
+
+    if WARNINGS:
+        print(f'\n{yellow("[!] Warnings:")}')
+        for w in WARNINGS:
+            for line in w.splitlines():
+                print(f'    {line}')
+
+    if not FAILURES and not WARNINGS and all_ok:
+        print(green('\n[+] All packages installed successfully.'))
+        print(    '    Launch the GUI with:')
+        print(f'       python rawkee/tools/lidar/scan_gui.py')
+    elif not FAILURES and all_ok:
+        print(yellow('\n[!] Required packages OK; some optional packages have warnings.'))
+        print(    '    The GUI will launch but some features may be limited.')
+        print(f'    Launch with: python rawkee/tools/lidar/scan_gui.py')
+    else:
+        print(red('\n[X] Some required packages failed. Fix the errors above and re-run.'))
+        print(    '    You can also run: python rawkee/tools/lidar/hpc_preflight_check.py')
+
+    print('=' * 60)
+    sys.exit(0 if (not FAILURES and all_ok) else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/rawkee/tools/lidar/mesh_pipeline.py
+++ b/rawkee/tools/lidar/mesh_pipeline.py
@@ -1,0 +1,541 @@
+"""Textured polygon mesh pipeline for mobile LiDAR scan datasets.
+
+Strategy
+--------
+1. Extract LiDAR point clouds from the SLAM ROS bag (PandarXTM laser_horiz +
+   laser_vert).  Falls back to GPU depth estimation (Depth Anything V2) when
+   the bag does not expose raw scan topics.
+2. Colorize point cloud: reproject each LiDAR point into every camera frame
+   that sees it, average colour using inverse-distance weighting.
+3. Run Open3D Poisson surface reconstruction on the coloured cloud.
+4. UV unwrap and bake a texture atlas.
+5. Export via scan.export in the requested format.
+"""
+from __future__ import annotations
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn.functional as F
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+try:
+    import open3d as o3d
+    _O3D = True
+except ImportError:
+    _O3D = False
+
+try:
+    from rosbags.rosbag1 import Reader as Rosbag1Reader
+    _ROSBAGS = True
+except ImportError:
+    _ROSBAGS = False
+
+from .dataset import ScanDataset, _quat_to_rot
+
+log = logging.getLogger(__name__)
+
+
+def _warn_no_gpu(pipeline: str, require: bool = False) -> None:
+    """Print actionable GPU diagnostic and optionally raise."""
+    lines = ['', f'WARNING: No CUDA GPU is available for the {pipeline} pipeline.']
+    if _TORCH:
+        lines.append(f'  PyTorch version : {torch.__version__}')
+        lines.append(f'  PyTorch CUDA    : {torch.version.cuda or "not compiled"}')
+    else:
+        lines.append('  PyTorch is not installed.')
+    lines += [
+        '  Suggested fixes:',
+        '    1. Ensure your NVIDIA driver is installed (>=525 for CUDA 12.x).',
+        '    2. Reinstall PyTorch for your CUDA version:',
+        '         pip install torch --index-url https://download.pytorch.org/whl/cu124',
+        '    3. For Grace/Hopper or DGX Spark use the NGC PyTorch container.',
+        '    4. Quick check: python -c "import torch; print(torch.cuda.is_available())"',
+    ]
+    if require:
+        lines.append('')
+        print('\n'.join(lines), flush=True)
+        raise RuntimeError(f'A CUDA GPU is required for the {pipeline} pipeline but none is available.')
+    lines.append('  Continuing on CPU — performance will be significantly reduced.')
+    lines.append('')
+    print('\n'.join(lines), flush=True)
+
+
+def _get_device() -> 'torch.device':
+    if _TORCH and torch.cuda.is_available():
+        p = torch.cuda.get_device_properties(0)
+        log.info('Mesh pipeline GPU: %s  sm_%d%d', p.name, p.major, p.minor)
+        if p.major >= 9:
+            torch.cuda.set_per_process_memory_fraction(0.85)
+        return torch.device('cuda')
+    _warn_no_gpu('mesh', require=False)
+    return torch.device('cpu')
+
+
+# ---------------------------------------------------------------------------
+# LiDAR extraction from ROS bag
+# ---------------------------------------------------------------------------
+
+def _parse_pointcloud2(msg_data: bytes, fields_meta: list) -> Optional[np.ndarray]:
+    """Parse a ROS sensor_msgs/PointCloud2 blob to (N,3) float32 xyz."""
+    try:
+        # Build field offset map
+        offsets = {f.name: (f.offset, f.datatype) for f in fields_meta}
+        point_step = None
+        # Attempt to find point_step from the raw header; we'll iterate offset-by-offset
+        x_off, x_dt = offsets.get('x', (0, 7))    # 7 = FLOAT32
+        y_off = offsets.get('y', (4, 7))[0]
+        z_off = offsets.get('z', (8, 7))[0]
+        # Try to infer point_step
+        sorted_offs = sorted(offsets.values(), key=lambda t: t[0])
+        last_off = sorted_offs[-1][0] + 4
+        point_step_guess = last_off
+        n_pts = len(msg_data) // point_step_guess
+        if n_pts == 0:
+            return None
+        pts = np.frombuffer(msg_data, dtype=np.uint8).reshape(n_pts, -1)
+        x = np.frombuffer(pts[:, x_off:x_off + 4].tobytes(), dtype=np.float32)
+        y = np.frombuffer(pts[:, y_off:y_off + 4].tobytes(), dtype=np.float32)
+        z = np.frombuffer(pts[:, z_off:z_off + 4].tobytes(), dtype=np.float32)
+        valid = np.isfinite(x) & np.isfinite(y) & np.isfinite(z)
+        return np.stack([x[valid], y[valid], z[valid]], axis=-1).astype(np.float32)
+    except Exception as exc:
+        log.debug('PointCloud2 parse failed: %s', exc)
+        return None
+
+
+def _extract_e57_cloud(dataset: ScanDataset) -> tuple[np.ndarray, 'np.ndarray | None']:
+    """Read (xyz, colors_or_None) from an E57 dataset and voxel-downsample."""
+    xyz, colors = dataset.e57_point_cloud()
+    if _O3D:
+        pcd = o3d.geometry.PointCloud()
+        pcd.points = o3d.utility.Vector3dVector(xyz.astype(np.float64))
+        if colors is not None:
+            pcd.colors = o3d.utility.Vector3dVector(np.clip(colors, 0, 1).astype(np.float64))
+        pcd = pcd.voxel_down_sample(voxel_size=0.02)
+        xyz    = np.asarray(pcd.points).astype(np.float32)
+        colors = np.asarray(pcd.colors).astype(np.float32) if pcd.has_colors() else None
+        log.info('E57 after voxel downsample: %d points', len(xyz))
+    return xyz, colors
+
+
+def _extract_lidar_from_bag(
+    bag_path: Path,
+    lidar_topics: tuple[str, ...] = ('/laser_horiz', '/laser_vert',
+                                      '/velodyne_points', '/points_raw'),
+    max_clouds: int = 500,
+) -> Optional[np.ndarray]:
+    """Return combined (N,3) float32 point cloud from a ROS1 bag, or None."""
+    if not _ROSBAGS:
+        log.warning('rosbags not installed — cannot read ROS bags: pip install rosbags')
+        return None
+    if not bag_path.exists():
+        log.warning('Bag not found: %s', bag_path)
+        return None
+
+    clouds = []
+    count = 0
+    try:
+        from rosbags.typesys import Stores, get_typestore
+        ts = get_typestore(Stores.ROS1_NOETIC)
+        with Rosbag1Reader(bag_path) as reader:
+            topics_in_bag = {c.topic for c in reader.connections}
+            active = [t for t in lidar_topics if t in topics_in_bag]
+            if not active:
+                log.warning('No LiDAR topics found in bag (have: %s)', topics_in_bag)
+                return None
+            log.info('Reading LiDAR from bag topics: %s', active)
+            conns = [c for c in reader.connections if c.topic in active]
+            for conn, ts_ns, raw in reader.messages(connections=conns):
+                if count >= max_clouds:
+                    break
+                try:
+                    msg = ts.deserialize_ros1(raw, conn.msgtype)
+                    xyz = _parse_pointcloud2(bytes(msg.data), msg.fields)
+                    if xyz is not None and len(xyz) > 0:
+                        clouds.append(xyz)
+                        count += 1
+                except Exception as exc:
+                    log.debug('Skip cloud %d: %s', count, exc)
+    except Exception as exc:
+        log.warning('Bag read error: %s', exc)
+        return None
+
+    if not clouds:
+        return None
+    combined = np.concatenate(clouds, axis=0)
+    log.info('Extracted %d LiDAR clouds → %d points total', count, len(combined))
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Depth estimation fallback (Depth Anything V2 via transformers)
+# ---------------------------------------------------------------------------
+
+def _estimate_depth_gpu(
+    dataset: ScanDataset,
+    frame_indices: list[int],
+    device: 'torch.device',
+    stride: int = 5,
+) -> np.ndarray:
+    """Estimate depth for selected frames and return fused (N,3) world point cloud."""
+    try:
+        from transformers import pipeline as hf_pipeline
+    except ImportError:
+        raise RuntimeError(
+            'transformers required for depth fallback: pip install transformers'
+        )
+
+    log.info('Depth estimation fallback using Depth Anything V2 …')
+    depth_pipe = hf_pipeline(
+        task='depth-estimation',
+        model='depth-anything/Depth-Anything-V2-Large-hf',
+        device=0 if device.type == 'cuda' else -1,
+    )
+
+    all_pts: list[np.ndarray] = []
+
+    for fi in frame_indices[::stride]:
+        head_pos, R_head = dataset.frame_transform(fi)
+        for ci, cam in enumerate(dataset.cameras):
+            dng = dataset.dng_path(fi, ci)
+            if not dng.exists():
+                continue
+            try:
+                from PIL import Image
+                import rawpy
+                with rawpy.imread(str(dng)) as raw:
+                    rgb8 = raw.postprocess(output_bps=8, use_camera_wb=True)
+                pil_img = Image.fromarray(rgb8)
+                pil_img = pil_img.resize((512, 512))
+                depth_out = depth_pipe(pil_img)
+                depth = np.array(depth_out['depth'], dtype=np.float32)
+
+                h, w = depth.shape
+                col_g = np.arange(w, dtype=np.float32)
+                row_g = np.arange(h, dtype=np.float32)
+                cc, rr = np.meshgrid(col_g, row_g)
+                cc = cc * (cam.ocam.width  / w)
+                rr = rr * (cam.ocam.height / h)
+                uv = np.stack([cc.ravel(), rr.ravel()], axis=-1)
+                dirs_cam = cam.ocam.unproject(uv)
+                pts_cam = dirs_cam * depth.ravel()[:, None]
+
+                # Transform to world frame
+                R_cam_to_head = cam.R                     # (3,3)
+                pts_head = pts_cam @ R_cam_to_head.T + cam.position
+                pts_world = pts_head @ R_head.T + head_pos
+
+                all_pts.append(pts_world.astype(np.float32))
+            except Exception as exc:
+                log.debug('Depth estimation frame %d cam %d: %s', fi, ci, exc)
+
+    if not all_pts:
+        raise RuntimeError('Depth estimation produced no points')
+    combined = np.concatenate(all_pts, axis=0)
+    log.info('Depth fallback: %d world points from %d frames', len(combined), len(frame_indices[::stride]))
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Colorisation
+# ---------------------------------------------------------------------------
+
+def _colorize_cloud(
+    xyz: np.ndarray,
+    dataset: ScanDataset,
+    frame_indices: list[int],
+    device: 'torch.device',
+    stride: int = 10,
+    max_dist: float = 20.0,
+) -> np.ndarray:
+    """Return (N,3) float32 RGB colours for each world-frame point in xyz."""
+    from .hdri import _load_image_hdr
+
+    N = len(xyz)
+    colour_sum   = np.zeros((N, 3), dtype=np.float32)
+    colour_count = np.zeros(N, dtype=np.float32)
+
+    xyz_t = torch.from_numpy(xyz).to(device)
+
+    # Pre-compute per-camera rotation and position tensors once
+    cam_R_t   = [torch.tensor(c.R,        device=device, dtype=torch.float32) for c in dataset.cameras]
+    cam_pos_t = [torch.tensor(c.position, device=device, dtype=torch.float32) for c in dataset.cameras]
+
+    for fi in frame_indices[::stride]:
+        head_pos, R_head = dataset.frame_transform(fi)
+        head_pos_t = torch.tensor(head_pos, device=device, dtype=torch.float32)
+        R_head_t   = torch.tensor(R_head,   device=device, dtype=torch.float32)
+
+        for ci, cam in enumerate(dataset.cameras):
+            dng = dataset.dng_path(fi, ci)
+            if not dng.exists():
+                continue
+            try:
+                img_np = _load_dng_hdr(dng)
+                img_t = torch.from_numpy(img_np).to(device).permute(2, 0, 1).unsqueeze(0)
+
+                pts_head = (xyz_t - head_pos_t) @ R_head_t
+                pts_cam  = (pts_head - cam_pos_t[ci]) @ cam_R_t[ci]
+
+                uvs, mask = cam.ocam.project_gpu(pts_cam, device)
+
+                # Additional distance filter
+                dist = torch.norm(pts_cam, dim=-1)
+                mask = mask & (dist < max_dist)
+
+                if not mask.any():
+                    continue
+
+                # grid_sample expects (1, C, 1, N_valid)
+                uvs_valid = uvs[mask].unsqueeze(0).unsqueeze(0)
+                sampled = F.grid_sample(
+                    img_t, uvs_valid, mode='bilinear',
+                    padding_mode='border', align_corners=True,
+                ).squeeze(0).squeeze(1).T   # (N_v, 3)
+
+                w = (1.0 / dist[mask].clamp(min=0.1)).cpu().numpy()
+                idx = mask.cpu().numpy().nonzero()[0]
+                colour_sum[idx]   += sampled.cpu().numpy() * w[:, None]
+                colour_count[idx] += w
+            except Exception as exc:
+                log.debug('Colorise frame %d cam %d: %s', fi, ci, exc)
+
+    valid = colour_count > 0
+    colours = np.where(
+        valid[:, None],
+        colour_sum / np.maximum(colour_count[:, None], 1e-8),
+        0.5,   # grey for unobserved points
+    )
+    log.info('Colourised %d / %d points', valid.sum(), N)
+    return colours.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Poisson reconstruction + texturing
+# ---------------------------------------------------------------------------
+
+def _poisson_mesh(xyz: np.ndarray, colours: np.ndarray, depth: int = 9) -> 'o3d.geometry.TriangleMesh':
+    """Run Open3D Poisson surface reconstruction."""
+    if not _O3D:
+        raise RuntimeError('open3d required: pip install open3d')
+
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(xyz.astype(np.float64))
+    pcd.colors = o3d.utility.Vector3dVector(np.clip(colours, 0, 1).astype(np.float64))
+
+    log.info('Estimating normals …')
+    pcd.estimate_normals(
+        search_param=o3d.geometry.KDTreeSearchParamHybrid(radius=0.1, max_nn=30)
+    )
+    pcd.orient_normals_consistent_tangent_plane(k=15)
+
+    log.info('Poisson reconstruction (depth=%d) …', depth)
+    mesh, densities = o3d.geometry.TriangleMesh.create_from_point_cloud_poisson(
+        pcd, depth=depth, scale=1.1, linear_fit=False
+    )
+    # Prune low-density vertices (artefacts)
+    thresh = np.quantile(np.asarray(densities), 0.05)
+    mesh.remove_vertices_by_mask(np.asarray(densities) < thresh)
+    mesh.remove_degenerate_triangles()
+    mesh.remove_unreferenced_vertices()
+    mesh.compute_vertex_normals()
+    log.info('Mesh: %d vertices, %d faces', len(mesh.vertices), len(mesh.triangles))
+    return mesh
+
+
+def _bake_texture(
+    mesh: 'o3d.geometry.TriangleMesh',
+    xyz: np.ndarray,
+    colours: np.ndarray,
+    atlas_size: int = 4096,
+) -> tuple['o3d.geometry.TriangleMesh', np.ndarray]:
+    """UV-unwrap and bake vertex colours into a texture atlas.
+
+    Returns (textured_mesh, atlas_image).
+    """
+    if not _O3D:
+        raise RuntimeError('open3d required')
+
+    # Simple per-vertex colour transfer; proper atlas unwrap is not yet
+    # part of Open3D's Python API — we use vertex colours directly and
+    # rely on the exporter to convert to a texture atlas where needed.
+    verts = np.asarray(mesh.vertices)
+    vcolors = np.asarray(mesh.vertex_colors) if mesh.has_vertex_colors() else None
+
+    if vcolors is None or len(vcolors) == 0:
+        log.info('Projecting point-cloud colours to mesh vertices …')
+        from scipy.spatial import cKDTree
+        tree = cKDTree(xyz)
+        dists, idxs = tree.query(verts, k=4, workers=-1)
+        weights = 1.0 / np.maximum(dists, 1e-6)
+        weights /= weights.sum(axis=1, keepdims=True)
+        vcolors = (weights[:, :, None] * colours[idxs]).sum(axis=1)
+        mesh.vertex_colors = o3d.utility.Vector3dVector(np.clip(vcolors, 0, 1))
+
+    # Build a simple (N_tris * 3, 2) UV map using a planar unwrap approximation
+    tris    = np.asarray(mesh.triangles)
+    n_tris  = len(tris)
+    n_tiles = math.ceil(math.sqrt(n_tris))
+    tile_sz = 1.0 / n_tiles
+
+    ti_arr   = np.arange(n_tris)
+    t_rows, t_cols = np.divmod(ti_arr, n_tiles)
+    u0 = (t_cols * tile_sz).astype(np.float32)
+    v0 = (t_rows * tile_sz).astype(np.float32)
+    uvs = np.empty((n_tris * 3, 2), dtype=np.float32)
+    uvs[0::3, 0] = u0;              uvs[0::3, 1] = v0
+    uvs[1::3, 0] = u0 + tile_sz;   uvs[1::3, 1] = v0
+    uvs[2::3, 0] = u0;              uvs[2::3, 1] = v0 + tile_sz
+
+    # Rasterise per-triangle mean colour into atlas
+    atlas = np.zeros((atlas_size, atlas_size, 3), dtype=np.float32)
+    sz    = max(1, int(tile_sz * atlas_size))
+    r0_arr = (t_rows * tile_sz * atlas_size).astype(int)
+    c0_arr = (t_cols * tile_sz * atlas_size).astype(int)
+    tri_colors = np.clip(vcolors[tris].mean(axis=1), 0, 1)  # (T, 3) — vectorized
+    for ti in range(n_tris):
+        atlas[r0_arr[ti]:r0_arr[ti] + sz, c0_arr[ti]:c0_arr[ti] + sz] = tri_colors[ti]
+
+    mesh.triangle_uvs = o3d.utility.Vector2dVector(uvs)
+    return mesh, atlas
+
+
+# ---------------------------------------------------------------------------
+# Public pipeline class
+# ---------------------------------------------------------------------------
+
+class MeshPipeline:
+    """End-to-end scan dataset → textured polygon mesh pipeline."""
+
+    def __init__(
+        self,
+        poisson_depth: int = 9,
+        atlas_size: int = 4096,
+        colorise_stride: int = 10,
+        depth_fallback_stride: int = 5,
+        prefer_cuda: bool = True,
+    ) -> None:
+        self.poisson_depth = poisson_depth
+        self.atlas_size = atlas_size
+        self.colorise_stride = colorise_stride
+        self.depth_fallback_stride = depth_fallback_stride
+        self.device = _get_device() if prefer_cuda else torch.device('cpu')
+
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        dataset: ScanDataset,
+        output_dir: Path,
+        output_format: str = 'x3d',
+        hdri_frame: Optional[int] = None,
+        envmap_width: int = 4096,
+        envmap_height: int = 2048,
+        trimble_csv: Optional[Path] = None,
+        georef_epsg: int = 32605,
+    ) -> Path:
+        """Run the full mesh pipeline and export.
+
+        Parameters
+        ----------
+        dataset:       ScanDataset instance.
+        output_dir:    Directory to write outputs.
+        output_format: One of x3d | x3dv | x3dj | obj | glb.
+        hdri_frame:    Frame index used for HDRI generation (None = auto).
+        trimble_csv:   Optional path to a Trimble survey CSV for georeferencing.
+        georef_epsg:   Target projected CRS (default 32605 = UTM Zone 5N).
+        """
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if trimble_csv is not None:
+            dataset.apply_trimble_georef(trimble_csv, epsg=georef_epsg)
+
+        valid_frames = dataset.valid_frame_indices()
+
+        # 1. Point cloud (and optional pre-coloured E57 cloud)
+        e57_colours: 'np.ndarray | None' = None
+        if dataset.platform == 'e57':
+            xyz, e57_colours = _extract_e57_cloud(dataset)
+        else:
+            xyz = self._get_point_cloud(dataset, valid_frames)
+
+        # 2. Colourisation
+        if e57_colours is not None:
+            colours = e57_colours
+            log.info('Using embedded E57 RGB colours — skipping camera reprojection')
+        else:
+            colours = _colorize_cloud(
+                xyz, dataset, valid_frames, self.device,
+                stride=self.colorise_stride,
+            )
+
+        # 3. Poisson reconstruction + texture bake
+        if not _O3D:
+            raise RuntimeError('open3d required for mesh reconstruction: pip install open3d')
+        mesh = _poisson_mesh(xyz, colours, depth=self.poisson_depth)
+        mesh, atlas = _bake_texture(mesh, xyz, colours, atlas_size=self.atlas_size)
+
+        # 4. HDRI for environment light
+        from .hdri import HDRIGenerator
+        hdri_gen = HDRIGenerator(envmap_width, envmap_height, prefer_cuda=self.device.type == 'cuda')
+        equirect  = hdri_gen.generate(dataset, hdri_frame)
+        specular  = hdri_gen.to_cubemap(equirect)
+        diffuse_e = hdri_gen.generate_diffuse(equirect)
+        diffuse   = hdri_gen.to_cubemap(diffuse_e)
+        spec_paths = hdri_gen.save_cubemap_hdr(specular, output_dir, 'envmap_spec')
+        diff_paths = hdri_gen.save_cubemap_hdr(diffuse,  output_dir, 'envmap_diff')
+        equirect_spec_path = output_dir / 'envmap_spec_equirect.hdr'
+        equirect_diff_path = output_dir / 'envmap_diff_equirect.hdr'
+        hdri_gen.save_equirect_hdr(equirect,  equirect_spec_path)
+        hdri_gen.save_equirect_hdr(diffuse_e, equirect_diff_path)
+
+        # 5. Export
+        from .export import export_mesh
+        out_path = export_mesh(
+            mesh=mesh,
+            atlas=atlas,
+            spec_cubemap_paths=spec_paths,
+            diff_cubemap_paths=diff_paths,
+            equirect_spec_path=equirect_spec_path,
+            equirect_diff_path=equirect_diff_path,
+            output_dir=output_dir,
+            stem=dataset.dataset_name,
+            fmt=output_format,
+            geo_origin=dataset.geo_origin(),
+        )
+        log.info('Mesh export complete → %s', out_path)
+        return out_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_point_cloud(
+        self, dataset: ScanDataset, valid_frames: list[int]
+    ) -> np.ndarray:
+        """Try LiDAR bag extraction; fall back to depth estimation."""
+        bag = dataset.bag_path('trajectory_slam')
+        xyz = _extract_lidar_from_bag(bag)
+        if xyz is None:
+            log.info('LiDAR bag extraction failed — using depth estimation fallback')
+            xyz = _estimate_depth_gpu(
+                dataset, valid_frames, self.device,
+                stride=self.depth_fallback_stride,
+            )
+        # Voxel downsample for tractable reconstruction
+        if _O3D:
+            pcd = o3d.geometry.PointCloud()
+            pcd.points = o3d.utility.Vector3dVector(xyz.astype(np.float64))
+            pcd = pcd.voxel_down_sample(voxel_size=0.02)
+            xyz = np.asarray(pcd.points).astype(np.float32)
+            log.info('After voxel downsample: %d points', len(xyz))
+        return xyz

--- a/rawkee/tools/lidar/run_pipeline.py
+++ b/rawkee/tools/lidar/run_pipeline.py
@@ -1,0 +1,130 @@
+"""Command-line entry point for the scan mesh and Gaussian splat pipelines.
+
+Usage
+-----
+  python run_pipeline.py mesh  --dataset DIR --output DIR [options]
+  python run_pipeline.py splat --dataset DIR --output DIR [options]
+
+Run with --help for full option list.
+"""
+import argparse
+import logging
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='run_pipeline.py',
+        description='Mobile LiDAR scan → X3D mesh and Gaussian splat pipelines',
+    )
+    sub = p.add_subparsers(dest='mode', required=True)
+
+    # ---- shared arguments ------------------------------------------------
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument('--dataset',   required=True, metavar='DIR',
+                        help='Path to scan dataset directory')
+    shared.add_argument('--output',    required=True, metavar='DIR',
+                        help='Output directory')
+    shared.add_argument('--format',    default='x3d', metavar='FMT',
+                        help='Output format (default: x3d)')
+    shared.add_argument('--platform',  default='auto', metavar='NAME',
+                        help='Scanner platform: navvis | metashape | meshroom | pix4d | colmap | e57 | auto (default: auto-detect)')
+    shared.add_argument('--geo-csv',     default=None, metavar='FILE',
+                        help='Geospatial survey CSV for georeferencing (optional)')
+    shared.add_argument('--no-georef',   action='store_true',
+                        help='Skip georeferencing even if --geo-csv is supplied')
+    shared.add_argument('--epsg',      type=int, default=32605, metavar='INT',
+                        help='Target projected CRS EPSG code (default: 32605 = UTM Zone 5N)')
+    shared.add_argument('--verbose',   action='store_true',
+                        help='Enable INFO logging')
+
+    # ---- mesh subcommand -------------------------------------------------
+    mesh = sub.add_parser('mesh', parents=[shared],
+                          help='Textured polygon mesh pipeline')
+    mesh.add_argument('--poisson-depth',    type=int,   default=9,    metavar='INT')
+    mesh.add_argument('--atlas-size',       type=int,   default=4096, metavar='INT')
+    mesh.add_argument('--colorise-stride',  type=int,   default=10,   metavar='INT')
+    mesh.add_argument('--depth-stride',     type=int,   default=5,    metavar='INT')
+    mesh.add_argument('--envmap-width',     type=int,   default=4096, metavar='INT')
+    mesh.add_argument('--envmap-height',    type=int,   default=2048, metavar='INT')
+    mesh.add_argument('--hdri-frame',       type=int,   default=None, metavar='INT',
+                      help='Frame index for HDRI generation (default: auto)')
+
+    # ---- splat subcommand ------------------------------------------------
+    splat = sub.add_parser('splat', parents=[shared],
+                           help='Gaussian splat pipeline')
+    splat.add_argument('--image-size',    type=int,   default=512,    metavar='INT')
+    splat.add_argument('--sh-degree',     type=int,   default=3,      metavar='INT')
+    splat.add_argument('--iterations',    type=int,   default=10000,  metavar='INT')
+    splat.add_argument('--frame-stride',  type=int,   default=5,      metavar='INT')
+    splat.add_argument('--init-points',   type=int,   default=100000, metavar='INT')
+
+    return p
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format='%(levelname)s %(name)s %(message)s',
+        stream=sys.stdout,
+    )
+
+    from rawkee.tools.lidar import ScanDataset
+
+    dataset = ScanDataset(args.dataset, platform=args.platform)
+
+    # Resolve georeferencing: warn and fall back if CSV is missing or suppressed
+    effective_csv = None
+    if args.geo_csv and not args.no_georef:
+        from pathlib import Path as _Path
+        _csv = _Path(args.geo_csv)
+        if _csv.exists():
+            effective_csv = _csv
+        else:
+            logging.getLogger(__name__).warning(
+                'Trimble CSV not found: %s — proceeding without georeferencing', _csv
+            )
+
+    if args.mode == 'mesh':
+        from rawkee.tools.lidar import MeshPipeline
+        MeshPipeline(
+            poisson_depth=args.poisson_depth,
+            atlas_size=args.atlas_size,
+            colorise_stride=args.colorise_stride,
+            depth_fallback_stride=args.depth_stride,
+        ).run(
+            dataset,
+            output_dir=args.output,
+            output_format=args.format,
+            hdri_frame=args.hdri_frame,
+            envmap_width=args.envmap_width,
+            envmap_height=args.envmap_height,
+            trimble_csv=effective_csv,
+            georef_epsg=args.epsg,
+        )
+
+    elif args.mode == 'splat':
+        from rawkee.tools.lidar import SplatPipeline
+        SplatPipeline(
+            image_size=args.image_size,
+            sh_degree=args.sh_degree,
+            iterations=args.iterations,
+            frame_stride=args.frame_stride,
+            init_points=args.init_points,
+        ).run(
+            dataset,
+            output_dir=args.output,
+            output_format=args.format,
+            trimble_csv=effective_csv,
+            georef_epsg=args.epsg,
+        )
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except RuntimeError as exc:
+        print(f'\nFATAL: {exc}', flush=True)
+        sys.exit(1)

--- a/rawkee/tools/lidar/scan_gui.py
+++ b/rawkee/tools/lidar/scan_gui.py
@@ -1,0 +1,555 @@
+"""Desktop GUI for the rawkee scan pipelines (mesh + Gaussian splat).
+
+Requires: PySide6  (pip install PySide6)
+Run:      python scan_gui.py
+"""
+from __future__ import annotations
+import logging
+import sys
+from pathlib import Path
+
+try:
+    from PySide6.QtWidgets import (
+        QApplication, QMainWindow, QWidget, QTabWidget,
+        QVBoxLayout, QHBoxLayout, QGridLayout,
+        QLabel, QLineEdit, QPushButton, QComboBox,
+        QCheckBox, QSpinBox, QGroupBox,
+        QFileDialog, QTextEdit, QSizePolicy, QMessageBox, QMenu,
+    )
+    from PySide6.QtCore import QThread, Signal, Qt
+    from PySide6.QtGui import QFont, QTextCursor
+except ImportError:
+    print('PySide6 is required: pip install PySide6')
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Logging → Qt text widget bridge
+# ---------------------------------------------------------------------------
+
+class _QtLogHandler(logging.Handler):
+    def __init__(self, signal):
+        super().__init__()
+        self._signal = signal
+
+    def emit(self, record):
+        self._signal.emit(self.format(record))
+
+
+# ---------------------------------------------------------------------------
+# Background worker thread
+# ---------------------------------------------------------------------------
+
+class _PipelineWorker(QThread):
+    log_line  = Signal(str)
+    finished  = Signal(bool, str)   # success, message
+
+    def __init__(self, mode: str, kwargs: dict):
+        super().__init__()
+        self._mode   = mode
+        self._kwargs = kwargs
+
+    def run(self):
+        handler = _QtLogHandler(self.log_line)
+        handler.setFormatter(logging.Formatter('%(levelname)s %(name)s %(message)s'))
+        root_log = logging.getLogger()
+        root_log.addHandler(handler)
+        root_log.setLevel(logging.INFO)
+        try:
+            from rawkee.tools.lidar import ScanDataset, MeshPipeline, SplatPipeline
+            kw = self._kwargs
+
+            dataset = ScanDataset(kw['dataset'], platform=kw['platform'])
+
+            # Georeferencing: apply before pipeline if CSV given and not suppressed
+            effective_csv = _resolve_georef_csv(kw.get('trimble_csv'), kw.get('no_georef', False))
+
+            if self._mode == 'mesh':
+                out = MeshPipeline(
+                    poisson_depth        = kw['poisson_depth'],
+                    atlas_size           = kw['atlas_size'],
+                    colorise_stride      = kw['colorise_stride'],
+                    depth_fallback_stride= kw['depth_stride'],
+                ).run(
+                    dataset,
+                    output_dir    = kw['output'],
+                    output_format = kw['fmt'],
+                    hdri_frame    = kw.get('hdri_frame'),
+                    envmap_width  = kw['envmap_width'],
+                    envmap_height = kw['envmap_height'],
+                    trimble_csv   = effective_csv,
+                    georef_epsg   = kw['epsg'],
+                )
+            else:
+                out = SplatPipeline(
+                    image_size   = kw['image_size'],
+                    sh_degree    = kw['sh_degree'],
+                    iterations   = kw['iterations'],
+                    frame_stride = kw['frame_stride'],
+                    init_points  = kw['init_points'],
+                ).run(
+                    dataset,
+                    output_dir    = kw['output'],
+                    output_format = kw['fmt'],
+                    trimble_csv   = effective_csv,
+                    georef_epsg   = kw['epsg'],
+                )
+            self.finished.emit(True, str(out))
+        except Exception as exc:
+            import traceback
+            self.log_line.emit('ERROR: ' + traceback.format_exc())
+            self.finished.emit(False, str(exc))
+        finally:
+            root_log.removeHandler(handler)
+
+
+def _resolve_georef_csv(trimble_csv: str | None, no_georef: bool) -> Path | None:
+    """Return Path to Trimble CSV, or None with a warning if unavailable."""
+    if no_georef or not trimble_csv:
+        return None
+    p = Path(trimble_csv)
+    if not p.exists():
+        logging.getLogger(__name__).warning(
+            'Trimble CSV not found: %s — proceeding without georeferencing', p
+        )
+        return None
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Reusable widgets
+# ---------------------------------------------------------------------------
+
+def _folder_row(label: str, placeholder: str) -> tuple[QLabel, QLineEdit, QPushButton]:
+    lbl  = QLabel(label)
+    edit = QLineEdit()
+    edit.setPlaceholderText(placeholder)
+    btn  = QPushButton('Browse…')
+    return lbl, edit, btn
+
+
+# _file_row is an alias; both open a file dialog depending on caller context
+_file_row = _folder_row
+
+
+# ---------------------------------------------------------------------------
+# Shared options group (georef + format + platform)
+# ---------------------------------------------------------------------------
+
+class _SharedOptions(QGroupBox):
+    def __init__(self):
+        super().__init__('Common Options')
+        g = QGridLayout(self)
+        row = 0
+
+        # Platform
+        g.addWidget(QLabel('Platform'), row, 0)
+        self.platform = QComboBox()
+        self.platform.addItems(['auto', 'navvis', 'metashape', 'meshroom', 'pix4d', 'colmap', 'e57'])
+        self.platform.setEditable(True)
+        self.platform.setToolTip('auto = detected from the dataset path')
+        g.addWidget(self.platform, row, 1)
+        row += 1
+
+        # Format
+        g.addWidget(QLabel('Output format'), row, 0)
+        self.fmt = QComboBox()
+        g.addWidget(self.fmt, row, 1)
+        row += 1
+
+        # Trimble CSV
+        g.addWidget(QLabel('Trimble CSV'), row, 0)
+        self.trimble_edit = QLineEdit()
+        self.trimble_edit.setPlaceholderText('Optional — for georeferencing')
+        g.addWidget(self.trimble_edit, row, 1)
+        self.trimble_btn = QPushButton('Browse…')
+        g.addWidget(self.trimble_btn, row, 2)
+        row += 1
+
+        # No-georef override
+        self.no_georef = QCheckBox('Skip georeferencing (even if CSV is set)')
+        g.addWidget(self.no_georef, row, 0, 1, 3)
+        row += 1
+
+        # EPSG
+        g.addWidget(QLabel('EPSG code'), row, 0)
+        self.epsg = QSpinBox()
+        self.epsg.setRange(1024, 99999)
+        self.epsg.setValue(32605)
+        self.epsg.setToolTip('Projected CRS for georeferencing (32605 = UTM Zone 5N)')
+        g.addWidget(self.epsg, row, 1)
+        row += 1
+
+        self.trimble_btn.clicked.connect(self._browse_csv)
+
+    def _browse_csv(self):
+        path, _ = QFileDialog.getOpenFileName(self, 'Select Trimble CSV', '', 'CSV files (*.csv);;All files (*)')
+        if path:
+            self.trimble_edit.setText(path)
+
+    def set_formats(self, formats: list[str]):
+        self.fmt.clear()
+        self.fmt.addItems(formats)
+
+
+# ---------------------------------------------------------------------------
+# Mesh tab
+# ---------------------------------------------------------------------------
+
+class _MeshTab(QWidget):
+    def __init__(self, shared: _SharedOptions, log_widget: QTextEdit):
+        super().__init__()
+        self._shared = shared
+        self._log    = log_widget
+        self._worker = None
+        layout = QVBoxLayout(self)
+
+        # Dataset + output
+        io_box = QGroupBox('Input / Output')
+        g = QGridLayout(io_box)
+        _, self.ds_edit, ds_btn = _folder_row('Dataset', '/path/to/navvis-folder  or  project.psx')
+        _, self.out_edit, out_btn = _folder_row('Output folder', '/path/to/output')
+        ds_menu = QMenu(ds_btn)
+        ds_menu.addAction('Browse Folder…',        lambda: self._browse_dataset_folder())
+        ds_menu.addAction('Browse .psx File…',     lambda: self._browse_dataset_psx())
+        ds_menu.addAction('Browse .mg File…',      lambda: self._browse_dataset_mg())
+        ds_menu.addAction('Browse .p4d File…',     lambda: self._browse_dataset_p4d())
+        ds_menu.addAction('Browse .e57 File…',     lambda: self._browse_dataset_e57())
+        ds_menu.addAction('Browse COLMAP Folder…', lambda: self._browse_dataset_colmap())
+        ds_btn.setMenu(ds_menu)
+        ds_btn.setText('Browse ▾')
+        g.addWidget(QLabel('Dataset'), 0, 0); g.addWidget(self.ds_edit, 0, 1); g.addWidget(ds_btn, 0, 2)
+        g.addWidget(QLabel('Output'),  1, 0); g.addWidget(self.out_edit, 1, 1); g.addWidget(out_btn, 1, 2)
+        out_btn.clicked.connect(lambda: self._browse_output_folder())
+        layout.addWidget(io_box)
+        opt_box = QGroupBox('Mesh Options')
+        g2 = QGridLayout(opt_box)
+        self.poisson_depth   = self._spin(g2, 0, 'Poisson depth',    9,  4, 13)
+        self.atlas_size      = self._spin(g2, 1, 'Atlas size (px)',   4096, 512, 16384, step=512)
+        self.colorise_stride = self._spin(g2, 2, 'Colorise stride',   10, 1, 50)
+        self.depth_stride    = self._spin(g2, 3, 'Depth est. stride', 5,  1, 20)
+        self.envmap_w        = self._spin(g2, 4, 'Envmap width',      4096, 512, 8192, step=512)
+        self.envmap_h        = self._spin(g2, 5, 'Envmap height',     2048, 256, 4096, step=256)
+        layout.addWidget(opt_box)
+
+        self.run_btn = QPushButton('Run Mesh Pipeline')
+        self.run_btn.setFixedHeight(36)
+        self.run_btn.clicked.connect(self._run)
+        layout.addWidget(self.run_btn)
+        layout.addStretch()
+
+        shared.set_formats(['x3d', 'x3dv', 'x3dj', 'obj', 'glb'])
+
+    def _spin(self, grid, row, label, default, lo, hi, step=1):
+        grid.addWidget(QLabel(label), row, 0)
+        w = QSpinBox()
+        w.setRange(lo, hi)
+        w.setValue(default)
+        w.setSingleStep(step)
+        grid.addWidget(w, row, 1)
+        return w
+
+    def _browse_dataset_folder(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select NavVis dataset folder')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText(self._auto_detect(path))
+
+    def _browse_dataset_psx(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Metashape project', '', 'Metashape Projects (*.psx);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('metashape')
+
+    def _browse_dataset_mg(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Meshroom project', '', 'Meshroom Projects (*.mg);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('meshroom')
+
+    def _browse_dataset_p4d(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Pix4D project', '', 'Pix4D Projects (*.p4d);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('pix4d')
+
+    def _browse_dataset_e57(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select E57 point cloud', '', 'E57 Files (*.e57);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('e57')
+
+    def _browse_dataset_colmap(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select COLMAP sparse reconstruction folder')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('colmap')
+
+    def _browse_output_folder(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select output folder')
+        if path:
+            self.out_edit.setText(path)
+
+    @staticmethod
+    def _auto_detect(path: str) -> str:
+        try:
+            from rawkee.tools.lidar.dataset import _detect_platform
+            return _detect_platform(path)
+        except Exception:
+            return 'auto'
+
+    def _browse_folder(self, edit):
+        path = QFileDialog.getExistingDirectory(self, 'Select folder')
+        if path:
+            edit.setText(path)
+
+    def _run(self):
+        if not self.ds_edit.text() or not self.out_edit.text():
+            QMessageBox.warning(self, 'Missing paths', 'Dataset and output folders are required.')
+            return
+        s = self._shared
+        kw = dict(
+            dataset        = self.ds_edit.text(),
+            output         = self.out_edit.text(),
+            platform       = s.platform.currentText(),
+            fmt            = s.fmt.currentText(),
+            trimble_csv    = s.trimble_edit.text() or None,
+            no_georef      = s.no_georef.isChecked(),
+            epsg           = s.epsg.value(),
+            poisson_depth  = self.poisson_depth.value(),
+            atlas_size     = self.atlas_size.value(),
+            colorise_stride= self.colorise_stride.value(),
+            depth_stride   = self.depth_stride.value(),
+            envmap_width   = self.envmap_w.value(),
+            envmap_height  = self.envmap_h.value(),
+        )
+        self._start_worker('mesh', kw)
+
+    def _start_worker(self, mode, kw):
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.quit()
+            self._worker.wait(2000)
+        self.run_btn.setEnabled(False)
+        self._log.clear()
+        self._worker = _PipelineWorker(mode, kw)
+        self._worker.log_line.connect(self._append_log)
+        self._worker.finished.connect(self._done)
+        self._worker.start()
+
+    def _append_log(self, text):
+        self._log.append(text)
+        self._log.moveCursor(QTextCursor.End)
+
+    def _done(self, ok, msg):
+        self.run_btn.setEnabled(True)
+        if ok:
+            QMessageBox.information(self, 'Done', f'Output written to:\n{msg}')
+        else:
+            QMessageBox.critical(self, 'Pipeline error', msg)
+
+
+# ---------------------------------------------------------------------------
+# Splat tab
+# ---------------------------------------------------------------------------
+
+class _SplatTab(QWidget):
+    def __init__(self, shared: _SharedOptions, log_widget: QTextEdit):
+        super().__init__()
+        self._shared = shared
+        self._log    = log_widget
+        self._worker = None
+        layout = QVBoxLayout(self)
+
+        io_box = QGroupBox('Input / Output')
+        g = QGridLayout(io_box)
+        _, self.ds_edit, ds_btn = _folder_row('Dataset', '/path/to/navvis-folder  or  project.psx')
+        _, self.out_edit, out_btn = _folder_row('Output folder', '/path/to/output')
+        ds_menu = QMenu(ds_btn)
+        ds_menu.addAction('Browse Folder…',        lambda: self._browse_dataset_folder())
+        ds_menu.addAction('Browse .psx File…',     lambda: self._browse_dataset_psx())
+        ds_menu.addAction('Browse .mg File…',      lambda: self._browse_dataset_mg())
+        ds_menu.addAction('Browse .p4d File…',     lambda: self._browse_dataset_p4d())
+        ds_menu.addAction('Browse .e57 File…',     lambda: self._browse_dataset_e57())
+        ds_menu.addAction('Browse COLMAP Folder…', lambda: self._browse_dataset_colmap())
+        ds_btn.setMenu(ds_menu)
+        ds_btn.setText('Browse ▾')
+        g.addWidget(QLabel('Dataset'), 0, 0); g.addWidget(self.ds_edit, 0, 1); g.addWidget(ds_btn, 0, 2)
+        g.addWidget(QLabel('Output'),  1, 0); g.addWidget(self.out_edit, 1, 1); g.addWidget(out_btn, 1, 2)
+        out_btn.clicked.connect(lambda: self._browse_output_folder())
+        layout.addWidget(io_box)
+
+        opt_box = QGroupBox('Splat Options')
+        g2 = QGridLayout(opt_box)
+        self.image_size   = self._spin(g2, 0, 'Image size (px)',   512,  64,  2048, step=64)
+        self.sh_degree    = self._spin(g2, 1, 'SH degree',         3,    0,   3)
+        self.iterations   = self._spin(g2, 2, 'Iterations',        10000, 100, 100000, step=1000)
+        self.frame_stride = self._spin(g2, 3, 'Frame stride',      5,    1,   20)
+        self.init_points  = self._spin(g2, 4, 'Init points',       100000, 1000, 1000000, step=10000)
+        layout.addWidget(opt_box)
+
+        self.run_btn = QPushButton('Run Splat Pipeline')
+        self.run_btn.setFixedHeight(36)
+        self.run_btn.clicked.connect(self._run)
+        layout.addWidget(self.run_btn)
+        layout.addStretch()
+
+        shared.set_formats(['x3d', 'x3dv', 'x3dj', 'ply', 'splat', 'glb'])
+
+    def _spin(self, grid, row, label, default, lo, hi, step=1):
+        grid.addWidget(QLabel(label), row, 0)
+        w = QSpinBox()
+        w.setRange(lo, hi)
+        w.setValue(default)
+        w.setSingleStep(step)
+        grid.addWidget(w, row, 1)
+        return w
+
+    def _browse_dataset_folder(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select NavVis dataset folder')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText(self._auto_detect(path))
+
+    def _browse_dataset_psx(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Metashape project', '', 'Metashape Projects (*.psx);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('metashape')
+
+    def _browse_dataset_mg(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Meshroom project', '', 'Meshroom Projects (*.mg);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('meshroom')
+
+    def _browse_dataset_p4d(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select Pix4D project', '', 'Pix4D Projects (*.p4d);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('pix4d')
+
+    def _browse_dataset_e57(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Select E57 point cloud', '', 'E57 Files (*.e57);;All files (*)')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('e57')
+
+    def _browse_dataset_colmap(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select COLMAP sparse reconstruction folder')
+        if path:
+            self.ds_edit.setText(path)
+            self._shared.platform.setCurrentText('colmap')
+
+    def _browse_output_folder(self):
+        path = QFileDialog.getExistingDirectory(self, 'Select output folder')
+        if path:
+            self.out_edit.setText(path)
+
+    @staticmethod
+    def _auto_detect(path: str) -> str:
+        try:
+            from rawkee.tools.lidar.dataset import _detect_platform
+            return _detect_platform(path)
+        except Exception:
+            return 'auto'
+
+    def _browse_folder(self, edit):
+        path = QFileDialog.getExistingDirectory(self, 'Select folder')
+        if path:
+            edit.setText(path)
+
+    def _run(self):
+        if not self.ds_edit.text() or not self.out_edit.text():
+            QMessageBox.warning(self, 'Missing paths', 'Dataset and output folders are required.')
+            return
+        s = self._shared
+        kw = dict(
+            dataset       = self.ds_edit.text(),
+            output        = self.out_edit.text(),
+            platform      = s.platform.currentText(),
+            fmt           = s.fmt.currentText(),
+            trimble_csv   = s.trimble_edit.text() or None,
+            no_georef     = s.no_georef.isChecked(),
+            epsg          = s.epsg.value(),
+            image_size    = self.image_size.value(),
+            sh_degree     = self.sh_degree.value(),
+            iterations    = self.iterations.value(),
+            frame_stride  = self.frame_stride.value(),
+            init_points   = self.init_points.value(),
+        )
+        self._start_worker('splat', kw)
+
+    def _start_worker(self, mode, kw):
+        self.run_btn.setEnabled(False)
+        self._log.clear()
+        self._worker = _PipelineWorker(mode, kw)
+        self._worker.log_line.connect(self._append_log)
+        self._worker.finished.connect(self._done)
+        self._worker.start()
+
+    def _append_log(self, text):
+        self._log.append(text)
+        self._log.moveCursor(QTextCursor.End)
+
+    def _done(self, ok, msg):
+        self.run_btn.setEnabled(True)
+        if ok:
+            QMessageBox.information(self, 'Done', f'Output written to:\n{msg}')
+        else:
+            QMessageBox.critical(self, 'Pipeline error', msg)
+
+
+# ---------------------------------------------------------------------------
+# Main window
+# ---------------------------------------------------------------------------
+
+class ScanPipelineApp(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('rawkee — Scan Pipeline')
+        self.resize(680, 720)
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+        root.setSpacing(8)
+
+        # Shared options (georef, format, platform) — lives above the tabs
+        self._shared = _SharedOptions()
+        root.addWidget(self._shared)
+
+        # Log output — shared between both tabs
+        log_box = QGroupBox('Log')
+        log_layout = QVBoxLayout(log_box)
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setFont(QFont('Courier New', 9))
+        self._log.setMinimumHeight(160)
+        log_layout.addWidget(self._log)
+        root.addWidget(log_box)
+
+        # Pipeline tabs
+        tabs = QTabWidget()
+        tabs.addTab(_MeshTab(self._shared, self._log),  'Mesh')
+        tabs.addTab(_SplatTab(self._shared, self._log), 'Gaussian Splat')
+        root.insertWidget(1, tabs)   # insert between shared options and log
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setStyle('Fusion')
+    win = ScanPipelineApp()
+    win.show()
+    sys.exit(app.exec())
+
+
+if __name__ == '__main__':
+    main()

--- a/rawkee/tools/lidar/slurm_scan_ddp_dgx_spark.sh
+++ b/rawkee/tools/lidar/slurm_scan_ddp_dgx_spark.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=rawkee-splat-ddp
+#SBATCH --partition=dgx-spark          # adjust to your cluster's partition name
+#SBATCH --nodes=4                      # number of DGX Spark nodes
+#SBATCH --ntasks-per-node=1            # one torchrun process per node
+#SBATCH --cpus-per-task=20             # all Arm Cortex-X925 cores per node
+#SBATCH --mem=112G                     # leave ~16 GB headroom in the 128 GB unified pool
+#SBATCH --gres=gpu:gb10:1             # one GB10 Blackwell GPU per node
+#SBATCH --time=04:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+# --- Environment ---
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export OPENCV_IO_ENABLE_OPENEXR=1
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=20
+# NCCL over InfiniBand / NVLink fabric; set to eth0 if using Ethernet
+export NCCL_SOCKET_IFNAME=ib0
+export NCCL_DEBUG=WARN
+
+source /path/to/venv/bin/activate
+
+DATASET=/path/to/scan/dataset
+OUTPUT_SPLAT=/path/to/output/splat
+GEO_CSV=/path/to/survey.csv           # optional; remove --geo-csv flag if not needed
+PIPELINE_SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+
+# torchrun rendezvous: use the first allocated node as master
+MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+MASTER_PORT=29500
+NNODES=$SLURM_NNODES
+
+# --- Gaussian splat pipeline (distributed across all nodes) ---
+# srun launches one task per node; torchrun manages the DDP process group.
+# Mesh pipeline runs single-node on rank 0 after splat training completes.
+srun torchrun \
+    --nproc_per_node=1 \
+    --nnodes="$NNODES" \
+    --rdzv_backend=c10d \
+    --rdzv_endpoint="${MASTER_ADDR}:${MASTER_PORT}" \
+    "$PIPELINE_SCRIPT" splat \
+        --dataset     "$DATASET" \
+        --output      "$OUTPUT_SPLAT" \
+        --format      x3d \
+        --platform    navvis \
+        --geo-csv     "$GEO_CSV" \
+        --epsg        32605 \
+        --image-size  800 \
+        --sh-degree   3 \
+        --iterations  50000 \
+        --frame-stride 2 \
+        --init-points 300000 \
+        --verbose

--- a/rawkee/tools/lidar/slurm_scan_dgx_spark.sh
+++ b/rawkee/tools/lidar/slurm_scan_dgx_spark.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#SBATCH --job-name=rawkee-scan
+#SBATCH --partition=dgx-spark          # adjust to your cluster's partition name
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=20             # all Arm Cortex-X925 cores on the node
+#SBATCH --mem=112G                     # leave ~16 GB headroom in the 128 GB unified pool
+#SBATCH --gres=gpu:gb10:1             # GB10 Blackwell GPU
+#SBATCH --time=06:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+# --- Environment ---
+# NVLink-C2C means CPU and GPU share physical memory; expandable_segments
+# lets PyTorch grow into the unified pool without pre-reserving a fixed block.
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export CUDA_VISIBLE_DEVICES=0
+export OPENCV_IO_ENABLE_OPENEXR=1
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=20
+
+source /path/to/venv/bin/activate
+
+DATASET=/path/to/field-training/Field-Training/woodcrest-003
+OUTPUT_MESH=/path/to/output/woodcrest-mesh
+OUTPUT_SPLAT=/path/to/output/woodcrest-splat
+GEO_CSV=/path/to/Trimble/site14_aug24.csv   # optional; remove flag if not needed
+PIPELINE_SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+
+# --- Mesh pipeline ---
+python "$PIPELINE_SCRIPT" mesh \
+    --dataset   "$DATASET" \
+    --output    "$OUTPUT_MESH" \
+    --format    x3d \
+    --platform  navvis \
+    --geo-csv     "$GEO_CSV" \
+    --epsg      32605 \
+    --poisson-depth   11 \
+    --atlas-size      8192 \
+    --colorise-stride 3 \
+    --envmap-width    4096 \
+    --envmap-height   2048 \
+    --verbose
+
+# --- Gaussian splat pipeline ---
+python "$PIPELINE_SCRIPT" splat \
+    --dataset      "$DATASET" \
+    --output       "$OUTPUT_SPLAT" \
+    --format       x3d \
+    --platform     navvis \
+    --geo-csv      "$GEO_CSV" \
+    --no-georef \
+    --epsg         32605 \
+    --image-size   800 \
+    --sh-degree    3 \
+    --iterations   50000 \
+    --frame-stride 2 \
+    --init-points  300000 \
+    --verbose

--- a/rawkee/tools/lidar/slurm_scan_gpu.sh
+++ b/rawkee/tools/lidar/slurm_scan_gpu.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=rawkee-scan
+#SBATCH --partition=gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=128G
+#SBATCH --gres=gpu:1
+#SBATCH --time=04:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+# --- Environment ---
+module load cuda/12.4          # adjust to your cluster's module name
+source /path/to/venv/bin/activate
+
+export OPENCV_IO_ENABLE_OPENEXR=1
+export PYTHONUNBUFFERED=1
+
+DATASET=/path/to/field-training/Field-Training/woodcrest-003
+OUTPUT_MESH=/path/to/output/woodcrest-mesh
+OUTPUT_SPLAT=/path/to/output/woodcrest-splat
+GEO_CSV=/path/to/Trimble/site14_aug24.csv   # optional; remove flag if not needed
+PIPELINE_SCRIPT=/path/to/rawkee/rawkee/tools/lidar/run_pipeline.py
+
+# --- Mesh pipeline ---
+python "$PIPELINE_SCRIPT" mesh \
+    --dataset   "$DATASET" \
+    --output    "$OUTPUT_MESH" \
+    --format    x3d \
+    --platform  navvis \
+    --geo-csv     "$GEO_CSV" \
+    --epsg      32605 \
+    --poisson-depth   9 \
+    --atlas-size      4096 \
+    --colorise-stride 5 \
+    --verbose
+
+# --- Gaussian splat pipeline ---
+python "$PIPELINE_SCRIPT" splat \
+    --dataset      "$DATASET" \
+    --output       "$OUTPUT_SPLAT" \
+    --format       x3d \
+    --platform     navvis \
+    --geo-csv      "$GEO_CSV" \
+    --no-georef \
+    --epsg         32605 \
+    --image-size   512 \
+    --sh-degree    3 \
+    --iterations   30000 \
+    --frame-stride 3 \
+    --init-points  100000 \
+    --verbose

--- a/rawkee/tools/lidar/splat_pipeline.py
+++ b/rawkee/tools/lidar/splat_pipeline.py
@@ -1,0 +1,559 @@
+"""Gaussian splat pipeline for mobile LiDAR scan datasets.
+
+Strategy
+--------
+1. Prepare training cameras: load DNG frames, extract poses, build
+   a pinhole camera approximation from the OCamModel for the gsplat rasteriser.
+2. Initialise Gaussians from the LiDAR point cloud (if available) or from
+   random sampling on a unit sphere scaled to the scene bounding box.
+3. Train with the gsplat rasteriser:
+      - photometric L1 + SSIM loss
+      - adaptive density control (split/clone/prune)
+4. Export via scan.export.
+"""
+from __future__ import annotations
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    _TORCH = True
+except ImportError:
+    _TORCH = False
+
+try:
+    from gsplat import rasterization
+    _GSPLAT = True
+except ImportError:
+    _GSPLAT = False
+
+try:
+    import open3d as o3d
+    _O3D = True
+except ImportError:
+    _O3D = False
+
+from .dataset import ScanDataset
+from .mesh_pipeline import _extract_lidar_from_bag
+
+log = logging.getLogger(__name__)
+
+
+def _warn_no_gpu(pipeline: str, require: bool = False) -> None:
+    """Print actionable GPU diagnostic and optionally raise."""
+    lines = ['', f'WARNING: No CUDA GPU is available for the {pipeline} pipeline.']
+    if _TORCH:
+        lines.append(f'  PyTorch version : {torch.__version__}')
+        lines.append(f'  PyTorch CUDA    : {torch.version.cuda or "not compiled"}')
+    else:
+        lines.append('  PyTorch is not installed.')
+    lines += [
+        '  Suggested fixes:',
+        '    1. Ensure your NVIDIA driver is installed (>=525 for CUDA 12.x).',
+        '    2. Reinstall PyTorch for your CUDA version:',
+        '         pip install torch --index-url https://download.pytorch.org/whl/cu124',
+        '    3. For Grace/Hopper or DGX Spark use the NGC PyTorch container.',
+        '    4. Quick check: python -c "import torch; print(torch.cuda.is_available())"',
+    ]
+    if require:
+        lines.append('')
+        print('\n'.join(lines), flush=True)
+        raise RuntimeError(f'A CUDA GPU is required for the {pipeline} pipeline but none is available.')
+    lines.append('  Continuing on CPU — performance will be significantly reduced.')
+    lines.append('')
+    print('\n'.join(lines), flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Distributed process group helpers
+# ---------------------------------------------------------------------------
+
+def _dist_init() -> tuple[int, int]:
+    """Initialise torch.distributed if launched via torchrun; return (rank, world_size)."""
+    import os
+    rank       = int(os.environ.get('RANK',       0))
+    world_size = int(os.environ.get('WORLD_SIZE', 1))
+    if world_size > 1:
+        import torch.distributed as dist
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend='nccl',
+                timeout=__import__('datetime').timedelta(minutes=30),
+            )
+        log.info('Distributed: rank %d / %d', rank, world_size)
+    return rank, world_size
+
+
+def _dist_teardown() -> None:
+    """Destroy the process group if it was initialised."""
+    try:
+        import torch.distributed as dist
+        if dist.is_initialized():
+            dist.destroy_process_group()
+    except ImportError:
+        pass
+
+
+def _dist_all_reduce_grads(params: dict, world_size: int) -> None:
+    """Average gradients across all ranks after backward."""
+    import torch.distributed as dist
+    for p in params.values():
+        if p.grad is not None:
+            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+
+# ---------------------------------------------------------------------------
+# Device setup (shared pattern with mesh_pipeline)
+# ---------------------------------------------------------------------------
+
+def _get_device() -> 'torch.device':
+    if _TORCH and torch.cuda.is_available():
+        p = torch.cuda.get_device_properties(0)
+        log.info('Splat pipeline GPU: %s  sm_%d%d', p.name, p.major, p.minor)
+        if p.major >= 9:
+            torch.cuda.set_per_process_memory_fraction(0.85)
+        return torch.device('cuda')
+    _warn_no_gpu('Gaussian splat', require=True)
+
+
+# ---------------------------------------------------------------------------
+# Camera preparation
+# ---------------------------------------------------------------------------
+
+def _ocam_to_pinhole_approx(ocam) -> tuple[float, float, float, float]:
+    """Approximate OCamModel as a pinhole camera (fx, fy, cx_col, cy_row).
+
+    Uses the world2cam polynomial at theta=0 (on-axis) to derive focal length.
+    """
+    # world2cam[0] is the on-axis mapping coefficient (scale at centre of FOV)
+    f = abs(float(ocam.world2cam[0]))
+    return f, f, float(ocam.cy), float(ocam.cx)   # fx, fy, cx_col, cy_row
+
+
+def _load_training_images(
+    dataset: ScanDataset,
+    frame_indices: list[int],
+    cam_idx: int,
+    target_size: int = 512,
+    device: 'torch.device' = None,
+) -> tuple[list['torch.Tensor'], list[np.ndarray], list[np.ndarray]]:
+    """Load DNG images and poses for one camera into GPU tensors.
+
+    Returns:
+        images  – list of (3, H, W) float32 tensors on device
+        Rs      – list of (3,3) rotation matrices (world → camera)
+        ts      – list of (3,) translation vectors (camera origin in world)
+    """
+    import rawpy
+    from PIL import Image
+
+    images, Rs, ts = [], [], []
+    cam = dataset.cameras[cam_idx]
+
+    for fi in frame_indices:
+        img_path = dataset.image_path(fi, cam_idx)
+        if not img_path.exists():
+            continue
+        try:
+            # Support DNG/RAW and standard JPEG/TIFF
+            from PIL import Image as _PILImage
+            if img_path.suffix.lower() in ('.dng', '.nef', '.cr2', '.arw', '.raw', '.rw2'):
+                import rawpy
+                with rawpy.imread(str(img_path)) as raw:
+                    rgb8 = raw.postprocess(output_bps=8, use_camera_wb=True)
+            else:
+                rgb8 = np.array(_PILImage.open(img_path).convert('RGB'))
+            img = np.array(_PILImage.fromarray(rgb8).resize((target_size, target_size)))
+            img_t = torch.from_numpy(img).float().div(255.0).permute(2, 0, 1)
+            if device is not None:
+                img_t = img_t.to(device)
+            images.append(img_t)
+
+            # Pose: world → camera
+            head_pos, R_head = dataset.frame_transform(fi)
+            # R_head rotates head→world; we need world→cam = (R_head @ R_cam)^T
+            R_head_to_world = R_head                   # (3,3) cols are head-axes in world
+            R_cam_to_head   = cam.R                    # (3,3)
+            R_cam_to_world  = R_head_to_world @ R_cam_to_head
+            R_world_to_cam  = R_cam_to_world.T
+            # Camera origin in world = head_pos + R_head @ cam.position
+            cam_origin = head_pos + R_head @ cam.position
+            t_world_to_cam = -R_world_to_cam @ cam_origin
+
+            Rs.append(R_world_to_cam.astype(np.float32))
+            ts.append(t_world_to_cam.astype(np.float32))
+        except Exception as exc:
+            log.debug('Skip frame %d cam %d: %s', fi, cam_idx, exc)
+
+    log.info('Loaded %d training images for cam%d', len(images), cam_idx)
+    return images, Rs, ts
+
+
+# ---------------------------------------------------------------------------
+# Gaussian initialisation
+# ---------------------------------------------------------------------------
+
+def _init_gaussians_from_pcd(
+    xyz: np.ndarray,
+    device: 'torch.device',
+    sh_degree: int = 3,
+) -> dict[str, 'torch.Tensor']:
+    """Initialise Gaussian parameters from an (N,3) point cloud."""
+    N = len(xyz)
+    means = torch.tensor(xyz, dtype=torch.float32, device=device)
+
+    # Estimate initial scale from nearest-neighbour distance
+    if _O3D and N > 1000:
+        pcd = o3d.geometry.PointCloud()
+        pcd.points = o3d.utility.Vector3dVector(xyz.astype(np.float64))
+        pcd = pcd.voxel_down_sample(0.05)
+        pts_ds = np.asarray(pcd.points)
+        from scipy.spatial import cKDTree
+        tree = cKDTree(pts_ds)
+        d, _ = tree.query(pts_ds, k=2)
+        nn_dist = float(np.median(d[:, 1]))
+    else:
+        nn_dist = 0.05
+
+    log_scale_val = math.log(nn_dist)
+    log_scales = torch.full((N, 3), log_scale_val, dtype=torch.float32, device=device)
+
+    # Identity quaternion (w, x, y, z)
+    quats = torch.zeros(N, 4, dtype=torch.float32, device=device)
+    quats[:, 0] = 1.0
+
+    # Initialise SH DC with grey; higher-order = 0
+    n_sh = (sh_degree + 1) ** 2
+    sh_coeffs = torch.zeros(N, n_sh, 3, dtype=torch.float32, device=device)
+    sh_coeffs[:, 0] = 0.5 / math.sqrt(4 * math.pi)   # DC grey
+
+    # Opacity: inverse-sigmoid of 0.1
+    opacities = torch.full((N,), math.log(0.1 / (1 - 0.1)), dtype=torch.float32, device=device)
+
+    return {
+        'means':      means,
+        'log_scales': log_scales,
+        'quats':      quats,
+        'sh_coeffs':  sh_coeffs,
+        'opacities':  opacities,
+    }
+
+
+def _random_init_gaussians(
+    n: int,
+    scene_bbox: tuple[np.ndarray, np.ndarray],
+    device: 'torch.device',
+    sh_degree: int = 3,
+) -> dict[str, 'torch.Tensor']:
+    """Initialise Gaussians randomly within scene bounding box."""
+    lo, hi = scene_bbox
+    xyz = np.random.uniform(lo, hi, (n, 3)).astype(np.float32)
+    return _init_gaussians_from_pcd(xyz, device, sh_degree)
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+def _pcd_to_gaussians_direct(
+    xyz: np.ndarray,
+    colors: 'np.ndarray | None',
+    device: 'torch.device',
+    sh_degree: int = 3,
+) -> dict[str, 'torch.Tensor']:
+    """Convert a colored point cloud to Gaussian parameters without training.
+
+    One Gaussian per point: scale from nearest-neighbour distance, opacity=0.99,
+    color from RGB (DC SH coefficient). Exports valid splats instantly.
+    """
+    gaussians = _init_gaussians_from_pcd(xyz, device, sh_degree)
+    if colors is not None:
+        sh0 = 0.28209479177387814  # 1 / (2*sqrt(pi))
+        dc  = (torch.from_numpy(colors.astype(np.float32)).to(device) - 0.5) / sh0
+        gaussians['sh_coeffs'][:, 0, :] = dc
+    # Set fully opaque (inverse sigmoid of 0.99)
+    gaussians['opacities'][:] = math.log(0.99 / 0.01)
+    return {k: v.detach() for k, v in gaussians.items()}
+
+
+def _ssim_loss(pred: 'torch.Tensor', target: 'torch.Tensor') -> 'torch.Tensor':
+    """Simple patch-based SSIM approximation."""
+    mu1 = F.avg_pool2d(pred,   11, 1, 5)
+    mu2 = F.avg_pool2d(target, 11, 1, 5)
+    s1  = F.avg_pool2d(pred   ** 2, 11, 1, 5) - mu1 ** 2
+    s2  = F.avg_pool2d(target ** 2, 11, 1, 5) - mu2 ** 2
+    s12 = F.avg_pool2d(pred * target,  11, 1, 5) - mu1 * mu2
+    C1, C2 = 0.01 ** 2, 0.03 ** 2
+    ssim = ((2 * mu1 * mu2 + C1) * (2 * s12 + C2)) / (
+        (mu1 ** 2 + mu2 ** 2 + C1) * (s1 + s2 + C2)
+    )
+    return 1 - ssim.mean()
+
+
+def _train(
+    gaussians: dict[str, 'torch.Tensor'],
+    images: list['torch.Tensor'],
+    Rs: list[np.ndarray],
+    ts: list[np.ndarray],
+    focal: tuple[float, float],
+    img_wh: tuple[int, int],
+    device: 'torch.device',
+    iterations: int = 10_000,
+    densify_every: int = 500,
+    densify_until: int = 7_000,
+    rank: int = 0,
+    world_size: int = 1,
+) -> dict[str, 'torch.Tensor']:
+    """3DGS training loop using gsplat rasteriser, with optional multi-node DDP."""
+    if not _GSPLAT:
+        raise RuntimeError('gsplat required: pip install gsplat')
+
+    if world_size > 1:
+        import torch.distributed as dist
+
+    fx, fy = focal
+    W, H   = img_wh
+
+    # Each rank trains on its own image shard
+    local_images = images[rank::world_size]
+    local_Rs     = Rs[rank::world_size]
+    local_ts     = ts[rank::world_size]
+    if not local_images:
+        raise RuntimeError(f'Rank {rank} received no training images (total={len(images)}, world={world_size})')
+
+    # Make Gaussian parameters trainable
+    params = {k: nn.Parameter(v.clone()) for k, v in gaussians.items()}
+
+    def _make_opt():
+        return torch.optim.Adam([
+            {'params': [params['means']],      'lr': 1.6e-4},
+            {'params': [params['log_scales']], 'lr': 5e-3},
+            {'params': [params['quats']],      'lr': 1e-3},
+            {'params': [params['sh_coeffs']],  'lr': 2.5e-3},
+            {'params': [params['opacities']],  'lr': 5e-2},
+        ])
+
+    # Pre-compute intrinsics and pose tensors to avoid per-iteration allocation
+    K = torch.tensor([[fx, 0, W / 2], [0, fy, H / 2], [0, 0, 1]],
+                      device=device, dtype=torch.float32).unsqueeze(0)
+    R_tensors = [torch.tensor(r, device=device, dtype=torch.float32).unsqueeze(0)
+                 for r in local_Rs]
+    t_tensors = [torch.tensor(t_, device=device, dtype=torch.float32).unsqueeze(0)
+                 for t_ in local_ts]
+
+    opt = _make_opt()
+    scheduler = torch.optim.lr_scheduler.ExponentialLR(opt, gamma=0.999)
+
+    N_local = len(local_images)
+    if rank == 0:
+        log.info('Training %d Gaussians for %d iterations  world_size=%d  local_cams=%d',
+                 len(params['means']), iterations, world_size, N_local)
+
+    for step in range(1, iterations + 1):
+        ci     = step % N_local
+        img_gt = local_images[ci].unsqueeze(0).to(device)
+        R      = R_tensors[ci]
+        t      = t_tensors[ci]
+
+        scales_exp  = torch.exp(params['log_scales'])
+        quats_n     = F.normalize(params['quats'], dim=-1)
+        opacities_a = torch.sigmoid(params['opacities'])
+
+        rendered, _, _ = rasterization(
+            means=params['means'], quats=quats_n, scales=scales_exp,
+            opacities=opacities_a, colors=params['sh_coeffs'],
+            viewmats=torch.cat([R, t.unsqueeze(-1)], dim=-1),
+            Ks=K, width=W, height=H, sh_degree=3, packed=True,
+        )
+        rendered = rendered.permute(0, 3, 1, 2).clamp(0, 1)
+
+        loss = 0.8 * F.l1_loss(rendered, img_gt) + 0.2 * _ssim_loss(rendered, img_gt)
+        opt.zero_grad()
+        loss.backward()
+
+        # Average gradients across ranks before the optimiser step
+        if world_size > 1:
+            _dist_all_reduce_grads(params, world_size)
+
+        opt.step()
+        scheduler.step()
+
+        if step % 500 == 0 and rank == 0:
+            log.info('step %5d / %d  loss=%.5f  N=%d',
+                     step, iterations, loss.item(), len(params['means']))
+
+        # Adaptive density control
+        if step % densify_every == 0 and step < densify_until:
+            with torch.no_grad():
+                if world_size > 1:
+                    # Rank 0 decides which Gaussians to keep; all ranks obey
+                    keep = torch.zeros(len(params['means']), dtype=torch.bool, device=device)
+                    if rank == 0:
+                        keep = torch.sigmoid(params['opacities']) > 0.005  # prune near-transparent splats
+                    dist.broadcast(keep, src=0)
+                else:
+                    keep = torch.sigmoid(params['opacities']) > 0.005  # prune near-transparent splats
+
+                for k in params:
+                    params[k] = nn.Parameter(params[k][keep])
+
+                # After pruning, broadcast rank-0 data so all ranks stay identical
+                if world_size > 1:
+                    for p in params.values():
+                        dist.broadcast(p.data, src=0)
+
+                opt = _make_opt()
+            if rank == 0:
+                log.info('Density control: %d Gaussians remaining', keep.sum().item())
+
+
+# ---------------------------------------------------------------------------
+# Public pipeline class
+# ---------------------------------------------------------------------------
+
+class SplatPipeline:
+    """End-to-end scan dataset → Gaussian splat pipeline."""
+
+    def __init__(
+        self,
+        image_size: int = 512,
+        sh_degree: int = 3,
+        iterations: int = 10_000,
+        frame_stride: int = 5,
+        init_points: int = 100_000,
+        prefer_cuda: bool = True,
+    ) -> None:
+        self.image_size  = image_size
+        self.sh_degree   = sh_degree
+        self.iterations  = iterations
+        self.frame_stride = frame_stride
+        self.init_points = init_points
+        self.device      = _get_device() if prefer_cuda else torch.device('cpu')
+
+    def run(
+        self,
+        dataset: ScanDataset,
+        output_dir: Path,
+        output_format: str = 'x3d',
+        trimble_csv: Optional[Path] = None,
+        georef_epsg: int = 32605,
+    ) -> Path:
+        """Run the full Gaussian splat pipeline and export.
+
+        Parameters
+        ----------
+        dataset:       ScanDataset instance.
+        output_dir:    Directory to write output file(s).
+        output_format: One of x3d | x3dv | x3dj | ply | splat | glb.
+        trimble_csv:   Optional path to a Trimble survey CSV for georeferencing.
+        georef_epsg:   Target projected CRS (default 32605 = UTM Zone 5N).
+        """
+        if not _TORCH:
+            raise RuntimeError('PyTorch is required for Gaussian splat training')
+        if not _GSPLAT:
+            raise RuntimeError('gsplat is required: pip install gsplat')
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if trimble_csv is not None:
+            dataset.apply_trimble_georef(trimble_csv, epsg=georef_epsg)
+
+        # E57 without embedded images: bypass training entirely
+        if dataset.platform == 'e57' and not dataset.has_training_images():
+            log.info('E57 input with no training images — using direct point-cloud-to-splat conversion')
+            xyz, colors = dataset.e57_point_cloud()
+            if len(xyz) > self.init_points:
+                idx = np.random.choice(len(xyz), self.init_points, replace=False)
+                xyz    = xyz[idx]
+                colors = colors[idx] if colors is not None else None
+            trained = _pcd_to_gaussians_direct(xyz, colors, self.device, self.sh_degree)
+            from .export import export_splat
+            out_path = export_splat(
+                gaussians=trained, output_dir=output_dir,
+                stem=dataset.dataset_name, fmt=output_format,
+                sh_degree=self.sh_degree, geo_origin=dataset.geo_origin(),
+            )
+            log.info('E57 direct splat export → %s', out_path)
+            return out_path
+
+        valid = dataset.valid_frame_indices()
+        frames = valid[::self.frame_stride]
+        log.info('Training on %d frames (every %dth of %d valid)',
+                 len(frames), self.frame_stride, len(valid))
+
+        # 1. Initialise from LiDAR or fallback
+        xyz = None
+        bag = dataset.bag_path('trajectory_slam')
+        if bag.exists():
+            xyz = _extract_lidar_from_bag(bag, max_clouds=200)
+        if xyz is None or len(xyz) < 1000:
+            # Compute scene bbox from frame positions
+            positions = np.array([dataset.frame_position(fi) for fi in valid])
+            lo = positions.min(axis=0) - 3.0
+            hi = positions.max(axis=0) + 3.0
+            log.info('Random Gaussian init within bbox %s … %s', lo, hi)
+            gaussians = _random_init_gaussians(
+                self.init_points, (lo, hi), self.device, self.sh_degree
+            )
+        else:
+            # Subsample LiDAR to init_points
+            if len(xyz) > self.init_points:
+                idx = np.random.choice(len(xyz), self.init_points, replace=False)
+                xyz = xyz[idx]
+            gaussians = _init_gaussians_from_pcd(xyz, self.device, self.sh_degree)
+
+        # 2. Load training data (all 4 cameras combined)
+        all_images, all_Rs, all_ts = [], [], []
+        for cam_idx in range(len(dataset.cameras)):
+            imgs, Rs, ts = _load_training_images(
+                dataset, frames, cam_idx, self.image_size, self.device
+            )
+            all_images.extend(imgs)
+            all_Rs.extend(Rs)
+            all_ts.extend(ts)
+
+        if not all_images:
+            raise RuntimeError('No training images could be loaded')
+
+        # Approximate focal length from cam0
+        cam0 = dataset.cameras[0]
+        fx, fy, _, _ = _ocam_to_pinhole_approx(cam0.ocam)
+        scale = self.image_size / cam0.ocam.width
+        focal = (fx * scale, fy * scale)
+
+        # 3. Train
+        rank, world_size = _dist_init()
+        try:
+            trained = _train(
+                gaussians, all_images, all_Rs, all_ts,
+                focal=focal,
+                img_wh=(self.image_size, self.image_size),
+                device=self.device,
+                iterations=self.iterations,
+                rank=rank,
+                world_size=world_size,
+            )
+        finally:
+            _dist_teardown()
+
+        # 4. Only rank 0 exports
+        if rank != 0:
+            return Path(output_dir)
+        from .export import export_splat
+        out_path = export_splat(
+            gaussians=trained,
+            output_dir=output_dir,
+            stem=dataset.dataset_name,
+            fmt=output_format,
+            sh_degree=self.sh_degree,
+            geo_origin=dataset.geo_origin(),
+        )
+        log.info('Splat export complete → %s', out_path)
+        return out_path


### PR DESCRIPTION
This pull request introduces a new LiDAR processing toolkit to the `rawkee.tools.lidar` package, providing command-line pipelines for generating textured meshes and Gaussian splats from mobile LiDAR and 360-camera scan datasets. It adds GPU-accelerated HDRI panorama generation, a CLI entry point, and a distributed SLURM job script for large-scale processing. Minor improvements and bugfixes are also made in related scene traversal code.

**New LiDAR Toolkit and Pipelines:**

* Added the `rawkee.tools.lidar` package with a public API for scan dataset handling, mesh and Gaussian splat pipelines, and export utilities. (`rawkee/tools/lidar/__init__.py`)
* Implemented GPU-accelerated HDRI panorama generation from fisheye scan cameras in `HDRIGenerator`, supporting equirectangular and cubemap outputs, blending, and optional diffuse convolution. (`rawkee/tools/lidar/hdri.py`)
* Introduced a command-line interface for running mesh and splat pipelines with flexible options for dataset, output, georeferencing, and processing parameters. (`rawkee/tools/lidar/run_pipeline.py`)
* Added a SLURM batch script for distributed Gaussian splat training on multi-node GPU clusters, supporting the new pipeline. (`rawkee/tools/lidar/slurm_scan_ddp_dgx_spark.sh`)

**Scene Traversal Improvements:**

* Added support for a new `'GaussianSplats'` scene type and fixed a bug in `processNode` to avoid appending 'IS' fields, improving scene traversal logic. (`rawkee/io/RKSceneTraversal.py`) [[1]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14L49-R49) [[2]](diffhunk://#diff-186f90652aca005b803ef961d80bc1d235f22605a703f7cbf7977c87b0fc1b14R219)