### PR TITLE
Updated readme isntructions for lidar module to account for missing flag.

### DIFF
--- a/rawkee/tools/lidar/README.md
+++ b/rawkee/tools/lidar/README.md
@@ -177,6 +177,7 @@ Run `python run_pipeline.py mesh --help` or `splat --help` for the full list of 
 | `--iterations` | 10000 | Training iterations |
 | `--frame-stride` | 5 | Use every Nth frame for training |
 | `--init-points` | 100000 | Number of Gaussians at initialisation |
+| `--decode-sh` | off | Pre-decode SH coefficients to RGB in PLY output (for consumers without SH support) |
 
 ---
 


### PR DESCRIPTION
This pull request adds documentation for a new command-line option to the LiDAR tool's README. The update describes the `--decode-sh` flag, which allows users to pre-decode spherical harmonics (SH) coefficients to RGB in PLY output, improving compatibility with consumers that don't support SH.

Documentation updates:

* Added `--decode-sh` option to the parameter table in `rawkee/tools/lidar/README.md`, explaining its purpose for PLY output compatibility.